### PR TITLE
feat: expose InstrumentRegistry/SymbolIndex to external sequencer consumers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,10 +224,10 @@ pub use orderbook::{
     AggregatedGreeks, CleanupResult, CycleRule, ExpirationCallback, ExpiryCycleConfig,
     ExpiryLifecycleManager, ExpiryScheduler, ExpiryType, FlatVolSurface, GreeksAggregator,
     GreeksEngine, GreeksRecalcTrigger, GreeksUpdate, GreeksUpdateListener, IndexPriceFeed,
-    LifecycleConfig, LifecycleEvent, LifecycleListener, LifecycleResult, MarkPriceCalculator,
-    MarkPriceConfig, MarkPriceConfigBuilder, MockPriceFeed, Position, PriceUpdate,
-    PriceUpdateListener, RefreshResult, StaticPriceFeed, StrikeGenerator, StrikeRangeConfig,
-    StrikeRangeConfigBuilder, SubscriptionId, SymbolIndex, SymbolRef, VolSurface,
-    calculate_tte_years, wire_feed_to_calculator,
+    InstrumentInfo, InstrumentRegistry, LifecycleConfig, LifecycleEvent, LifecycleListener,
+    LifecycleResult, MarkPriceCalculator, MarkPriceConfig, MarkPriceConfigBuilder, MockPriceFeed,
+    Position, PriceUpdate, PriceUpdateListener, RefreshResult, StaticPriceFeed, StrikeGenerator,
+    StrikeRangeConfig, StrikeRangeConfigBuilder, SubscriptionId, SymbolIndex, SymbolRef,
+    VolSurface, calculate_tte_years, wire_feed_to_calculator,
 };
 pub use utils::{ParsedSymbol, SymbolParser};

