### PR TITLE
fix(managers): atomic, idempotent get_or_create via get_or_insert (#49)

### DIFF
--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -918,12 +918,27 @@ impl OptionChainOrderBookManager {
     ///
     /// If a validation config has been set via [`set_validation`](Self::set_validation),
     /// newly created chains will have that config propagated to their strike manager.
+    ///
+    /// # Concurrency
+    ///
+    /// This is atomic and idempotent. The fresh chain is fully configured before
+    /// it is published, and publishing uses [`SkipMap::get_or_insert`], which
+    /// inserts only when the key is absent and never evicts an existing entry.
+    /// The first inserter wins and is never orphaned; concurrent losers receive
+    /// the winning handle and drop their fresh chain. Building and configuring a
+    /// chain has no global side effects (instrument IDs and symbol-index entries
+    /// are only allocated lazily at strike creation), so a dropped loser leaks
+    /// nothing.
     pub fn get_or_create(&self, expiration: ExpirationDate) -> Arc<OptionChainOrderBook> {
         let key = ExpirationKey::from(&expiration);
         if let Some(entry) = self.chains.get(&key) {
             return Arc::clone(entry.value());
         }
-        let chain = if let Some(ref reg) = self.registry {
+        // Build and fully configure the fresh chain BEFORE publishing it, so the
+        // winning chain is configured-before-visible. Configuration only mutates
+        // the fresh object (no global side effects), so a race loser's chain is
+        // dropped harmlessly.
+        let fresh = if let Some(ref reg) = self.registry {
             Arc::new(OptionChainOrderBook::new_with_registry(
                 &self.underlying,
                 expiration,
@@ -933,20 +948,21 @@ impl OptionChainOrderBookManager {
             Arc::new(OptionChainOrderBook::new(&self.underlying, expiration))
         };
         if let Some(ref config) = self.validation_config.get() {
-            chain.set_validation(config.clone());
+            fresh.set_validation(config.clone());
         }
         if let Some(ref specs) = self.contract_specs.get() {
-            chain.set_specs(specs.clone());
+            fresh.set_specs(specs.clone());
         }
         let stp = self.stp_mode.get();
         if stp != STPMode::None {
-            chain.set_stp_mode(stp);
+            fresh.set_stp_mode(stp);
         }
         if let Some(schedule) = self.fee_schedule.get() {
-            chain.set_fee_schedule(schedule);
+            fresh.set_fee_schedule(schedule);
         }
-        self.chains.insert(key, Arc::clone(&chain));
-        chain
+        // Atomic, idempotent publish: first inserter wins and is never evicted.
+        let entry = self.chains.get_or_insert(key, fresh);
+        Arc::clone(entry.value())
     }
 
     /// Gets an option chain by expiration.
@@ -1109,6 +1125,42 @@ mod tests {
         let second = manager.get_or_create(exp);
 
         assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn test_option_chain_manager_get_or_create_concurrent_returns_same_handle() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        // Race N threads to create the SAME chain via a barrier for lockstep.
+        // With `get_or_insert` the first inserter wins and is never evicted, so
+        // every thread must observe one identical handle and the map must hold
+        // exactly one entry (no orphan, no split-brain).
+        const N: usize = 16;
+        let manager = Arc::new(OptionChainOrderBookManager::new("BTC"));
+        let barrier = Arc::new(Barrier::new(N));
+        let exp = test_expiration();
+
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            let manager = Arc::clone(&manager);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                manager.get_or_create(exp)
+            }));
+        }
+
+        let chains: Vec<Arc<OptionChainOrderBook>> = handles
+            .into_iter()
+            .map(|h| h.join().expect("thread panicked"))
+            .collect();
+
+        let first = chains.first().expect("no chains returned");
+        for chain in &chains {
+            assert!(Arc::ptr_eq(first, chain));
+        }
         assert_eq!(manager.len(), 1);
     }
 

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -743,12 +743,27 @@ impl ExpirationOrderBookManager {
     ///
     /// If a validation config has been set via [`set_validation`](Self::set_validation),
     /// newly created expiration books will have that config propagated to their chain.
+    ///
+    /// # Concurrency
+    ///
+    /// This is atomic and idempotent. The fresh expiration book is fully
+    /// configured before it is published, and publishing uses
+    /// [`SkipMap::get_or_insert`], which inserts only when the key is absent and
+    /// never evicts an existing entry. The first inserter wins and is never
+    /// orphaned; concurrent losers receive the winning handle and drop their
+    /// fresh book. Building and configuring the book has no global side effects
+    /// (instrument IDs and symbol-index entries are only allocated lazily at
+    /// strike creation), so a dropped loser leaks nothing.
     pub fn get_or_create(&self, expiration: ExpirationDate) -> Arc<ExpirationOrderBook> {
         let key = ExpirationKey::from(&expiration);
         if let Some(entry) = self.expirations.get(&key) {
             return Arc::clone(entry.value());
         }
-        let book = match (&self.registry, &self.symbol_index) {
+        // Build and fully configure the fresh book BEFORE publishing it, so the
+        // winning book is configured-before-visible. Configuration only mutates
+        // the fresh object (no global side effects), so a race loser's book is
+        // dropped harmlessly.
+        let fresh = match (&self.registry, &self.symbol_index) {
             (Some(reg), Some(idx)) => Arc::new(ExpirationOrderBook::new_with_registry_and_index(
                 &self.underlying,
                 expiration,
@@ -763,20 +778,21 @@ impl ExpirationOrderBookManager {
             _ => Arc::new(ExpirationOrderBook::new(&self.underlying, expiration)),
         };
         if let Some(ref config) = self.validation_config.get() {
-            book.set_validation(config.clone());
+            fresh.set_validation(config.clone());
         }
         if let Some(ref specs) = self.contract_specs.get() {
-            book.chain().set_specs(specs.clone());
+            fresh.chain().set_specs(specs.clone());
         }
         let stp = self.stp_mode.get();
         if stp != STPMode::None {
-            book.set_stp_mode(stp);
+            fresh.set_stp_mode(stp);
         }
         if let Some(schedule) = self.fee_schedule.get() {
-            book.set_fee_schedule(schedule);
+            fresh.set_fee_schedule(schedule);
         }
-        self.expirations.insert(key, Arc::clone(&book));
-        book
+        // Atomic, idempotent publish: first inserter wins and is never evicted.
+        let entry = self.expirations.get_or_insert(key, fresh);
+        Arc::clone(entry.value())
     }
 
     /// Gets an expiration order book.
@@ -1148,6 +1164,42 @@ mod tests {
         let second = manager.get_or_create(exp);
 
         assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn test_expiration_manager_get_or_create_concurrent_returns_same_handle() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        // Race N threads to create the SAME expiration via a barrier for
+        // lockstep. With `get_or_insert` the first inserter wins and is never
+        // evicted, so every thread must observe one identical handle and the
+        // map must hold exactly one entry (no orphan, no split-brain).
+        const N: usize = 16;
+        let manager = Arc::new(ExpirationOrderBookManager::new("BTC"));
+        let barrier = Arc::new(Barrier::new(N));
+        let exp = test_expiration();
+
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            let manager = Arc::clone(&manager);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                manager.get_or_create(exp)
+            }));
+        }
+
+        let books: Vec<Arc<ExpirationOrderBook>> = handles
+            .into_iter()
+            .map(|h| h.join().expect("thread panicked"))
+            .collect();
+
+        let first = books.first().expect("no books returned");
+        for book in &books {
+            assert!(Arc::ptr_eq(first, book));
+        }
         assert_eq!(manager.len(), 1);
     }
 

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -924,29 +924,45 @@ impl StrikeOrderBookManager {
     /// [`OptionOrderBook`] is assigned a unique instrument ID and registered
     /// in the reverse index.
     ///
-    /// Uses a check-insert-check pattern: if two threads race to create the
-    /// same strike, only the first insertion's book survives and only that
-    /// book's IDs are registered in the reverse index.
+    /// # Concurrency
+    ///
+    /// This is atomic and idempotent: the fresh call/put pair is built without
+    /// any global side effects (no instrument-ID allocation, no symbol-index
+    /// registration) and published with [`SkipMap::get_or_insert`], which
+    /// inserts only when the key is absent and never evicts an existing entry.
+    /// The first inserter wins and is never orphaned; concurrent losers receive
+    /// the winning handle and drop their fresh pair. The global side effects
+    /// (ID allocation and symbol-index registration) run exactly once, on the
+    /// winning thread only, gated by [`Arc::ptr_eq`].
+    ///
+    /// Because ID assignment is deferred to the winner *after* the strike is
+    /// published, there is a brief eventual-consistency window in which a
+    /// concurrent reader (or a race loser) may observe the new call/put pair
+    /// with [`instrument_id`](OptionOrderBook::instrument_id) still `0` until
+    /// the winner completes registration. Callers that need the assigned IDs
+    /// immediately after creation under contention should resolve them via the
+    /// [`InstrumentRegistry`] / [`SymbolIndex`] once creation has settled rather
+    /// than reading `instrument_id()` synchronously off the returned handle.
     pub fn get_or_create(&self, strike: u64) -> Arc<StrikeOrderBook> {
         if let Some(entry) = self.strikes.get(&strike) {
             return Arc::clone(entry.value());
         }
 
-        // Build the book without allocating IDs yet.
-        let book = self.create_strike_book_without_ids(strike);
-        self.strikes.insert(strike, Arc::clone(&book));
+        // Build the call/put pair WITHOUT allocating instrument IDs or touching
+        // the registry / symbol index. Those are global side effects that must
+        // run exactly once on the winning thread; a race loser's fresh pair is
+        // dropped, so performing them here would leak IDs and index entries.
+        let fresh = self.create_strike_book_without_ids(strike);
 
-        // Re-check: another thread may have inserted first.
-        if let Some(entry) = self.strikes.get(&strike) {
-            let winner = Arc::clone(entry.value());
-            if Arc::ptr_eq(&winner, &book) {
-                // We won the race — allocate and register IDs now.
-                self.assign_instrument_ids(&winner, strike);
-            }
-            winner
-        } else {
-            book
+        // Atomic, idempotent publish: the first inserter wins and is never
+        // evicted (no orphan window); concurrent losers get the winner.
+        let entry = self.strikes.get_or_insert(strike, Arc::clone(&fresh));
+        let winner = Arc::clone(entry.value());
+        if Arc::ptr_eq(&winner, &fresh) {
+            // We won the race — allocate IDs and register symbols exactly once.
+            self.assign_instrument_ids(&winner, strike);
         }
+        winner
     }
 
     /// Internal helper that builds a [`StrikeOrderBook`] with optional
@@ -1223,6 +1239,77 @@ mod tests {
 
         let strikes = manager.strike_prices();
         assert_eq!(strikes, vec![45000, 50000, 55000]);
+    }
+
+    #[test]
+    fn test_strike_get_or_create_returns_same_handle() {
+        let manager = StrikeOrderBookManager::new("BTC", test_expiration());
+
+        let first = manager.get_or_create(50000);
+        let second = manager.get_or_create(50000);
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn test_strike_get_or_create_concurrent_single_id_pair() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        // Race N threads to create the SAME strike via a barrier for lockstep.
+        // With `get_or_insert` the first inserter wins and is never evicted, and
+        // the global side effects (ID allocation + symbol-index registration)
+        // run exactly once on the winner. Assert: every thread sees one
+        // identical handle, exactly one map entry, and exactly one ID pair (no
+        // orphan, no double-allocation).
+        const N: usize = 16;
+        let registry = Arc::new(InstrumentRegistry::new());
+        let symbol_index = Arc::new(SymbolIndex::new());
+        let manager = Arc::new(StrikeOrderBookManager::new_with_registry_and_index(
+            "BTC",
+            test_expiration(),
+            Arc::clone(&registry),
+            Arc::clone(&symbol_index),
+        ));
+        let barrier = Arc::new(Barrier::new(N));
+
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            let manager = Arc::clone(&manager);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                manager.get_or_create(50000)
+            }));
+        }
+
+        let books: Vec<Arc<StrikeOrderBook>> = handles
+            .into_iter()
+            .map(|h| h.join().expect("thread panicked"))
+            .collect();
+
+        // All threads observe the same winning handle.
+        let first = books.first().expect("no books returned");
+        for book in &books {
+            assert!(Arc::ptr_eq(first, book));
+        }
+
+        // Exactly one map entry.
+        assert_eq!(manager.len(), 1);
+
+        // Exactly one instrument-ID pair allocated (call + put): the registry
+        // advanced by exactly 2 and holds 2 entries; the symbol index holds 2.
+        assert_eq!(registry.len(), 2);
+        assert_eq!(registry.current_id(), 3);
+        assert_eq!(symbol_index.len(), 2);
+
+        // The winning book carries distinct, non-zero IDs.
+        let call_id = first.call().instrument_id();
+        let put_id = first.put().instrument_id();
+        assert_ne!(call_id, 0);
+        assert_ne!(put_id, 0);
+        assert_ne!(call_id, put_id);
     }
 
     #[test]

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -979,25 +979,41 @@ impl UnderlyingOrderBookManager {
     /// The shared [`InstrumentRegistry`] is automatically propagated
     /// so that all [`OptionOrderBook`](super::book::OptionOrderBook)
     /// instances created through the hierarchy receive unique IDs.
+    ///
+    /// # Concurrency
+    ///
+    /// This is atomic and idempotent. The fresh underlying book is fully
+    /// configured before it is published, and publishing uses
+    /// [`SkipMap::get_or_insert`], which inserts only when the key is absent and
+    /// never evicts an existing entry. The first inserter wins and is never
+    /// orphaned; concurrent losers receive the winning handle and drop their
+    /// fresh book. Building and configuring the book has no global side effects
+    /// (instrument IDs and symbol-index entries are only allocated lazily at
+    /// strike creation), so a dropped loser leaks nothing.
     pub fn get_or_create(&self, underlying: impl Into<String>) -> Arc<UnderlyingOrderBook> {
         let underlying = underlying.into();
         if let Some(entry) = self.underlyings.get(&underlying) {
             return Arc::clone(entry.value());
         }
-        let book = Arc::new(UnderlyingOrderBook::new_with_registry_and_index(
+        // Build and fully configure the fresh book BEFORE publishing it, so the
+        // winning book is configured-before-visible. Configuration only mutates
+        // the fresh object (no global side effects), so a race loser's book is
+        // dropped harmlessly.
+        let fresh = Arc::new(UnderlyingOrderBook::new_with_registry_and_index(
             &underlying,
             Arc::clone(&self.registry),
             Arc::clone(&self.symbol_index),
         ));
         let stp = self.stp_mode.get();
         if stp != STPMode::None {
-            book.set_stp_mode(stp);
+            fresh.set_stp_mode(stp);
         }
         if let Some(schedule) = self.fee_schedule.get() {
-            book.set_fee_schedule(schedule);
+            fresh.set_fee_schedule(schedule);
         }
-        self.underlyings.insert(underlying, Arc::clone(&book));
-        book
+        // Atomic, idempotent publish: first inserter wins and is never evicted.
+        let entry = self.underlyings.get_or_insert(underlying, fresh);
+        Arc::clone(entry.value())
     }
 
     /// Sets the STP mode for all future underlying books created by this manager.
@@ -1797,6 +1813,62 @@ mod tests {
         drop(manager.get_or_create("SPX"));
 
         assert_eq!(manager.len(), 3);
+    }
+
+    #[test]
+    fn test_underlying_manager_get_or_create_returns_same_handle() {
+        let manager = UnderlyingOrderBookManager::new();
+
+        let first = manager.get_or_create("BTC");
+        let second = manager.get_or_create("BTC");
+
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(manager.len(), 1);
+    }
+
+    #[test]
+    fn test_underlying_manager_get_or_create_concurrent_returns_same_handle() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        // Race N threads to create the SAME underlying via a barrier for
+        // lockstep. With `get_or_insert` the first inserter wins and is never
+        // evicted, so every thread must observe one identical handle and the
+        // map must hold exactly one entry (no orphan, no split-brain).
+        const N: usize = 16;
+        let manager = Arc::new(UnderlyingOrderBookManager::new());
+        let barrier = Arc::new(Barrier::new(N));
+
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            let manager = Arc::clone(&manager);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                manager.get_or_create("BTC")
+            }));
+        }
+
+        let books: Vec<Arc<UnderlyingOrderBook>> = handles
+            .into_iter()
+            .map(|h| h.join().expect("thread panicked"))
+            .collect();
+
+        let first = books.first().expect("no books returned");
+        for book in &books {
+            assert!(Arc::ptr_eq(first, book));
+        }
+        assert_eq!(manager.len(), 1);
+
+        // End-to-end: creating one strike through the winning handle allocates
+        // exactly one instrument-ID pair in the shared registry/index — proving
+        // the whole sub-hierarchy shares a single registry with no orphan.
+        let exp = first.get_or_create_expiration(test_expiration());
+        let strike = exp.get_or_create_strike(50000);
+        assert_ne!(strike.call().instrument_id(), 0);
+        assert_ne!(strike.put().instrument_id(), 0);
+        assert_ne!(strike.call().instrument_id(), strike.put().instrument_id());
+        assert_eq!(manager.symbol_index().len(), 2);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Every manager's `get_or_create` did an unsynchronized check-then-act and published with `SkipMap::insert`, which **overwrites**. Under concurrent same-key creation both threads built a book, the second insert evicted the first, and each caller got its own `Arc` — one then operated on an orphaned book invisible to every later lookup, stat, mass-cancel, and replay. Split-brain data loss; violates the `get_or_create_*` idempotency rule. This makes all four levels atomic and idempotent.

