### PR TITLE
ci: make the format and test gates actually enforce (#63)

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -33,4 +33,4 @@ jobs:
           components: rustfmt
 
       - name: Format check
-        run: make fmt
+        run: make fmt-check

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ build:
 release:
 	cargo build --release
 
-# Run tests
+# Run tests (all features, so nats- and sequencer-gated code is covered)
 .PHONY: test
 test:
-	LOGLEVEL=WARN cargo test
+	LOGLEVEL=WARN cargo test --all-features
 
 # Format the code
 .PHONY: fmt


### PR DESCRIPTION
## Summary

Two CI gates were inert. `format_check.yml` ran `make fmt`, which **reformats in place and always exits 0** — the format gate passed regardless of the submitted code. And `make test` (used by the `run_tests` CI job and by `make pre-push`) ran `cargo test` with **no feature flags**, so all `nats`- and `sequencer`-gated code was excluded from every run and a regression there could land on `main` undetected.

## Changes

- `format_check.yml`: `make fmt` → `make fmt-check` (`cargo fmt --check`, fails on unformatted code).
- `Makefile` `test`: add `--all-features` so the `nats`/`sequencer` paths are exercised — this fixes the CI `run_tests` job and also makes `make pre-push` cover the feature-gated code.

## Testing

- [x] `make fmt-check` exits 0 on the formatted tree (and now fails on unformatted input)
- [x] `make test` now runs `--all-features`: 728 lib + 5 integration + 88 doctests, 0 failures — sequencer/nats tests included
- [x] `make pre-push` clean

## Checklist

- [x] No weakening of any check; gates now strictly stronger
- [x] No source/behavior change; CI-config + Makefile only

Closes #63