--- a/src/orderbook/instrument_registry.rs
+++ b/src/orderbook/instrument_registry.rs
@@ -208,6 +208,40 @@ impl InstrumentRegistry {
     pub fn current_id(&self) -> u32 {
         self.next_id.load(Ordering::Relaxed)
     }
+
+    /// Returns a snapshot of all registered `(id, InstrumentInfo)` pairs.
+    ///
+    /// The returned `Vec` is a point-in-time snapshot — concurrent
+    /// registrations that occur after the call begins may or may not
+    /// be included. The order of entries is arbitrary.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use option_chain_orderbook::orderbook::{InstrumentInfo, InstrumentRegistry};
+    /// use optionstratlib::{ExpirationDate, OptionStyle};
+    /// use optionstratlib::prelude::pos_or_panic;
+    ///
+    /// let registry = InstrumentRegistry::new();
+    /// let id = registry.allocate();
+    /// registry.register(id, InstrumentInfo::new(
+    ///     "BTC-20240329-50000-C",
+    ///     ExpirationDate::Days(pos_or_panic!(30.0)),
+    ///     50000,
+    ///     OptionStyle::Call,
+    /// ));
+    ///
+    /// let entries = registry.iter();
+    /// assert_eq!(entries.len(), 1);
+    /// assert_eq!(entries[0].0, id);
+    /// ```
+    #[must_use]
+    pub fn iter(&self) -> Vec<(u32, InstrumentInfo)> {
+        self.index
+            .iter()
+            .map(|entry| (*entry.key(), entry.value().clone()))
+            .collect()
+    }
 }
 
 impl Default for InstrumentRegistry {
@@ -423,5 +457,44 @@ mod tests {
         let registry = InstrumentRegistry::new_with_seed(0);
         assert_eq!(registry.current_id(), 1);
         assert_eq!(registry.allocate(), 1);
+    }
+
+    #[test]
+    fn test_iter_empty() {
+        let registry = InstrumentRegistry::new();
+        let entries = registry.iter();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_iter_returns_all_entries() {
+        let registry = InstrumentRegistry::new();
+
+        for i in 0..5 {
+            let id = registry.allocate();
+            registry.register(
+                id,
+                InstrumentInfo::new(
+                    format!("BTC-20240329-{}-C", 50000 + i * 1000),
+                    test_expiration(),
+                    50000 + i * 1000,
+                    OptionStyle::Call,
+                ),
+            );
+        }
+
+        let entries = registry.iter();
+        assert_eq!(entries.len(), 5);
+
+        // Verify all IDs are present (order is arbitrary)
+        let mut ids: Vec<u32> = entries.iter().map(|(id, _)| *id).collect();
+        ids.sort();
+        assert_eq!(ids, vec![1, 2, 3, 4, 5]);
+
+        // Verify info is correct for one entry
+        let entry = entries.iter().find(|(id, _)| *id == 1);
+        assert!(entry.is_some());
+        let (_, info) = entry.expect("entry should exist");
+        assert_eq!(info.strike(), 50000);
     }
 }

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -24,6 +24,8 @@
 
 use crate::error::Error;
 use crate::orderbook::book::TerminalOrderSummary;
+use crate::orderbook::instrument_registry::InstrumentRegistry;
+use crate::orderbook::symbol_index::SymbolIndex;
 use crate::orderbook::underlying::UnderlyingOrderBook;
 use crate::utils::nanos_since_epoch;
 use optionstratlib::ExpirationDate;
@@ -425,7 +427,7 @@ impl Default for OptionChainSequencer {
 /// internal sequencer, assigning monotonic sequence numbers and optionally
 /// persisting events to a journal for replay.
 ///
-/// # Example
+/// # Example — basic usage
 ///
 /// ```rust,ignore
 /// use option_chain_orderbook::orderbook::SequencedUnderlyingOrderBook;
@@ -442,6 +444,41 @@ impl Default for OptionChainSequencer {
 /// )?;
 ///
 /// println!("Sequence: {}", receipt.sequence_num);
+/// ```
+///
+/// # Example — listing instruments via registry
+///
+/// ```rust,ignore
+/// use std::sync::Arc;
+/// use option_chain_orderbook::orderbook::{
+///     InstrumentRegistry, SequencedUnderlyingOrderBook, SymbolIndex,
+/// };
+/// use orderbook_rs::{OrderId, Side};
+///
+/// // 1. Create shared registry & symbol index
+/// let registry = Arc::new(InstrumentRegistry::new());
+/// let symbol_index = Arc::new(SymbolIndex::new());
+///
+/// // 2. Build the sequenced book with registry + index
+/// let book = SequencedUnderlyingOrderBook::new_with_registry_and_index(
+///     "BTC",
+///     Arc::clone(&registry),
+///     Arc::clone(&symbol_index),
+/// );
+///
+/// // 3. Submit an order — the hierarchy auto-registers the instrument
+/// let _receipt = book.submit_add_order(
+///     "BTC-20240329-50000-C",
+///     OrderId::new(),
+///     Side::Buy,
+///     100,
+///     10,
+/// )?;
+///
+/// // 4. Enumerate instruments
+/// for (id, info) in registry.iter() {
+///     println!("id={id}, symbol={}", info.symbol());
+/// }
 /// ```
 pub struct SequencedUnderlyingOrderBook {
     /// The underlying order book hierarchy.
@@ -476,6 +513,62 @@ impl SequencedUnderlyingOrderBook {
         }
     }
 
+    /// Creates a new sequenced underlying order book with an instrument
+    /// registry and symbol index, without journaling.
+    ///
+    /// The registry and index are propagated through the
+    /// [`UnderlyingOrderBook`] hierarchy so that every strike created by
+    /// subsequent commands is automatically registered.
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying` - The underlying asset symbol (e.g., "BTC")
+    /// * `registry` - Shared instrument registry for ID allocation
+    /// * `symbol_index` - Shared symbol index for O(1) lookups
+    #[must_use]
+    pub fn new_with_registry_and_index(
+        underlying: impl Into<String>,
+        registry: Arc<InstrumentRegistry>,
+        symbol_index: Arc<SymbolIndex>,
+    ) -> Self {
+        Self {
+            inner: UnderlyingOrderBook::new_with_registry_and_index(
+                underlying,
+                registry,
+                symbol_index,
+            ),
+            sequencer: OptionChainSequencer::new(),
+            journal: None,
+        }
+    }
+
+    /// Creates a new sequenced underlying order book with journal,
+    /// instrument registry, and symbol index.
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying` - The underlying asset symbol
+    /// * `journal` - Journal for event persistence and replay
+    /// * `registry` - Shared instrument registry for ID allocation
+    /// * `symbol_index` - Shared symbol index for O(1) lookups
+    #[must_use]
+    pub fn with_journal_registry_and_index(
+        underlying: impl Into<String>,
+        journal: Arc<dyn OptionChainJournal>,
+        registry: Arc<InstrumentRegistry>,
+        symbol_index: Arc<SymbolIndex>,
+    ) -> Self {
+        Self {
+            inner: UnderlyingOrderBook::new_with_registry_and_index(
+                underlying,
+                registry,
+                symbol_index,
+            ),
+            sequencer: OptionChainSequencer::new(),
+            journal: Some(journal),
+        }
+    }
+
     /// Creates a sequenced wrapper around an existing underlying order book.
     #[must_use]
     pub fn from_underlying(underlying: UnderlyingOrderBook) -> Self {
@@ -504,6 +597,22 @@ impl SequencedUnderlyingOrderBook {
     #[inline]
     pub fn underlying(&self) -> &UnderlyingOrderBook {
         &self.inner
+    }
+
+    /// Returns a reference to the instrument registry, if one was provided
+    /// at construction time.
+    #[must_use]
+    #[inline]
+    pub fn registry(&self) -> Option<&Arc<InstrumentRegistry>> {
+        self.inner.registry()
+    }
+
+    /// Returns a reference to the symbol index, if one was provided
+    /// at construction time.
+    #[must_use]
+    #[inline]
+    pub fn symbol_index(&self) -> Option<&Arc<SymbolIndex>> {
+        self.inner.symbol_index()
     }
 
     /// Returns the current sequence number.
@@ -1901,5 +2010,114 @@ mod tests {
             .submit_add_order("BTC-20240329-50000-P", OrderId::new(), Side::Buy, 40, 5)
             .expect("submit");
         assert!(receipt.result.is_success());
+    }
+
+    // ── Registry / SymbolIndex integration ──────────────────────────────
+
+    #[test]
+    fn test_sequenced_book_new_without_registry() {
+        let book = SequencedUnderlyingOrderBook::new("BTC");
+        assert!(book.registry().is_none());
+        assert!(book.symbol_index().is_none());
+    }
+
+    #[test]
+    fn test_sequenced_book_new_with_registry_and_index() {
+        let registry = Arc::new(InstrumentRegistry::new());
+        let symbol_index = Arc::new(SymbolIndex::new());
+
+        let book = SequencedUnderlyingOrderBook::new_with_registry_and_index(
+            "BTC",
+            Arc::clone(&registry),
+            Arc::clone(&symbol_index),
+        );
+
+        assert!(book.registry().is_some());
+        assert!(book.symbol_index().is_some());
+        assert_eq!(book.underlying_symbol(), "BTC");
+        assert_eq!(book.current_sequence(), 0);
+        assert!(!book.has_journal());
+    }
+
+    #[test]
+    fn test_sequenced_book_with_journal_registry_and_index() {
+        let registry = Arc::new(InstrumentRegistry::new());
+        let symbol_index = Arc::new(SymbolIndex::new());
+        let journal: Arc<dyn OptionChainJournal> = Arc::new(InMemoryOptionChainJournal::new());
+
+        let book = SequencedUnderlyingOrderBook::with_journal_registry_and_index(
+            "BTC",
+            journal,
+            Arc::clone(&registry),
+            Arc::clone(&symbol_index),
+        );
+
+        assert!(book.registry().is_some());
+        assert!(book.symbol_index().is_some());
+        assert!(book.has_journal());
+    }
+
+    #[test]
+    fn test_sequenced_book_registry_populated_after_add_order() {
+        use chrono::{NaiveDate, TimeZone, Utc};
+
+        let registry = Arc::new(InstrumentRegistry::new());
+        let symbol_index = Arc::new(SymbolIndex::new());
+
+        let underlying = UnderlyingOrderBook::new_with_registry_and_index(
+            "BTC",
+            Arc::clone(&registry),
+            Arc::clone(&symbol_index),
+        );
+
+        assert!(registry.is_empty());
+        assert!(symbol_index.is_empty());
+
+        // Create the hierarchy — this registers instruments in the registry
+        let date = NaiveDate::from_ymd_opt(2024, 3, 29).expect("valid date");
+        let dt = date.and_hms_opt(0, 0, 0).expect("valid time");
+        let expiry = ExpirationDate::DateTime(Utc.from_utc_datetime(&dt));
+
+        let exp_book = underlying.get_or_create_expiration(expiry);
+        let strike = exp_book.get_or_create_strike(50000);
+        drop(strike);
+        drop(exp_book);
+
+        // Registry and symbol index should be populated after hierarchy creation
+        assert!(!registry.is_empty());
+        assert!(!symbol_index.is_empty());
+        assert!(symbol_index.contains("BTC-20240329-50000-C"));
+
+        // Wrap in sequencer and submit an order
+        let book = SequencedUnderlyingOrderBook::from_underlying(underlying);
+        let receipt = book
+            .submit_add_order("BTC-20240329-50000-C", OrderId::new(), Side::Buy, 100, 10)
+            .expect("submit");
+        assert!(receipt.result.is_success());
+
+        // Verify iter() returns the registered entries
+        let entries = registry.iter();
+        assert!(!entries.is_empty());
+
+        // Verify entries() on symbol index
+        let sym_entries = symbol_index.entries();
+        assert!(!sym_entries.is_empty());
+    }
+
+    #[test]
+    fn test_sequenced_book_from_underlying_with_registry() {
+        let registry = Arc::new(InstrumentRegistry::new());
+        let symbol_index = Arc::new(SymbolIndex::new());
+
+        let underlying = UnderlyingOrderBook::new_with_registry_and_index(
+            "ETH",
+            Arc::clone(&registry),
+            Arc::clone(&symbol_index),
+        );
+
+        let book = SequencedUnderlyingOrderBook::from_underlying(underlying);
+
+        assert!(book.registry().is_some());
+        assert!(book.symbol_index().is_some());
     }
 }

--- a/src/orderbook/symbol_index.rs
+++ b/src/orderbook/symbol_index.rs
@@ -206,6 +206,40 @@ impl SymbolIndex {
     pub fn symbols(&self) -> Vec<String> {
         self.index.iter().map(|entry| entry.key().clone()).collect()
     }
+
+    /// Returns a snapshot of all registered `(symbol, SymbolRef)` pairs.
+    ///
+    /// The returned `Vec` is a point-in-time snapshot — concurrent
+    /// registrations that occur after the call begins may or may not
+    /// be included. The order of entries is arbitrary.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use option_chain_orderbook::orderbook::symbol_index::{SymbolIndex, SymbolRef};
+    /// use optionstratlib::{ExpirationDate, OptionStyle};
+    /// use optionstratlib::prelude::pos_or_panic;
+    ///
+    /// let index = SymbolIndex::new();
+    /// let sym_ref = SymbolRef::new(
+    ///     "BTC",
+    ///     ExpirationDate::Days(pos_or_panic!(30.0)),
+    ///     50000,
+    ///     OptionStyle::Call,
+    /// );
+    /// index.register("BTC-20260130-50000-C", sym_ref);
+    ///
+    /// let entries = index.entries();
+    /// assert_eq!(entries.len(), 1);
+    /// assert_eq!(entries[0].0, "BTC-20260130-50000-C");
+    /// ```
+    #[must_use]
+    pub fn entries(&self) -> Vec<(String, SymbolRef)> {
+        self.index
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+            .collect()
+    }
 }
 
 impl Default for SymbolIndex {
@@ -354,5 +388,40 @@ mod tests {
         assert_eq!(symbols.len(), 2);
         assert!(symbols.contains(&"BTC-20260130-50000-C".to_string()));
         assert!(symbols.contains(&"BTC-20260130-50000-P".to_string()));
+    }
+
+    #[test]
+    fn test_symbol_index_entries_empty() {
+        let index = SymbolIndex::new();
+        let entries = index.entries();
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn test_symbol_index_entries() {
+        let index = SymbolIndex::new();
+
+        let call_ref = SymbolRef::new("BTC", test_expiration(), 50000, OptionStyle::Call);
+        let put_ref = SymbolRef::new("BTC", test_expiration(), 50000, OptionStyle::Put);
+
+        index.register("BTC-20260130-50000-C", call_ref.clone());
+        index.register("BTC-20260130-50000-P", put_ref.clone());
+
+        let entries = index.entries();
+        assert_eq!(entries.len(), 2);
+
+        let call_entry = entries
+            .iter()
+            .find(|(sym, _)| sym == "BTC-20260130-50000-C");
+        assert!(call_entry.is_some());
+        let (_, sym_ref) = call_entry.expect("call entry should exist");
+        assert_eq!(sym_ref.option_style(), OptionStyle::Call);
+
+        let put_entry = entries
+            .iter()
+            .find(|(sym, _)| sym == "BTC-20260130-50000-P");
+        assert!(put_entry.is_some());
+        let (_, sym_ref) = put_entry.expect("put entry should exist");
+        assert_eq!(sym_ref.option_style(), OptionStyle::Put);
     }
 }

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -47,8 +47,6 @@ pub struct UnderlyingOrderBook {
     /// Instrument registry propagated to expiration managers.
     registry: Option<Arc<InstrumentRegistry>>,
     /// Symbol index for O(1) lookup by symbol string.
-    /// Stored for future use in hierarchy traversal.
-    #[allow(dead_code)]
     symbol_index: Option<Arc<SymbolIndex>>,
     /// Strike range configurations per expiry type.
     strike_range_configs: SharedStrikeRangeConfigs,
@@ -193,8 +191,7 @@ impl UnderlyingOrderBook {
     /// * `underlying` - The underlying asset symbol
     /// * `registry` - The instrument registry for ID allocation
     #[must_use]
-    #[allow(dead_code)]
-    pub(crate) fn new_with_registry(
+    pub fn new_with_registry(
         underlying: impl Into<String>,
         registry: Arc<InstrumentRegistry>,
     ) -> Self {
@@ -224,7 +221,7 @@ impl UnderlyingOrderBook {
     /// * `registry` - The instrument registry for ID allocation
     /// * `symbol_index` - The symbol index for O(1) lookups
     #[must_use]
-    pub(crate) fn new_with_registry_and_index(
+    pub fn new_with_registry_and_index(
         underlying: impl Into<String>,
         registry: Arc<InstrumentRegistry>,
         symbol_index: Arc<SymbolIndex>,
@@ -262,6 +259,12 @@ impl UnderlyingOrderBook {
     #[must_use]
     pub fn registry(&self) -> Option<&Arc<InstrumentRegistry>> {
         self.registry.as_ref()
+    }
+
+    /// Returns a reference to the symbol index, if any.
+    #[must_use]
+    pub fn symbol_index(&self) -> Option<&Arc<SymbolIndex>> {
+        self.symbol_index.as_ref()
     }
 
     /// Sets the contract specifications for this underlying.


### PR DESCRIPTION
## Summary

Unblocks external consumers of `SequencedUnderlyingOrderBook` that need to enumerate instruments their sequencer has seen, without maintaining a parallel data structure.

Closes #6

## Changes

### Public API additions

| Type | Method | Description |
|------|--------|-------------|
| `UnderlyingOrderBook` | `new_with_registry()` | Promoted from `pub(crate)` → `pub` |
| `UnderlyingOrderBook` | `new_with_registry_and_index()` | Promoted from `pub(crate)` → `pub` |
| `UnderlyingOrderBook` | `symbol_index()` | New accessor returning `Option<&Arc<SymbolIndex>>` |
| `SequencedUnderlyingOrderBook` | `new_with_registry_and_index()` | New constructor with registry + index |
| `SequencedUnderlyingOrderBook` | `with_journal_registry_and_index()` | New constructor with journal + registry + index |
| `SequencedUnderlyingOrderBook` | `registry()` | Delegation accessor |
| `SequencedUnderlyingOrderBook` | `symbol_index()` | Delegation accessor |
| `InstrumentRegistry` | `iter()` | Returns `Vec<(u32, InstrumentInfo)>` snapshot |
| `SymbolIndex` | `entries()` | Returns `Vec<(String, SymbolRef)>` snapshot |

### Re-exports

`InstrumentInfo` and `InstrumentRegistry` added to top-level `lib.rs` re-exports.

### Documentation

Doc example on `SequencedUnderlyingOrderBook` showing end-to-end instrument listing via registry.

### Tests

- `test_sequenced_book_new_without_registry`
- `test_sequenced_book_new_with_registry_and_index`
- `test_sequenced_book_with_journal_registry_and_index`
- `test_sequenced_book_registry_populated_after_add_order`
- `test_sequenced_book_from_underlying_with_registry`
- `test_iter_empty`
- `test_iter_returns_all_entries`
- `test_symbol_index_entries_empty`
- `test_symbol_index_entries`

## Verification

- `cargo test --all-features` — 789 tests pass (696 lib + 5 integration + 88 doc)
- `cargo clippy --all-targets --all-features -- -D warnings` — zero warnings
- `make pre-push` — clean