## Changes

- Keep a cheap lock-free `SkipMap::get()` fast-path (hit path stays allocation-free); on a miss, publish with `SkipMap::get_or_insert` — an atomic CAS where the first inserter wins and is never evicted, and concurrent losers receive the winner and drop their `fresh` book.
- **Strike leaf:** `fresh` is built side-effect-free (no instrument-ID allocation, no symbol-index registration). The global side effects run exactly once on the winning thread, gated by `Arc::ptr_eq(winner, fresh)`, so a race loser leaks no IDs or index entries.
- **Chain / expiration / underlying:** configured-before-visible (all config applied to `fresh` before the SeqCst publish), so no gate is needed.
- Fixed the stale `strike.rs` doc claiming the old check-insert-check survived the first insertion; added accurate `# Concurrency` docs at all four levels, including the transient `instrument_id()==0` eventual-consistency note.

## Technical decisions

- ID allocation stays deferred to the winner rather than pre-assigned to `fresh`: pre-assigning would burn a registry ID pair and leak two `SymbolIndex` entries on **every** losing thread (observable monotonic-ID gaps), which is strictly worse. The transient `instrument_id()==0` window is pre-existing, reaches no event/journal/NATS/aggregate (no production code reads `instrument_id()`), and is now documented as a contract.

## Testing

- [x] Single-threaded: two `get_or_create(K)` return `Arc::ptr_eq` handles and the count does not grow — strike, chain, expiration, underlying
- [x] 16-thread `Barrier` concurrency tests at all four levels: all returned `Arc`s mutually `ptr_eq`, exactly one map entry, exactly one instrument-ID pair (`registry.len()==2`, one shared registry/index), no orphan
- [x] Regression direction confirmed: the old overwrite-`insert` fails the strike concurrency test (split-brain handles); the fix passes 8× consecutively
- [x] Hot-path reviewed (hit path allocation-free/lock-free), determinism re-audited (replay-safe; `id==0` window reaches no deterministic output), architect-validated (CAS atomicity + win-gate sound)
- [x] `clippy --all-targets --all-features --workspace -D warnings`, `fmt --check`, `cargo test --all-features` (724+5+88, 0 fail), `make pre-push`, strict rustdoc — all clean

## Checklist

- [x] `rules/global_rules.md` + `CLAUDE.md`; lock-free, synchronous order path; no unwrap/expect; no `unsafe`; no new deps
- [x] Layering preserved; idempotency rule honored; deterministic aggregation/mass-cancel order unchanged
- [x] No public-surface change (`README.md` regenerated identical)

Closes #49
