### PR TITLE
fix(expiration): deterministic ExpirationKey for SkipMap keys (#50)

### DIFF
--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -4,6 +4,7 @@
 //! for managing all strikes within a single expiration.
 
 use super::contract_specs::{ContractSpecs, SharedContractSpecs};
+use super::expiration_key::ExpirationKey;
 use super::fees::SharedFeeSchedule;
 use super::instrument_registry::InstrumentRegistry;
 use super::stp::SharedSTPMode;
@@ -759,8 +760,14 @@ impl ChainMassCancelResult {
 ///
 /// Uses `SkipMap` for thread-safe concurrent access.
 pub struct OptionChainOrderBookManager {
-    /// Option chains indexed by expiration.
-    chains: SkipMap<ExpirationDate, Arc<OptionChainOrderBook>>,
+    /// Option chains indexed by a deterministic [`ExpirationKey`].
+    ///
+    /// Keyed on [`ExpirationKey`] rather than [`ExpirationDate`] directly
+    /// because the latter's `Ord`/`Eq` is wall-clock-relative and collides
+    /// distinct expirations (see [`ExpirationKey`] docs). Each stored
+    /// [`OptionChainOrderBook`] retains its original [`ExpirationDate`], so the
+    /// public API still hands back `ExpirationDate` values.
+    chains: SkipMap<ExpirationKey, Arc<OptionChainOrderBook>>,
     /// The underlying asset symbol.
     underlying: String,
     /// Validation config applied to newly created chains.
@@ -912,7 +919,8 @@ impl OptionChainOrderBookManager {
     /// If a validation config has been set via [`set_validation`](Self::set_validation),
     /// newly created chains will have that config propagated to their strike manager.
     pub fn get_or_create(&self, expiration: ExpirationDate) -> Arc<OptionChainOrderBook> {
-        if let Some(entry) = self.chains.get(&expiration) {
+        let key = ExpirationKey::from(&expiration);
+        if let Some(entry) = self.chains.get(&key) {
             return Arc::clone(entry.value());
         }
         let chain = if let Some(ref reg) = self.registry {
@@ -937,7 +945,7 @@ impl OptionChainOrderBookManager {
         if let Some(schedule) = self.fee_schedule.get() {
             chain.set_fee_schedule(schedule);
         }
-        self.chains.insert(expiration, Arc::clone(&chain));
+        self.chains.insert(key, Arc::clone(&chain));
         chain
     }
 
@@ -948,7 +956,7 @@ impl OptionChainOrderBookManager {
     /// Returns `Error::ExpirationNotFound` if the expiration does not exist.
     pub fn get(&self, expiration: &ExpirationDate) -> Result<Arc<OptionChainOrderBook>> {
         self.chains
-            .get(expiration)
+            .get(&ExpirationKey::from(expiration))
             .map(|e| Arc::clone(e.value()))
             .ok_or_else(|| Error::expiration_not_found(expiration.to_string()))
     }
@@ -956,21 +964,28 @@ impl OptionChainOrderBookManager {
     /// Returns true if an option chain exists for the expiration.
     #[must_use]
     pub fn contains(&self, expiration: &ExpirationDate) -> bool {
-        self.chains.contains_key(expiration)
+        self.chains.contains_key(&ExpirationKey::from(expiration))
     }
 
-    /// Returns an iterator over all chains.
-    pub fn iter(
-        &self,
-    ) -> impl Iterator<
-        Item = crossbeam_skiplist::map::Entry<'_, ExpirationDate, Arc<OptionChainOrderBook>>,
-    > {
-        self.chains.iter()
+    /// Returns an iterator over all chains, ordered by expiration.
+    ///
+    /// Yields `(ExpirationDate, Arc<OptionChainOrderBook>)` tuples in ascending
+    /// order. Ordering is driven by an internal deterministic expiration key
+    /// (clock-independent and collision-free, unlike `ExpirationDate`'s own
+    /// `Ord`), so the traversal order is stable and replay-safe. The
+    /// `ExpirationDate` is the original value stored in each chain; the internal
+    /// key is never exposed.
+    pub fn iter(&self) -> impl Iterator<Item = (ExpirationDate, Arc<OptionChainOrderBook>)> + '_ {
+        self.chains
+            .iter()
+            .map(|e| (*e.value().expiration(), Arc::clone(e.value())))
     }
 
     /// Removes an option chain.
     pub fn remove(&self, expiration: &ExpirationDate) -> bool {
-        self.chains.remove(expiration).is_some()
+        self.chains
+            .remove(&ExpirationKey::from(expiration))
+            .is_some()
     }
 
     /// Returns the total order count across all chains.
@@ -1083,6 +1098,66 @@ mod tests {
         drop(manager.get_or_create(ExpirationDate::Days(pos_or_panic!(90.0))));
 
         assert_eq!(manager.len(), 3);
+    }
+
+    #[test]
+    fn test_option_chain_manager_get_or_create_returns_same_handle() {
+        let manager = OptionChainOrderBookManager::new("BTC");
+        let exp = test_expiration();
+
+        let first = manager.get_or_create(exp);
+        let second = manager.get_or_create(exp);
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn test_option_chain_manager_same_day_of_month_distinct_months_both_retrievable() {
+        use chrono::{TimeZone, Utc};
+
+        // Regression for issue #50: two `DateTime` expirations sharing a
+        // day-of-month across different months must not collide into one
+        // `SkipMap` slot.
+        let jan = match Utc.with_ymd_and_hms(2026, 1, 15, 8, 0, 0) {
+            chrono::offset::LocalResult::Single(dt) => ExpirationDate::DateTime(dt),
+            _ => panic!("invalid jan fixture"),
+        };
+        let feb = match Utc.with_ymd_and_hms(2026, 2, 15, 8, 0, 0) {
+            chrono::offset::LocalResult::Single(dt) => ExpirationDate::DateTime(dt),
+            _ => panic!("invalid feb fixture"),
+        };
+
+        let manager = OptionChainOrderBookManager::new("BTC");
+
+        let jan_chain = manager.get_or_create(jan);
+        jan_chain.get_or_create_strike(50000);
+
+        let feb_chain = manager.get_or_create(feb);
+        feb_chain.get_or_create_strike(50000);
+        feb_chain.get_or_create_strike(51000);
+
+        assert_eq!(manager.len(), 2);
+        assert!(manager.contains(&jan));
+        assert!(manager.contains(&feb));
+
+        let jan_got = match manager.get(&jan) {
+            Ok(chain) => chain,
+            Err(err) => panic!("jan not found: {}", err),
+        };
+        let feb_got = match manager.get(&feb) {
+            Ok(chain) => chain,
+            Err(err) => panic!("feb not found: {}", err),
+        };
+        assert_eq!(jan_got.strike_count(), 1);
+        assert_eq!(feb_got.strike_count(), 2);
+        assert_eq!(*jan_got.expiration(), jan);
+        assert_eq!(*feb_got.expiration(), feb);
+
+        assert!(manager.remove(&jan));
+        assert_eq!(manager.len(), 1);
+        assert!(!manager.contains(&jan));
+        assert!(manager.contains(&feb));
     }
 
     #[test]

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -5,6 +5,7 @@
 
 use super::chain::{ChainMassCancelResult, OptionChainOrderBook};
 use super::contract_specs::{ContractSpecs, SharedContractSpecs};
+use super::expiration_key::ExpirationKey;
 use super::fees::SharedFeeSchedule;
 use super::instrument_registry::InstrumentRegistry;
 use super::stp::SharedSTPMode;
@@ -555,8 +556,14 @@ impl ExpirationOrderBook {
 /// Provides centralized access to all expirations for an underlying asset.
 /// Uses `SkipMap` for thread-safe concurrent access.
 pub struct ExpirationOrderBookManager {
-    /// Expiration order books indexed by expiration date.
-    expirations: SkipMap<ExpirationDate, Arc<ExpirationOrderBook>>,
+    /// Expiration order books indexed by a deterministic [`ExpirationKey`].
+    ///
+    /// Keyed on [`ExpirationKey`] rather than [`ExpirationDate`] directly
+    /// because the latter's `Ord`/`Eq` is wall-clock-relative and collides
+    /// distinct expirations (see [`ExpirationKey`] docs). Each stored
+    /// [`ExpirationOrderBook`] retains its original [`ExpirationDate`], so the
+    /// public API still hands back `ExpirationDate` values.
+    expirations: SkipMap<ExpirationKey, Arc<ExpirationOrderBook>>,
     /// The underlying asset symbol.
     underlying: String,
     /// Validation config applied to newly created expiration books.
@@ -737,7 +744,8 @@ impl ExpirationOrderBookManager {
     /// If a validation config has been set via [`set_validation`](Self::set_validation),
     /// newly created expiration books will have that config propagated to their chain.
     pub fn get_or_create(&self, expiration: ExpirationDate) -> Arc<ExpirationOrderBook> {
-        if let Some(entry) = self.expirations.get(&expiration) {
+        let key = ExpirationKey::from(&expiration);
+        if let Some(entry) = self.expirations.get(&key) {
             return Arc::clone(entry.value());
         }
         let book = match (&self.registry, &self.symbol_index) {
@@ -767,7 +775,7 @@ impl ExpirationOrderBookManager {
         if let Some(schedule) = self.fee_schedule.get() {
             book.set_fee_schedule(schedule);
         }
-        self.expirations.insert(expiration, Arc::clone(&book));
+        self.expirations.insert(key, Arc::clone(&book));
         book
     }
 
@@ -778,7 +786,7 @@ impl ExpirationOrderBookManager {
     /// Returns `Error::ExpirationNotFound` if the expiration does not exist.
     pub fn get(&self, expiration: &ExpirationDate) -> Result<Arc<ExpirationOrderBook>> {
         self.expirations
-            .get(expiration)
+            .get(&ExpirationKey::from(expiration))
             .map(|e| Arc::clone(e.value()))
             .ok_or_else(|| Error::expiration_not_found(expiration.to_string()))
     }
@@ -786,20 +794,29 @@ impl ExpirationOrderBookManager {
     /// Returns true if an expiration exists.
     #[must_use]
     pub fn contains(&self, expiration: &ExpirationDate) -> bool {
-        self.expirations.contains_key(expiration)
+        self.expirations
+            .contains_key(&ExpirationKey::from(expiration))
     }
 
-    /// Returns an iterator over all expirations.
-    pub fn iter(
-        &self,
-    ) -> impl Iterator<Item = crossbeam_skiplist::map::Entry<'_, ExpirationDate, Arc<ExpirationOrderBook>>>
-    {
-        self.expirations.iter()
+    /// Returns an iterator over all expirations, ordered by expiration.
+    ///
+    /// Yields `(ExpirationDate, Arc<ExpirationOrderBook>)` tuples in ascending
+    /// order. Ordering is driven by an internal deterministic expiration key
+    /// (clock-independent and collision-free, unlike `ExpirationDate`'s own
+    /// `Ord`), so the traversal order is stable and replay-safe. The
+    /// `ExpirationDate` is the original value stored in each book; the internal
+    /// key is never exposed.
+    pub fn iter(&self) -> impl Iterator<Item = (ExpirationDate, Arc<ExpirationOrderBook>)> + '_ {
+        self.expirations
+            .iter()
+            .map(|e| (*e.value().expiration(), Arc::clone(e.value())))
     }
 
     /// Removes an expiration order book.
     pub fn remove(&self, expiration: &ExpirationDate) -> bool {
-        self.expirations.remove(expiration).is_some()
+        self.expirations
+            .remove(&ExpirationKey::from(expiration))
+            .is_some()
     }
 
     /// Returns the total order count across all expirations.
@@ -1120,6 +1137,70 @@ mod tests {
         drop(manager.get_or_create(ExpirationDate::Days(pos_or_panic!(90.0))));
 
         assert_eq!(manager.len(), 3);
+    }
+
+    #[test]
+    fn test_expiration_manager_get_or_create_returns_same_handle() {
+        let manager = ExpirationOrderBookManager::new("BTC");
+        let exp = test_expiration();
+
+        let first = manager.get_or_create(exp);
+        let second = manager.get_or_create(exp);
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn test_expiration_manager_same_day_of_month_distinct_months_both_retrievable() {
+        use chrono::{TimeZone, Utc};
+
+        // Regression for issue #50: two `DateTime` expirations sharing a
+        // day-of-month across different months must not collide into one
+        // `SkipMap` slot.
+        let jan = match Utc.with_ymd_and_hms(2026, 1, 15, 8, 0, 0) {
+            chrono::offset::LocalResult::Single(dt) => ExpirationDate::DateTime(dt),
+            _ => panic!("invalid jan fixture"),
+        };
+        let feb = match Utc.with_ymd_and_hms(2026, 2, 15, 8, 0, 0) {
+            chrono::offset::LocalResult::Single(dt) => ExpirationDate::DateTime(dt),
+            _ => panic!("invalid feb fixture"),
+        };
+
+        let manager = ExpirationOrderBookManager::new("BTC");
+
+        // Distinguish the two books by strike population.
+        let jan_book = manager.get_or_create(jan);
+        jan_book.get_or_create_strike(50000);
+
+        let feb_book = manager.get_or_create(feb);
+        feb_book.get_or_create_strike(50000);
+        feb_book.get_or_create_strike(51000);
+
+        // Both expirations survive — the second insert did not overwrite the first.
+        assert_eq!(manager.len(), 2);
+        assert!(manager.contains(&jan));
+        assert!(manager.contains(&feb));
+
+        // `get` returns the correct, independent book for each expiration.
+        let jan_got = match manager.get(&jan) {
+            Ok(book) => book,
+            Err(err) => panic!("jan not found: {}", err),
+        };
+        let feb_got = match manager.get(&feb) {
+            Ok(book) => book,
+            Err(err) => panic!("feb not found: {}", err),
+        };
+        assert_eq!(jan_got.strike_count(), 1);
+        assert_eq!(feb_got.strike_count(), 2);
+        assert_eq!(*jan_got.expiration(), jan);
+        assert_eq!(*feb_got.expiration(), feb);
+
+        // Removing one leaves the other intact.
+        assert!(manager.remove(&jan));
+        assert_eq!(manager.len(), 1);
+        assert!(!manager.contains(&jan));
+        assert!(manager.contains(&feb));
     }
 
     #[test]

--- a/src/orderbook/expiration_key.rs
+++ b/src/orderbook/expiration_key.rs
@@ -1,0 +1,126 @@
+//! Internal ordered key for `ExpirationDate`-keyed `SkipMap`s.
+//!
+//! This module exists solely to give the expiration-level managers a *correct*
+//! ordered map key. It is dependency-light (only `chrono` and `optionstratlib`)
+//! and sits below the hierarchy layers that use it, so both `chain.rs` and
+//! `expiration.rs` can depend on it without inverting the layering.
+
+use chrono::{DateTime, Utc};
+use optionstratlib::ExpirationDate;
+use optionstratlib::prelude::Positive;
+
+/// Total-order key derived from an [`ExpirationDate`] for use as a `SkipMap` key.
+///
+/// # Why this exists
+///
+/// `optionstratlib`'s `ExpirationDate` (re-exported from the `expiration_date`
+/// crate) has a wall-clock-relative `Ord`/`Eq`: comparisons route both sides
+/// through `ExpirationDate::get_days()`, which for the `DateTime` variant
+/// computes `dt.signed_duration_since(Utc::now())` and **clamps every instant
+/// in the past to zero**. As a result:
+///
+/// * every already-expired `DateTime` collapses to the same comparison value
+///   (zero days) and collides into a single ordered-map slot — silently
+///   overwriting the previously inserted expiration and dropping its strikes
+///   and orders;
+/// * ordering is non-deterministic because it depends on `Utc::now()` at the
+///   moment of comparison (a hazard for replay and event-emission order); and
+/// * `get_days()` mutates process-global thread-local state on every call,
+///   which is an unacceptable side effect for a map-key comparison.
+///
+/// `ExpirationKey` mirrors the two `ExpirationDate` representations with a
+/// correct, deterministic, clock-independent total order:
+///
+/// * [`ExpirationKey::Days`] keeps the relative fractional-day count as a
+///   [`Positive`] and orders by it. `Positive` already excludes `NaN` by
+///   construction, so no `f64`→key conversion and no NaN can leak in here.
+/// * [`ExpirationKey::DateTime`] keeps the absolute UTC instant and orders by
+///   it via `chrono`'s correct, integral `Ord`.
+///
+/// # Ordering
+///
+/// The two variants occupy disjoint key spaces — a relative day-count and an
+/// absolute instant are not comparable on a single axis — so the derived
+/// lexicographic order places all `Days` keys before all `DateTime` keys.
+/// Within each variant the order is strictly chronological (more days / later
+/// instant sorts later). This matches the way the hierarchy already treats the
+/// two representations: lifecycle transitions operate only on `DateTime`
+/// expirations and skip `Days` ones.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub(crate) enum ExpirationKey {
+    /// Relative expiration measured in fractional days.
+    Days(Positive),
+    /// Absolute expiration instant in UTC.
+    DateTime(DateTime<Utc>),
+}
+
+impl From<&ExpirationDate> for ExpirationKey {
+    /// Builds the deterministic ordered key for an [`ExpirationDate`].
+    ///
+    /// The conversion is structural and clock-independent: it never calls
+    /// `Utc::now()` and never touches `ExpirationDate::get_days()`.
+    #[inline]
+    fn from(expiration: &ExpirationDate) -> Self {
+        match expiration {
+            ExpirationDate::Days(days) => Self::Days(*days),
+            ExpirationDate::DateTime(dt) => Self::DateTime(*dt),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use optionstratlib::prelude::pos_or_panic;
+
+    fn datetime(year: i32, month: u32, day: u32) -> ExpirationDate {
+        let dt = match Utc.with_ymd_and_hms(year, month, day, 8, 0, 0) {
+            chrono::offset::LocalResult::Single(dt) => dt,
+            _ => panic!("invalid fixture datetime"),
+        };
+        ExpirationDate::DateTime(dt)
+    }
+
+    #[test]
+    fn test_expiration_key_same_day_of_month_distinct_months_distinct_keys() {
+        // Regression: the upstream `Ord` collapses these toward a common
+        // day-count scale; the key must keep them distinct.
+        let jan = ExpirationKey::from(&datetime(2026, 1, 15));
+        let feb = ExpirationKey::from(&datetime(2026, 2, 15));
+        assert_ne!(jan, feb);
+        assert!(jan < feb);
+    }
+
+    #[test]
+    fn test_expiration_key_past_datetimes_distinct_keys() {
+        // Both are in the past; the upstream `get_days()` would clamp both to
+        // zero and collide them. The key must keep them distinct.
+        let a = ExpirationKey::from(&datetime(2000, 1, 1));
+        let b = ExpirationKey::from(&datetime(2001, 1, 1));
+        assert_ne!(a, b);
+        assert!(a < b);
+    }
+
+    #[test]
+    fn test_expiration_key_days_orders_chronologically() {
+        let d30 = ExpirationKey::from(&ExpirationDate::Days(pos_or_panic!(30.0)));
+        let d60 = ExpirationKey::from(&ExpirationDate::Days(pos_or_panic!(60.0)));
+        assert_ne!(d30, d60);
+        assert!(d30 < d60);
+    }
+
+    #[test]
+    fn test_expiration_key_days_sort_before_datetime() {
+        let days = ExpirationKey::from(&ExpirationDate::Days(pos_or_panic!(9999.0)));
+        let dt = ExpirationKey::from(&datetime(2000, 1, 1));
+        assert!(days < dt);
+    }
+
+    #[test]
+    fn test_expiration_key_same_expiration_equal_keys() {
+        let a = ExpirationKey::from(&datetime(2026, 3, 21));
+        let b = ExpirationKey::from(&datetime(2026, 3, 21));
+        assert_eq!(a, b);
+    }
+}

--- a/src/orderbook/expiry_lifecycle.rs
+++ b/src/orderbook/expiry_lifecycle.rs
@@ -266,9 +266,8 @@ impl ExpiryLifecycleManager {
         let expirations: Vec<(ExpirationDate, Option<InstrumentStatus>)> = underlying
             .expirations()
             .iter()
-            .map(|entry| {
-                let exp = *entry.value().expiration();
-                let status = chain_status(entry.value().chain());
+            .map(|(exp, book)| {
+                let status = chain_status(book.chain());
                 (exp, status)
             })
             .collect();
@@ -1098,12 +1097,13 @@ mod tests {
 
     // ── test_multiple_expirations_different_stages ────────────────────────
 
-    // FIXME: This test is broken due to optionstratlib's ExpirationDate::DateTime
-    // having a buggy Ord implementation that compares only day-of-month, causing
-    // different dates (e.g., 2026-03-15 vs 2026-01-15) to compare as Equal.
-    // See: https://github.com/joaquinbejar/OptionStratLib/issues/XXX
+    // Regression oracle for issue #50. `optionstratlib`'s `ExpirationDate` has a
+    // wall-clock-relative `Ord`/`Eq` that collides distinct `DateTime`
+    // expirations (every past instant collapses to zero days) into a single
+    // `SkipMap` slot. The manager now keys on the internal `ExpirationKey`
+    // (deterministic, absolute), so the three distinct expirations below stay
+    // distinct through their full lifecycle.
     #[test]
-    #[ignore = "blocked by optionstratlib ExpirationDate::DateTime Ord bug"]
     fn test_multiple_expirations_different_stages() {
         let exp_active = fixed_expiration(2026, 6, 15);
         let exp_settling = fixed_expiration(2026, 3, 15);

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -51,6 +51,7 @@ mod book;
 mod chain;
 mod contract_specs;
 mod expiration;
+mod expiration_key;
 mod expiry_cycle;
 mod expiry_lifecycle;
 mod expiry_scheduler;

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -588,9 +588,9 @@ impl UnderlyingOrderBook {
     pub fn cancel_all(&self) -> Result<UnderlyingMassCancelResult> {
         let mut per_child = Vec::new();
 
-        for entry in self.expirations.iter() {
-            let expiration_key = entry.key().to_string();
-            let result = entry.value().cancel_all()?;
+        for (expiration, book) in self.expirations.iter() {
+            let expiration_key = expiration.to_string();
+            let result = book.cancel_all()?;
             per_child.push((expiration_key, result));
         }
 
@@ -633,9 +633,9 @@ impl UnderlyingOrderBook {
     pub fn cancel_by_side(&self, side: Side) -> Result<UnderlyingMassCancelResult> {
         let mut per_child = Vec::new();
 
-        for entry in self.expirations.iter() {
-            let expiration_key = entry.key().to_string();
-            let result = entry.value().cancel_by_side(side)?;
+        for (expiration, book) in self.expirations.iter() {
+            let expiration_key = expiration.to_string();
+            let result = book.cancel_by_side(side)?;
             per_child.push((expiration_key, result));
         }
 
@@ -680,9 +680,9 @@ impl UnderlyingOrderBook {
     pub fn cancel_by_user(&self, user_id: Hash32) -> Result<UnderlyingMassCancelResult> {
         let mut per_child = Vec::new();
 
-        for entry in self.expirations.iter() {
-            let expiration_key = entry.key().to_string();
-            let result = entry.value().cancel_by_user(user_id)?;
+        for (expiration, book) in self.expirations.iter() {
+            let expiration_key = expiration.to_string();
+            let result = book.cancel_by_user(user_id)?;
             per_child.push((expiration_key, result));
         }
 
@@ -711,8 +711,8 @@ impl UnderlyingOrderBook {
     /// None.
     #[must_use]
     pub fn find_order(&self, order_id: OrderId) -> Option<(String, OrderStatus)> {
-        for entry in self.expirations.iter() {
-            if let Some(result) = entry.value().find_order(order_id) {
+        for (_, book) in self.expirations.iter() {
+            if let Some(result) = book.find_order(order_id) {
                 return Some(result);
             }
         }
@@ -740,7 +740,7 @@ impl UnderlyingOrderBook {
     pub fn total_active_orders(&self) -> usize {
         self.expirations
             .iter()
-            .map(|entry| entry.value().total_active_orders())
+            .map(|(_, book)| book.total_active_orders())
             .sum()
     }
 
@@ -764,7 +764,7 @@ impl UnderlyingOrderBook {
     pub fn purge_terminal_states(&self, older_than: Duration) -> usize {
         self.expirations
             .iter()
-            .map(|entry| entry.value().purge_terminal_states(older_than))
+            .map(|(_, book)| book.purge_terminal_states(older_than))
             .sum()
     }
 
@@ -790,7 +790,7 @@ impl UnderlyingOrderBook {
     pub fn orders_by_user(&self, user_id: Hash32) -> Vec<(String, OrderId, OrderStatus)> {
         self.expirations
             .iter()
-            .flat_map(|entry| entry.value().orders_by_user(user_id))
+            .flat_map(|(_, book)| book.orders_by_user(user_id))
             .collect()
     }
 
@@ -816,7 +816,7 @@ impl UnderlyingOrderBook {
     pub fn terminal_order_summary(&self) -> TerminalOrderSummary {
         self.expirations
             .iter()
-            .map(|entry| entry.value().terminal_order_summary())
+            .map(|(_, book)| book.terminal_order_summary())
             .sum()
     }
 
@@ -858,8 +858,8 @@ impl UnderlyingOrderBook {
         config: &super::nats::OptionChainNatsConfig,
     ) -> crate::Result<usize> {
         let mut total_connected = 0usize;
-        for entry in self.expirations.iter() {
-            let connected = entry.value().connect_nats(config)?;
+        for (_, book) in self.expirations.iter() {
+            let connected = book.connect_nats(config)?;
             total_connected = total_connected.saturating_add(connected);
         }
         Ok(total_connected)


### PR DESCRIPTION
## Summary

`ExpirationDate`'s `Ord` (via optionstratlib's `expiration_date` crate) is unfit as a map key: for the `DateTime` variant it reads `Utc::now()` on every comparison (wall-clock dependent, mutates thread-local state) and clamps every past instant to 0 days. Keying the expiration `SkipMap`s on it collapsed all past expirations — and any two same-day expirations in different months — into one slot, silently overwriting orders/strikes and corrupting lifecycle targeting and event-emission order. This fixes the keying with a deterministic internal key.

## Changes

- New private `ExpirationKey` (enum mirroring `ExpirationDate::{Days,DateTime}`) with a correct, total, clock-independent `Ord`; built purely structurally from `&ExpirationDate` (no `Utc::now()`).
- `ExpirationOrderBookManager` and `OptionChainOrderBookManager` now key their `SkipMap`s on `ExpirationKey`. All public methods still take/return `ExpirationDate`; conversion happens at the single manager boundary.
- Un-ignored `test_multiple_expirations_different_stages` (the regression oracle) and added same-day-of-month-different-month tests at the manager and key level, plus `get_or_create` idempotency tests.

## Technical decisions

- Local key newtype rather than pinning/forking optionstratlib (no new dependency, no upstream change needed).
- `Days` and `DateTime` occupy disjoint key spaces (relative day-count vs absolute instant aren't comparable on one axis), so `Days` keys sort before `DateTime` keys; within each variant the order is strictly chronological. Exact key identity replaces the old `1e-16` epsilon equality — correct for a map key. Lifecycle operates only on `DateTime`, matching existing behavior.

## Public API impact

`ExpirationOrderBookManager::iter()` and `OptionChainOrderBookManager::iter()` change their `Item` from `crossbeam_skiplist::map::Entry<'_, ExpirationDate, Arc<…>>` to `(ExpirationDate, Arc<…>)` — the internal `ExpirationKey` is never exposed, and the per-entry `ExpirationDate` is preserved. Breaking for external consumers of the old `Entry`/`.key()` shape; permissible for this 0.4.x (pre-1.0) crate. No in-repo consumer relied on the old shape. `lib.rs` module docs unchanged, so `README.md` (via `make readme`) is unchanged.

## Testing

- [x] Unit + manager-level regression tests (same-day-of-month distinct months both retrievable; distinct keys; idempotent `get_or_create`)
- [x] Previously-ignored multi-expiration lifecycle test now runs and passes
- [x] Determinism re-audited: key `Ord` is clock-independent; mass-cancel `per_child`, stats, and lifecycle order remain driven by the ordered `SkipMap`
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] `cargo test --all-features` — 706 lib + 5 integration + 88 doctests, 0 failures
- [x] `make pre-push` clean

## Checklist

- [x] Follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()`/`.expect()`/unchecked indexing in production code
- [x] No `unsafe`; layering respected (`expiration_key` is a dependency-light leaf)
- [x] `tracing` only; no new dependencies
- [x] Deterministic aggregation/mass-cancel order preserved

Closes #50
