### PR TITLE
fix(symbol): single SymbolParser source of truth; reject cross-underlying (#51)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "option-chain-orderbook"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance Rust library for options market making infrastructure, providing a complete Option Chain Order Book system built on top of OrderBook-rs, PriceLevel, and OptionStratLib."

--- a/src/error.rs
+++ b/src/error.rs
@@ -177,6 +177,20 @@ pub enum Error {
         symbol: String,
     },
 
+    /// Error when a command's symbol names a different underlying than the book
+    /// it is routed to (e.g. an ETH command submitted to a BTC book).
+    #[error(
+        "underlying mismatch for symbol '{symbol}': parsed underlying '{parsed}' but book is '{expected}'"
+    )]
+    UnderlyingMismatch {
+        /// The offending symbol.
+        symbol: String,
+        /// The underlying parsed from the symbol.
+        parsed: String,
+        /// The underlying the target book belongs to.
+        expected: String,
+    },
+
     /// Error when a journal operation fails.
     #[error("journal error: {message}")]
     JournalError {
@@ -353,6 +367,21 @@ impl Error {
         }
     }
 
+    /// Creates a new underlying mismatch error.
+    #[must_use]
+    #[cold]
+    pub fn underlying_mismatch(
+        symbol: impl Into<String>,
+        parsed: impl Into<String>,
+        expected: impl Into<String>,
+    ) -> Self {
+        Self::UnderlyingMismatch {
+            symbol: symbol.into(),
+            parsed: parsed.into(),
+            expected: expected.into(),
+        }
+    }
+
     /// Creates a new journal error.
     #[must_use]
     pub fn journal_error(message: impl Into<String>) -> Self {
@@ -514,5 +543,15 @@ mod tests {
         let msg = err.to_string();
         assert!(msg.contains("symbol not found"));
         assert!(msg.contains("BTC-20260130-50000-C"));
+    }
+
+    #[test]
+    fn test_underlying_mismatch_error() {
+        let err = Error::underlying_mismatch("ETH-20240329-3000-C", "ETH", "BTC");
+        let msg = err.to_string();
+        assert!(msg.contains("underlying mismatch"));
+        assert!(msg.contains("ETH-20240329-3000-C"));
+        assert!(msg.contains("ETH"));
+        assert!(msg.contains("BTC"));
     }
 }

--- a/src/orderbook/nats.rs
+++ b/src/orderbook/nats.rs
@@ -39,6 +39,8 @@
 //! ```
 
 use crate::error::Error;
+use crate::utils::SymbolParser;
+use optionstratlib::OptionStyle;
 
 /// Configuration for connecting NATS publishers to the option chain hierarchy.
 ///
@@ -154,7 +156,9 @@ impl OptionChainSubjectBuilder {
     ///
     /// # Errors
     ///
-    /// Returns an error if the symbol does not match the expected format.
+    /// Returns an error if the symbol does not match the expected format, or if
+    /// the (already grammar-valid) underlying contains a NATS subject-reserved
+    /// character (`.`, `*`, `>`).
     ///
     /// # Example
     ///
@@ -168,51 +172,33 @@ impl OptionChainSubjectBuilder {
     /// assert_eq!(builder.option_type(), "C");
     /// ```
     pub fn from_symbol(symbol: &str) -> Result<Self, Error> {
-        let parts: Vec<&str> = symbol.split('-').collect();
-        if parts.len() != 4 {
+        // The `{underlying}-{expiry}-{strike}-{type}` grammar is owned by
+        // `SymbolParser` (the single source of truth): 4 parts, an 8-digit
+        // canonical date, a positive integer strike and a case-insensitive
+        // `C`/`P` type. NATS adds only subject-character escaping on top.
+        let parsed = SymbolParser::parse(symbol)?;
+
+        // The underlying is the only free-form segment that can carry a NATS
+        // subject-reserved character; the expiry (digits) and strike (digits)
+        // are already constrained by `SymbolParser`.
+        let underlying = parsed.underlying();
+        if underlying.contains('.') || underlying.contains('*') || underlying.contains('>') {
             return Err(Error::invalid_symbol(
                 symbol,
-                format!("expected 4 parts, got {}", parts.len()),
+                "underlying contains invalid NATS characters",
             ));
         }
 
-        let option_type = parts[3].to_uppercase();
-        if option_type != "C" && option_type != "P" {
-            return Err(Error::invalid_symbol(
-                symbol,
-                format!("expected C or P, got {}", parts[3]),
-            ));
-        }
-
-        // Validate components for NATS subject rules
-        let underlying = parts[0];
-        let expiry = parts[1];
-        let strike = parts[2];
-
-        for (name, value) in [
-            ("underlying", underlying),
-            ("expiry", expiry),
-            ("strike", strike),
-        ] {
-            if value.is_empty() {
-                return Err(Error::invalid_symbol(
-                    symbol,
-                    format!("{} cannot be empty", name),
-                ));
-            }
-            if value.contains('.') || value.contains('*') || value.contains('>') {
-                return Err(Error::invalid_symbol(
-                    symbol,
-                    format!("{} contains invalid NATS characters", name),
-                ));
-            }
-        }
+        let option_type = match parsed.option_style() {
+            OptionStyle::Call => "C",
+            OptionStyle::Put => "P",
+        };
 
         Ok(Self {
             underlying: underlying.to_string(),
-            expiry: expiry.to_string(),
-            strike: strike.to_string(),
-            option_type,
+            expiry: parsed.expiration_str().to_string(),
+            strike: parsed.strike().to_string(),
+            option_type: option_type.to_string(),
         })
     }
 
@@ -338,6 +324,28 @@ mod tests {
     fn test_subject_builder_invalid_parts() {
         let result = OptionChainSubjectBuilder::from_symbol("BTC-20240329-50000");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_from_symbol_matches_symbol_parser_parse() {
+        for symbol in [
+            "BTC-20240329-50000-C",
+            "ETH-20240628-3000-P",
+            "BTC-20240329-50000-c",
+        ] {
+            let parsed = SymbolParser::parse(symbol).expect("symbol parser must parse");
+            let builder =
+                OptionChainSubjectBuilder::from_symbol(symbol).expect("from_symbol must parse");
+
+            assert_eq!(builder.underlying(), parsed.underlying());
+            assert_eq!(builder.expiry(), parsed.expiration_str());
+            assert_eq!(builder.strike(), parsed.strike().to_string());
+            let expected_type = match parsed.option_style() {
+                OptionStyle::Call => "C",
+                OptionStyle::Put => "P",
+            };
+            assert_eq!(builder.option_type(), expected_type);
+        }
     }
 
     #[test]

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -27,8 +27,8 @@ use crate::orderbook::book::TerminalOrderSummary;
 use crate::orderbook::instrument_registry::InstrumentRegistry;
 use crate::orderbook::symbol_index::SymbolIndex;
 use crate::orderbook::underlying::UnderlyingOrderBook;
-use crate::utils::nanos_since_epoch;
-use optionstratlib::ExpirationDate;
+use crate::utils::{SymbolParser, nanos_since_epoch};
+use optionstratlib::{ExpirationDate, OptionStyle};
 use orderbook_rs::{OrderId, Side};
 use pricelevel::Hash32;
 use serde::{Deserialize, Serialize};
@@ -787,6 +787,13 @@ impl SequencedUnderlyingOrderBook {
     ) -> OptionChainResult {
         let book = match self.find_book_by_symbol(symbol) {
             Ok(book) => book,
+            // A cross-underlying command must be rejected with the typed reason,
+            // never silently routed or masked as a missing book.
+            Err(e @ Error::UnderlyingMismatch { .. }) => {
+                return OptionChainResult::Rejected {
+                    reason: e.to_string(),
+                };
+            }
             Err(_) => {
                 return OptionChainResult::BookNotFound {
                     symbol: symbol.to_string(),
@@ -806,6 +813,13 @@ impl SequencedUnderlyingOrderBook {
     fn execute_cancel_order(&self, symbol: &str, order_id: OrderId) -> OptionChainResult {
         let book = match self.find_book_by_symbol(symbol) {
             Ok(book) => book,
+            // A cross-underlying command must be rejected with the typed reason,
+            // never silently routed or masked as a missing book.
+            Err(e @ Error::UnderlyingMismatch { .. }) => {
+                return OptionChainResult::Rejected {
+                    reason: e.to_string(),
+                };
+            }
             Err(_) => {
                 return OptionChainResult::BookNotFound {
                     symbol: symbol.to_string(),
@@ -1038,63 +1052,44 @@ impl SequencedUnderlyingOrderBook {
     }
 
     /// Finds an option book by symbol.
+    ///
+    /// The symbol grammar is parsed by [`SymbolParser`], the single source of
+    /// truth, so the derived expiration instant (and therefore the
+    /// `ExpirationKey` used to look up the chain) matches whatever created the
+    /// chain. The parsed underlying is validated against this book's underlying
+    /// — a mismatch is rejected with [`Error::UnderlyingMismatch`] rather than
+    /// silently routing the order into the wrong book.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSymbol`] for a malformed symbol,
+    /// [`Error::UnderlyingMismatch`] when the symbol's underlying differs from
+    /// this book's, or a not-found error when the expiration or strike does not
+    /// exist in this book.
     fn find_book_by_symbol(
         &self,
         symbol: &str,
     ) -> Result<Arc<crate::orderbook::OptionOrderBook>, Error> {
-        // Fallback: parse symbol and navigate
-        let parts: Vec<&str> = symbol.split('-').collect();
-        if parts.len() != 4 {
-            return Err(Error::invalid_symbol(
+        let parsed = SymbolParser::parse(symbol)?;
+
+        let expected = self.inner.underlying();
+        if parsed.underlying() != expected {
+            return Err(Error::underlying_mismatch(
                 symbol,
-                "expected format: UNDERLYING-YYYYMMDD-STRIKE-C|P",
+                parsed.underlying(),
+                expected,
             ));
         }
 
-        let expiry_str = parts[1];
-        let strike_str = parts[2];
-        let option_type = parts[3];
+        let exp_book = self.inner.get_expiration(parsed.expiration())?;
+        let strike_book = exp_book.get_strike(parsed.strike())?;
 
-        // Parse expiration date
-        let expiry = Self::parse_expiration(expiry_str)?;
-
-        // Parse strike
-        let strike: u64 = strike_str.parse().map_err(|_| {
-            Error::invalid_symbol(symbol, format!("invalid strike: {}", strike_str))
-        })?;
-
-        let exp_book = self.inner.get_expiration(&expiry)?;
-        let strike_book = exp_book.get_strike(strike)?;
-
-        let book = match option_type.to_uppercase().as_str() {
-            "C" => strike_book.call_arc(),
-            "P" => strike_book.put_arc(),
-            _ => {
-                return Err(Error::invalid_symbol(
-                    symbol,
-                    format!("expected C or P, got {}", option_type),
-                ));
-            }
+        let book = match parsed.option_style() {
+            OptionStyle::Call => strike_book.call_arc(),
+            OptionStyle::Put => strike_book.put_arc(),
         };
 
         Ok(book)
-    }
-
-    /// Parses an expiration date string (YYYYMMDD format).
-    fn parse_expiration(s: &str) -> Result<ExpirationDate, Error> {
-        use chrono::{NaiveDate, TimeZone, Utc};
-
-        let date = NaiveDate::parse_from_str(s, "%Y%m%d")
-            .map_err(|_| Error::invalid_symbol(s, "expected YYYYMMDD format"))?;
-
-        // Construct a concrete expiration DateTime at midnight UTC on the given date,
-        // to match the representation used elsewhere in the codebase.
-        let naive_dt = date
-            .and_hms_opt(0, 0, 0)
-            .ok_or_else(|| Error::invalid_symbol(s, "invalid expiration date"))?;
-        let datetime_utc = Utc.from_utc_datetime(&naive_dt);
-
-        Ok(ExpirationDate::DateTime(datetime_utc))
     }
 
     /// Replays events from the journal starting at `from_sequence`.
@@ -1491,11 +1486,10 @@ mod tests {
     /// Builds a `SequencedUnderlyingOrderBook` with a real expiration, strike,
     /// and resting orders so that command execution paths are exercisable.
     fn make_book_with_orders() -> (SequencedUnderlyingOrderBook, ExpirationDate, String) {
-        use chrono::{NaiveDate, TimeZone, Utc};
-
-        let date = NaiveDate::from_ymd_opt(2024, 3, 29).expect("valid date");
-        let dt = date.and_hms_opt(0, 0, 0).expect("valid time");
-        let expiry = ExpirationDate::DateTime(Utc.from_utc_datetime(&dt));
+        // Build the chain via the canonical parser so its `ExpirationKey`
+        // matches what `find_book_by_symbol` derives when routing the symbol.
+        let expiry = SymbolParser::parse_yyyymmdd("20240329", "BTC-20240329-50000-C")
+            .expect("canonical expiry");
 
         let underlying = UnderlyingOrderBook::new("BTC");
         let exp_book = underlying.get_or_create_expiration(expiry);
@@ -1521,11 +1515,8 @@ mod tests {
     }
 
     fn make_book_with_user_orders() -> (SequencedUnderlyingOrderBook, ExpirationDate) {
-        use chrono::{NaiveDate, TimeZone, Utc};
-
-        let date = NaiveDate::from_ymd_opt(2024, 3, 29).expect("valid date");
-        let dt = date.and_hms_opt(0, 0, 0).expect("valid time");
-        let expiry = ExpirationDate::DateTime(Utc.from_utc_datetime(&dt));
+        let expiry = SymbolParser::parse_yyyymmdd("20240329", "BTC-20240329-50000-C")
+            .expect("canonical expiry");
 
         let user_a = Hash32::from([1u8; 32]);
 
@@ -1921,12 +1912,9 @@ mod tests {
 
     #[test]
     fn test_mass_cancel_book_by_user() {
-        use chrono::{NaiveDate, TimeZone, Utc};
-
         let user_a = Hash32::from([1u8; 32]);
-        let date = NaiveDate::from_ymd_opt(2024, 3, 29).expect("valid date");
-        let dt = date.and_hms_opt(0, 0, 0).expect("valid time");
-        let expiry = ExpirationDate::DateTime(Utc.from_utc_datetime(&dt));
+        let expiry = SymbolParser::parse_yyyymmdd("20240329", "BTC-20240329-50000-C")
+            .expect("canonical expiry");
 
         let underlying = UnderlyingOrderBook::new("BTC");
         let exp_book = underlying.get_or_create_expiration(expiry);
@@ -1988,7 +1976,7 @@ mod tests {
         assert!(receipt.result.is_error());
     }
 
-    // ── parse_expiration ─────────────────────────────────────────────────
+    // ── symbol expiration parsing (delegated to SymbolParser) ─────────────
 
     #[test]
     fn test_parse_expiration_invalid() {
@@ -1998,6 +1986,73 @@ mod tests {
             .submit_add_order("BTC-NOTADATE-50000-C", OrderId::new(), Side::Buy, 100, 10)
             .expect("submit");
         assert!(receipt.result.is_error());
+    }
+
+    // ── underlying-mismatch routing (cross-book safety) ───────────────────
+
+    #[test]
+    fn test_find_book_by_symbol_cross_underlying_rejected_with_typed_error() {
+        // BTC book already holds 20240329 / 50000 — the same expiry+strike the
+        // ETH symbol names. Before consolidation the underlying was never
+        // checked, so this would have silently routed into the BTC book.
+        let (book, _, _) = make_book_with_orders();
+
+        // `Arc<OptionOrderBook>` is not `Debug`, so match instead of `expect_err`.
+        match book.find_book_by_symbol("ETH-20240329-50000-C") {
+            Err(Error::UnderlyingMismatch { .. }) => {}
+            Err(other) => panic!("expected UnderlyingMismatch, got {other:?}"),
+            Ok(_) => panic!("expected UnderlyingMismatch, got Ok"),
+        }
+    }
+
+    #[test]
+    fn test_submit_add_order_cross_underlying_rejected() {
+        let (book, _, _) = make_book_with_orders();
+
+        let receipt = book
+            .submit_add_order("ETH-20240329-50000-C", OrderId::new(), Side::Buy, 100, 10)
+            .expect("submit");
+        match &receipt.result {
+            OptionChainResult::Rejected { reason } => {
+                assert!(reason.contains("underlying mismatch"), "reason: {reason}");
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    // ── chain created via SymbolParser resolves a sequencer-routed order ──
+
+    #[test]
+    fn test_sequencer_resolves_chain_created_via_symbol_parser_same_yyyymmdd() {
+        let symbol = "BTC-20240329-50000-C";
+
+        // Create the chain straight from the canonical parser output.
+        let parsed = SymbolParser::parse(symbol).expect("parse");
+        let underlying = UnderlyingOrderBook::new("BTC");
+        let exp_book = underlying.get_or_create_expiration(*parsed.expiration());
+        let strike = exp_book.get_or_create_strike(parsed.strike());
+        let created_call = strike.call_arc();
+        drop(strike);
+        drop(exp_book);
+
+        let book = SequencedUnderlyingOrderBook::from_underlying(underlying);
+
+        // The sequencer must route the same YYYYMMDD symbol to that exact book.
+        let receipt = book
+            .submit_add_order(symbol, OrderId::new(), Side::Buy, 100, 10)
+            .expect("submit");
+        assert!(
+            receipt.result.is_success(),
+            "routed order must resolve: {:?}",
+            receipt.result
+        );
+
+        // Identical resolution: same leaf `Arc`, which can only happen if the
+        // derived `ExpirationKey` matched the one used to create the chain.
+        let resolved = book
+            .find_book_by_symbol(symbol)
+            .expect("symbol must resolve");
+        assert!(Arc::ptr_eq(&resolved, &created_call));
     }
 
     // ── put book path ────────────────────────────────────────────────────
@@ -2059,8 +2114,6 @@ mod tests {
 
     #[test]
     fn test_sequenced_book_registry_populated_after_add_order() {
-        use chrono::{NaiveDate, TimeZone, Utc};
-
         let registry = Arc::new(InstrumentRegistry::new());
         let symbol_index = Arc::new(SymbolIndex::new());
 
@@ -2073,10 +2126,10 @@ mod tests {
         assert!(registry.is_empty());
         assert!(symbol_index.is_empty());
 
-        // Create the hierarchy — this registers instruments in the registry
-        let date = NaiveDate::from_ymd_opt(2024, 3, 29).expect("valid date");
-        let dt = date.and_hms_opt(0, 0, 0).expect("valid time");
-        let expiry = ExpirationDate::DateTime(Utc.from_utc_datetime(&dt));
+        // Create the hierarchy via the canonical parser so the chain key matches
+        // what the routed symbol resolves to.
+        let expiry = SymbolParser::parse_yyyymmdd("20240329", "BTC-20240329-50000-C")
+            .expect("canonical expiry");
 
         let exp_book = underlying.get_or_create_expiration(expiry);
         let strike = exp_book.get_or_create_strike(50000);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -35,44 +35,22 @@ pub fn format_expiration_yyyymmdd(expiration: &ExpirationDate) -> Result<String>
     Ok(date.format("%Y%m%d").to_string())
 }
 
-/// Parses a YYYYMMDD string into an `ExpirationDate`.
+/// Parses a `YYYYMMDD` string into a canonical [`ExpirationDate`].
+///
+/// Thin wrapper that delegates to [`SymbolParser::parse_yyyymmdd`], the single
+/// source of truth for the symbol-expiry grammar and its canonical time-of-day.
+/// See that method for the exact instant assigned to the date.
 ///
 /// # Arguments
 ///
-/// * `date_str` - The date string in YYYYMMDD format
+/// * `date_str` - The date string in `YYYYMMDD` format
 /// * `symbol` - The original symbol (for error messages)
-///
-/// # Returns
-///
-/// An `ExpirationDate::DateTime` set to 23:59:59 UTC on the parsed date.
 ///
 /// # Errors
 ///
-/// Returns `Error::InvalidSymbol` if the date format is invalid.
+/// Returns [`Error::InvalidSymbol`] if the date format is invalid.
 pub fn parse_yyyymmdd(date_str: &str, symbol: &str) -> Result<ExpirationDate> {
-    if date_str.len() != 8 {
-        return Err(Error::invalid_symbol(
-            symbol,
-            format!("expiration must be 8 digits (YYYYMMDD), got '{}'", date_str),
-        ));
-    }
-
-    if !date_str.chars().all(|c| c.is_ascii_digit()) {
-        return Err(Error::invalid_symbol(
-            symbol,
-            format!("expiration must be numeric, got '{}'", date_str),
-        ));
-    }
-
-    let naive_date = NaiveDate::parse_from_str(date_str, "%Y%m%d")
-        .map_err(|_| Error::invalid_symbol(symbol, format!("invalid date '{}'", date_str)))?;
-
-    let naive_datetime = naive_date.and_hms_opt(23, 59, 59).ok_or_else(|| {
-        Error::invalid_symbol(symbol, "failed to construct expiration time 23:59:59")
-    })?;
-    let datetime = Utc.from_utc_datetime(&naive_datetime);
-
-    Ok(ExpirationDate::DateTime(datetime))
+    SymbolParser::parse_yyyymmdd(date_str, symbol)
 }
 
 /// Returns the current wall-clock time as nanoseconds since Unix epoch.
@@ -89,24 +67,147 @@ pub(crate) fn nanos_since_epoch() -> u64 {
 ///
 /// Represents a decomposed option symbol like `BTC-20260130-50000-C` with all
 /// its components extracted and validated.
+///
+/// # Invariants
+///
+/// All fields are private and the type can only be constructed through
+/// [`ParsedSymbol::try_new`] (or [`SymbolParser::parse`], which delegates to
+/// it). Construction guarantees:
+///
+/// * `underlying` is non-empty,
+/// * `strike` is strictly positive,
+/// * `expiration` is the canonical parse of `expiration_str` (so the two can
+///   never disagree).
+///
+/// Together these guarantee the [`ParsedSymbol::to_symbol`] round-trip: the
+/// reconstructed string always re-parses to an equal `ParsedSymbol`.
+///
+/// # Breaking
+///
+/// The fields are private; construct via [`ParsedSymbol::try_new`] and read
+/// them through the [`ParsedSymbol::underlying`], [`ParsedSymbol::expiration`],
+/// [`ParsedSymbol::expiration_str`], [`ParsedSymbol::strike`], and
+/// [`ParsedSymbol::option_style`] accessors.
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParsedSymbol {
     /// Underlying asset (e.g., "BTC").
-    pub underlying: String,
-    /// Expiration date.
-    pub expiration: ExpirationDate,
+    underlying: String,
+    /// Expiration date (canonical parse of `expiration_str`).
+    expiration: ExpirationDate,
     /// Original expiration string (YYYYMMDD format).
-    pub expiration_str: String,
+    expiration_str: String,
     /// Strike price.
-    pub strike: u64,
+    strike: u64,
     /// Option type (Call or Put).
-    pub option_style: OptionStyle,
+    option_style: OptionStyle,
 }
 
 impl ParsedSymbol {
+    /// Builds a validated `ParsedSymbol` from its components.
+    ///
+    /// The `expiration` field is derived from `expiration_str` via the canonical
+    /// [`SymbolParser::parse_yyyymmdd`], so the two can never diverge and the
+    /// [`ParsedSymbol::to_symbol`] round-trip is guaranteed by construction.
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying` - Underlying asset symbol (must be non-empty)
+    /// * `expiration_str` - Expiration date in `YYYYMMDD` format
+    /// * `strike` - Strike price (must be strictly positive)
+    /// * `option_style` - Call or Put
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSymbol`] if `underlying` is empty, `strike` is
+    /// zero, or `expiration_str` is not a valid `YYYYMMDD` date.
+    pub fn try_new(
+        underlying: impl Into<String>,
+        expiration_str: impl Into<String>,
+        strike: u64,
+        option_style: OptionStyle,
+    ) -> Result<Self> {
+        let underlying = underlying.into();
+        let expiration_str = expiration_str.into();
+        let option_char = match option_style {
+            OptionStyle::Call => "C",
+            OptionStyle::Put => "P",
+        };
+        // Reconstruct the symbol only for error context — the happy path (run
+        // per routed order) must not allocate it.
+        let symbol = || format!("{underlying}-{expiration_str}-{strike}-{option_char}");
+
+        if underlying.is_empty() {
+            return Err(Error::invalid_symbol(
+                symbol(),
+                "underlying cannot be empty",
+            ));
+        }
+        if strike == 0 {
+            return Err(Error::invalid_symbol(
+                symbol(),
+                "strike price must be positive, got 0",
+            ));
+        }
+
+        // `parse_yyyymmdd` only reads its `symbol` argument on the (cold) error
+        // path, so pass an empty placeholder and rebuild the full context with
+        // the original reason if it fails.
+        let expiration =
+            SymbolParser::parse_yyyymmdd(&expiration_str, "").map_err(|e| match e {
+                Error::InvalidSymbol { reason, .. } => Error::invalid_symbol(symbol(), reason),
+                other => other,
+            })?;
+
+        Ok(Self {
+            underlying,
+            expiration,
+            expiration_str,
+            strike,
+            option_style,
+        })
+    }
+
+    /// Returns the underlying asset symbol (e.g., `"BTC"`).
+    #[must_use]
+    #[inline]
+    pub fn underlying(&self) -> &str {
+        &self.underlying
+    }
+
+    /// Returns the canonical expiration date.
+    // Note: `ExpirationDate` is itself `#[must_use]`, so no attribute here
+    // (clippy::double_must_use).
+    #[inline]
+    pub const fn expiration(&self) -> &ExpirationDate {
+        &self.expiration
+    }
+
+    /// Returns the original expiration string in `YYYYMMDD` format.
+    #[must_use]
+    #[inline]
+    pub fn expiration_str(&self) -> &str {
+        &self.expiration_str
+    }
+
+    /// Returns the strike price.
+    #[must_use]
+    #[inline]
+    pub const fn strike(&self) -> u64 {
+        self.strike
+    }
+
+    /// Returns the option style (Call or Put).
+    #[must_use]
+    #[inline]
+    pub const fn option_style(&self) -> OptionStyle {
+        self.option_style
+    }
+
     /// Reconstructs the symbol string from parsed components.
     ///
-    /// This enables round-trip verification: parse → to_symbol → compare.
+    /// This enables round-trip verification: parse → to_symbol → compare. The
+    /// type invariants guarantee the result always re-parses to an equal
+    /// `ParsedSymbol`.
     #[must_use]
     pub fn to_symbol(&self) -> String {
         let option_char = match self.option_style {
@@ -124,6 +225,13 @@ impl ParsedSymbol {
 ///
 /// Parses symbols in the format `{UNDERLYING}-{YYYYMMDD}-{STRIKE}-{C|P}`.
 ///
+/// This is the single source of truth for the `{underlying}-{expiry}-{strike}-
+/// {type}` grammar across the crate: the sequencer's symbol routing and the
+/// NATS subject builder both delegate here so the parsed expiry instant — and
+/// therefore the derived `ExpirationKey` used to key the expiration `SkipMap`s
+/// — is identical everywhere. The option type is accepted case-insensitively
+/// (`C`/`c`, `P`/`p`) and normalized to the canonical uppercase form.
+///
 /// # Examples
 ///
 /// ```rust
@@ -132,14 +240,74 @@ impl ParsedSymbol {
 ///
 /// let parsed = SymbolParser::parse("BTC-20260130-50000-C")
 ///     .expect("valid symbol");
-/// assert_eq!(parsed.underlying, "BTC");
-/// assert_eq!(parsed.strike, 50000);
-/// assert_eq!(parsed.option_style, OptionStyle::Call);
+/// assert_eq!(parsed.underlying(), "BTC");
+/// assert_eq!(parsed.strike(), 50000);
+/// assert_eq!(parsed.option_style(), OptionStyle::Call);
 /// assert_eq!(parsed.to_symbol(), "BTC-20260130-50000-C");
 /// ```
 pub struct SymbolParser;
 
 impl SymbolParser {
+    /// Canonical UTC time-of-day, as `(hour, minute, second)`, assigned to the
+    /// `{YYYYMMDD}` segment of a symbol.
+    ///
+    /// A symbol's date segment names a calendar day, not an instant. The
+    /// contract is considered alive through the whole UTC trading day, so the
+    /// canonical expiry instant is the **end** of that day, `23:59:59 UTC`.
+    ///
+    /// This single choice is load-bearing: the expiration managers key their
+    /// `SkipMap`s on an `ExpirationKey` derived from the absolute
+    /// `DateTime<Utc>`, so two parsers disagreeing on the time-of-day would
+    /// produce different keys and silently split one chain across two map slots
+    /// (an order routed via one parser could not resolve a chain created via
+    /// the other). Keep every parser routed through this constant.
+    const CANONICAL_EXPIRY_HMS: (u32, u32, u32) = (23, 59, 59);
+
+    /// Parses a `YYYYMMDD` string into a canonical [`ExpirationDate`].
+    ///
+    /// The returned value is `ExpirationDate::DateTime` set to the canonical
+    /// expiry time-of-day (`23:59:59 UTC`, see `CANONICAL_EXPIRY_HMS`) on the
+    /// parsed date. This is the single source of truth for the symbol-expiry
+    /// time-of-day across the crate.
+    ///
+    /// # Arguments
+    ///
+    /// * `date_str` - The date string in `YYYYMMDD` format
+    /// * `symbol` - The original symbol (for error messages)
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InvalidSymbol`] if `date_str` is not 8 digits, is
+    /// non-numeric, or is not a valid calendar date.
+    pub fn parse_yyyymmdd(date_str: &str, symbol: &str) -> Result<ExpirationDate> {
+        if date_str.len() != 8 {
+            return Err(Error::invalid_symbol(
+                symbol,
+                format!("expiration must be 8 digits (YYYYMMDD), got '{}'", date_str),
+            ));
+        }
+
+        if !date_str.chars().all(|c| c.is_ascii_digit()) {
+            return Err(Error::invalid_symbol(
+                symbol,
+                format!("expiration must be numeric, got '{}'", date_str),
+            ));
+        }
+
+        let naive_date = NaiveDate::parse_from_str(date_str, "%Y%m%d")
+            .map_err(|_| Error::invalid_symbol(symbol, format!("invalid date '{}'", date_str)))?;
+
+        let (hour, minute, second) = Self::CANONICAL_EXPIRY_HMS;
+        let naive_datetime = naive_date
+            .and_hms_opt(hour, minute, second)
+            .ok_or_else(|| {
+                Error::invalid_symbol(symbol, "failed to construct canonical expiration time")
+            })?;
+        let datetime = Utc.from_utc_datetime(&naive_datetime);
+
+        Ok(ExpirationDate::DateTime(datetime))
+    }
+
     /// Parses a symbol string into its components.
     ///
     /// # Arguments
@@ -157,7 +325,7 @@ impl SymbolParser {
     /// - The underlying is empty
     /// - The expiration is not a valid YYYYMMDD date
     /// - The strike is not a valid positive integer
-    /// - The option type is not `C` or `P`
+    /// - The option type is not `C`/`c` or `P`/`p`
     pub fn parse(symbol: &str) -> Result<ParsedSymbol> {
         let parts: Vec<&str> = symbol.split('-').collect();
 
@@ -172,12 +340,7 @@ impl SymbolParser {
         }
 
         let underlying = parts[0];
-        if underlying.is_empty() {
-            return Err(Error::invalid_symbol(symbol, "underlying cannot be empty"));
-        }
-
         let expiration_str = parts[1];
-        let expiration = parse_yyyymmdd(expiration_str, symbol)?;
 
         let strike: u64 = parts[2].parse().map_err(|_| {
             Error::invalid_symbol(
@@ -189,16 +352,9 @@ impl SymbolParser {
             )
         })?;
 
-        if strike == 0 {
-            return Err(Error::invalid_symbol(
-                symbol,
-                "strike price must be positive, got 0",
-            ));
-        }
-
         let option_style = match parts[3] {
-            "C" => OptionStyle::Call,
-            "P" => OptionStyle::Put,
+            "C" | "c" => OptionStyle::Call,
+            "P" | "p" => OptionStyle::Put,
             other => {
                 return Err(Error::invalid_symbol(
                     symbol,
@@ -207,13 +363,9 @@ impl SymbolParser {
             }
         };
 
-        Ok(ParsedSymbol {
-            underlying: underlying.to_string(),
-            expiration,
-            expiration_str: expiration_str.to_string(),
-            strike,
-            option_style,
-        })
+        // `try_new` enforces the type invariants (non-empty underlying, positive
+        // strike, canonical expiration derived from `expiration_str`).
+        ParsedSymbol::try_new(underlying, expiration_str, strike, option_style)
     }
 }
 
@@ -254,32 +406,32 @@ mod tests {
     #[test]
     fn test_parse_valid_call_symbol() {
         let parsed = SymbolParser::parse("BTC-20260130-50000-C").expect("should parse");
-        assert_eq!(parsed.underlying, "BTC");
-        assert_eq!(parsed.expiration_str, "20260130");
-        assert_eq!(parsed.strike, 50000);
-        assert_eq!(parsed.option_style, OptionStyle::Call);
+        assert_eq!(parsed.underlying(), "BTC");
+        assert_eq!(parsed.expiration_str(), "20260130");
+        assert_eq!(parsed.strike(), 50000);
+        assert_eq!(parsed.option_style(), OptionStyle::Call);
     }
 
     #[test]
     fn test_parse_valid_put_symbol() {
         let parsed = SymbolParser::parse("ETH-20251222-3000-P").expect("should parse");
-        assert_eq!(parsed.underlying, "ETH");
-        assert_eq!(parsed.expiration_str, "20251222");
-        assert_eq!(parsed.strike, 3000);
-        assert_eq!(parsed.option_style, OptionStyle::Put);
+        assert_eq!(parsed.underlying(), "ETH");
+        assert_eq!(parsed.expiration_str(), "20251222");
+        assert_eq!(parsed.strike(), 3000);
+        assert_eq!(parsed.option_style(), OptionStyle::Put);
     }
 
     #[test]
     fn test_parse_single_char_underlying() {
         let parsed = SymbolParser::parse("E-20260101-100-C").expect("should parse");
-        assert_eq!(parsed.underlying, "E");
-        assert_eq!(parsed.strike, 100);
+        assert_eq!(parsed.underlying(), "E");
+        assert_eq!(parsed.strike(), 100);
     }
 
     #[test]
     fn test_parse_large_strike() {
         let parsed = SymbolParser::parse("BTC-20260130-1000000-P").expect("should parse");
-        assert_eq!(parsed.strike, 1_000_000);
+        assert_eq!(parsed.strike(), 1_000_000);
     }
 
     #[test]
@@ -364,7 +516,7 @@ mod tests {
     #[test]
     fn test_parsed_symbol_expiration_date_correctness() {
         let parsed = SymbolParser::parse("BTC-20260130-50000-C").expect("should parse");
-        let date = parsed.expiration.get_date().expect("should get date");
+        let date = parsed.expiration().get_date().expect("should get date");
         assert_eq!(date.year(), 2026);
         assert_eq!(date.month(), 1);
         assert_eq!(date.day(), 30);
@@ -399,5 +551,69 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(err.to_string().contains("strike price must be positive"));
+    }
+
+    #[test]
+    fn test_parse_canonical_expiry_time_of_day_end_of_day() {
+        use chrono::Timelike;
+        let parsed = SymbolParser::parse("BTC-20260130-50000-C").expect("should parse");
+        let dt = match parsed.expiration() {
+            ExpirationDate::DateTime(dt) => *dt,
+            other => panic!("expected DateTime, got {:?}", other),
+        };
+        assert_eq!((dt.hour(), dt.minute(), dt.second()), (23, 59, 59));
+    }
+
+    #[test]
+    fn test_parse_lowercase_option_type_normalizes_to_uppercase() {
+        let call = SymbolParser::parse("BTC-20260130-50000-c").expect("should parse");
+        assert_eq!(call.option_style(), OptionStyle::Call);
+        assert_eq!(call.to_symbol(), "BTC-20260130-50000-C");
+
+        let put = SymbolParser::parse("BTC-20260130-50000-p").expect("should parse");
+        assert_eq!(put.option_style(), OptionStyle::Put);
+        assert_eq!(put.to_symbol(), "BTC-20260130-50000-P");
+    }
+
+    #[test]
+    fn test_parsed_symbol_try_new_round_trip_reparses_equal() {
+        let built = ParsedSymbol::try_new("BTC", "20260130", 50000, OptionStyle::Call)
+            .expect("valid components");
+        let reparsed = SymbolParser::parse(&built.to_symbol()).expect("to_symbol must re-parse");
+        assert_eq!(built, reparsed);
+    }
+
+    #[test]
+    fn test_parsed_symbol_try_new_rejects_zero_strike() {
+        let result = ParsedSymbol::try_new("BTC", "20260130", 0, OptionStyle::Call);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("strike price must be positive"));
+    }
+
+    #[test]
+    fn test_parsed_symbol_try_new_rejects_empty_underlying() {
+        let result = ParsedSymbol::try_new("", "20260130", 50000, OptionStyle::Call);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("underlying cannot be empty"));
+    }
+
+    #[test]
+    fn test_parsed_symbol_try_new_rejects_invalid_expiration() {
+        let result = ParsedSymbol::try_new("BTC", "2026013", 50000, OptionStyle::Call);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("8 digits"));
+    }
+
+    #[test]
+    fn test_parsed_symbol_try_new_expiration_matches_expiration_str() {
+        let built = ParsedSymbol::try_new("ETH", "20251222", 3000, OptionStyle::Put)
+            .expect("valid components");
+        // The derived expiration must be the canonical parse of the string, so
+        // formatting it back yields the same string (no possible divergence).
+        let formatted = format_expiration_yyyymmdd(built.expiration()).expect("format");
+        assert_eq!(formatted, built.expiration_str());
     }
 }


### PR DESCRIPTION
## Summary

The `{underlying}-{expiry}-{strike}-{type}` symbol grammar was parsed in three places with divergent rules. `utils` built the expiry `DateTime` at 23:59:59 UTC while the sequencer used 00:00:00 UTC — and since #50 keys expiration `SkipMap`s on the absolute instant, the same `YYYYMMDD` produced different `ExpirationKey`s, so an order routed through the sequencer could not resolve a chain created via `SymbolParser`. The sequencer also never validated the parsed underlying, so an ETH command could route into a BTC book. This consolidates parsing to one source of truth.

## Changes

- `SymbolParser` is the single parser, with one canonical expiry time-of-day (`CANONICAL_EXPIRY_HMS = 23:59:59 UTC`). `utils::parse_yyyymmdd`, the sequencer, and the NATS subject builder all delegate to it; `sequencer::parse_expiration` is deleted.
- Sequencer `find_book_by_symbol` validates the parsed underlying against the book's and rejects a mismatch with a new typed `Error::UnderlyingMismatch`, surfaced as `OptionChainResult::Rejected { reason }` (never `BookNotFound`, never silent cross-routing).
- `ParsedSymbol` is encapsulated: private fields + validating `try_new` (derives `expiration` from `expiration_str`, rejects empty underlying / zero strike / bad date) + `#[must_use]` accessors. The happy path no longer allocates the reconstructed symbol (`format!` deferred to the cold error branch).

## Technical decisions

- 23:59:59 UTC (end of UTC trading day) chosen as the canonical instant; documented on `CANONICAL_EXPIRY_HMS`.
- Cross-underlying is a routing/validation rejection (`Rejected`), semantically distinct from a missing book (`BookNotFound`) — applied consistently across add/cancel/mass-cancel.

## Public API impact

`ParsedSymbol`'s fields are now private (construct via `try_new`, read via accessors) — a breaking change, so the crate is bumped **0.4.4 → 0.5.0**. New `Error::UnderlyingMismatch` variant. `ParsedSymbol` is re-exported from `lib.rs`; no in-repo consumer used the old fields. `lib.rs` module docs unchanged, `README.md` (via `make readme`) unchanged.

## Testing

- [x] Cross-feature test: a chain created via `SymbolParser` resolves a sequencer-routed order for the same `YYYYMMDD` (identical `ExpirationKey`, `Arc::ptr_eq`)
- [x] Cross-underlying sequencer command rejected with the typed error (add + cancel)
- [x] `ParsedSymbol::try_new` round-trip + rejects zero strike / empty underlying / bad date / `expiration↔expiration_str` consistency
- [x] NATS `from_symbol` parity with `SymbolParser`
- [x] Determinism re-audited (replay-safe; closes the prior key-divergence replay hazard)
- [x] `cargo clippy --all-targets --all-features --workspace -- -D warnings`, `cargo fmt --all --check`, `cargo test --all-features` (718+5+88, 0 fail), `make pre-push` — all clean

## Checklist

- [x] `rules/global_rules.md` + `CLAUDE.md`; no unwrap/expect/unchecked indexing; no `unsafe`; no new deps
- [x] `tracing` only; layering preserved (`utils` stays a leaf; sequencer/nats consume it downward)
- [x] Replay determinism preserved/improved; typed errors via `thiserror`

Closes #51
