### PR TITLE
fix(book): route clear()/expire() through cancel_all_orders (#54)

### DIFF
--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -566,18 +566,21 @@ impl OptionOrderBook {
 
     /// Expires the instrument, cancelling all resting orders.
     ///
-    /// Sets status to [`Expired`](InstrumentStatus::Expired), collects all
-    /// resting order IDs, and clears the book.
+    /// Sets status to [`Expired`](InstrumentStatus::Expired) and cancels every
+    /// resting order in a single pass via the underlying engine's
+    /// [`cancel_all_orders`](orderbook_rs::OrderBook::cancel_all_orders). Each
+    /// dropped order transitions to a terminal `Cancelled` state, the
+    /// price-level-changed listener fires (book-change events), the order
+    /// tracker counters advance, and the per-account pre-trade risk state is
+    /// reset. The status is set first so the book stops accepting new orders
+    /// before the sweep runs.
     ///
     /// # Returns
     ///
-    /// A vector of order IDs that were cancelled.
+    /// A vector of order IDs that were cancelled, in engine processing order.
     pub fn expire(&self) -> Vec<OrderId> {
         self.set_status(InstrumentStatus::Expired);
-        let orders = self.book.get_all_orders();
-        let ids: Vec<OrderId> = orders.iter().map(|o| o.id()).collect();
-        self.clear();
-        ids
+        self.book.cancel_all_orders().cancelled_order_ids().to_vec()
     }
 
     /// Checks that the instrument is accepting orders, returning an error if not.
@@ -1337,14 +1340,19 @@ impl OptionOrderBook {
     }
 
     /// Clears all orders from the book.
+    ///
+    /// Routes through the underlying engine's
+    /// [`cancel_all_orders`](orderbook_rs::OrderBook::cancel_all_orders) so
+    /// every dropped order transitions to a terminal `Cancelled` state, the
+    /// price-level-changed listener fires (book-change events), the order
+    /// tracker counters advance, and the per-account pre-trade risk state is
+    /// reset. A bare `restore_from_snapshot(empty)` would drop the orders
+    /// silently — leaving `active_order_count`, `get_order_status`, the
+    /// cancelled counter, downstream book-change publishers, and per-account
+    /// risk counters stale — so that path is reserved for genuine snapshot
+    /// restore only.
     pub fn clear(&self) {
-        let empty_snapshot = OrderBookSnapshot {
-            symbol: self.symbol.clone(),
-            timestamp: orderbook_rs::current_time_millis(),
-            bids: vec![],
-            asks: vec![],
-        };
-        let _ = self.book.restore_from_snapshot(empty_snapshot);
+        let _ = self.book.cancel_all_orders();
     }
 
     /// Returns the order book imbalance for top N levels.
@@ -1818,6 +1826,34 @@ mod tests {
     }
 
     #[test]
+    fn test_clear_transitions_orders_to_cancelled_terminal() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let id1 = OrderId::new();
+        let id2 = OrderId::new();
+        book.add_limit_order(id1, Side::Buy, 100, 10)
+            .expect("add bid");
+        book.add_limit_order(id2, Side::Sell, 105, 5)
+            .expect("add ask");
+        assert_eq!(book.active_order_count(), 2);
+
+        book.clear();
+
+        // Dropped orders must reach the terminal state, the active count must
+        // collapse to zero, and the cancelled counter must advance by the
+        // number of orders cleared.
+        assert_eq!(book.active_order_count(), 0);
+        assert!(matches!(
+            book.get_order_status(id1),
+            Some(OrderStatus::Cancelled { .. })
+        ));
+        assert!(matches!(
+            book.get_order_status(id2),
+            Some(OrderStatus::Cancelled { .. })
+        ));
+        assert_eq!(book.terminal_order_summary().cancelled, 2);
+    }
+
+    #[test]
     fn test_update_last_quote() {
         let mut book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
 
@@ -2108,6 +2144,43 @@ mod tests {
         let cancelled = book.expire();
         assert_eq!(book.status(), InstrumentStatus::Expired);
         assert!(cancelled.is_empty());
+    }
+
+    #[test]
+    fn test_expire_transitions_orders_to_cancelled_and_rejects_new_adds() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let id1 = OrderId::new();
+        let id2 = OrderId::new();
+        book.add_limit_order(id1, Side::Buy, 100, 10)
+            .expect("add bid");
+        book.add_limit_order(id2, Side::Sell, 105, 5)
+            .expect("add ask");
+        assert_eq!(book.active_order_count(), 2);
+
+        let cancelled = book.expire();
+
+        // All resting orders cancelled and transitioned to a terminal state.
+        assert_eq!(cancelled.len(), 2);
+        assert_eq!(book.active_order_count(), 0);
+        assert!(matches!(
+            book.get_order_status(id1),
+            Some(OrderStatus::Cancelled { .. })
+        ));
+        assert!(matches!(
+            book.get_order_status(id2),
+            Some(OrderStatus::Cancelled { .. })
+        ));
+        assert_eq!(book.terminal_order_summary().cancelled, 2);
+
+        // Instrument is now Expired and must reject new flow.
+        assert_eq!(book.status(), InstrumentStatus::Expired);
+        let rejected = book.add_limit_order(OrderId::new(), Side::Buy, 100, 1);
+        let err = match rejected {
+            Ok(()) => panic!("expected InstrumentNotActive error"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("instrument not active"));
+        assert!(err.to_string().contains("Expired"));
     }
 
     #[test]

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -1512,6 +1512,42 @@ mod tests {
     }
 
     #[test]
+    fn test_strike_clear_transitions_both_legs_to_terminal() {
+        let strike = StrikeOrderBook::new("BTC", test_expiration(), 50000);
+
+        let call_id = OrderId::new();
+        let put_id = OrderId::new();
+        strike
+            .call()
+            .add_limit_order(call_id, Side::Buy, 100, 10)
+            .expect("add call");
+        strike
+            .put()
+            .add_limit_order(put_id, Side::Buy, 50, 5)
+            .expect("add put");
+        assert_eq!(strike.call().active_order_count(), 1);
+        assert_eq!(strike.put().active_order_count(), 1);
+
+        strike.clear();
+
+        // Both legs must reach zero active orders and transition their dropped
+        // orders to the terminal cancelled state through the shared Arc handles.
+        assert_eq!(strike.call().active_order_count(), 0);
+        assert_eq!(strike.put().active_order_count(), 0);
+        assert!(strike.is_empty());
+        assert!(matches!(
+            strike.call().get_order_status(call_id),
+            Some(OrderStatus::Cancelled { .. })
+        ));
+        assert!(matches!(
+            strike.put().get_order_status(put_id),
+            Some(OrderStatus::Cancelled { .. })
+        ));
+        assert_eq!(strike.call().terminal_order_summary().cancelled, 1);
+        assert_eq!(strike.put().terminal_order_summary().cancelled, 1);
+    }
+
+    #[test]
     fn test_strike_greeks() {
         use optionstratlib::greeks::Greek;
         use rust_decimal_macros::dec;


### PR DESCRIPTION
## Summary

`clear()` emptied the book via `restore_from_snapshot(empty)` and `expire()` delegated to `clear()`. `restore_from_snapshot` drops orders from the maps directly — it does **not** transition them to a terminal state, fire the price-level-changed listener, or reset `risk_state`. So after `clear()`/`expire()`: `active_order_count` kept counting cleared orders, `get_order_status` still returned `Open`, the cancelled counter never advanced, NATS book-change publishers never saw the removals, and inflated per-account risk counters could permanently reject new flow. This propagated into `StrikeOrderBook::clear` over the shared `Arc`.

## Changes

- `clear()` → a single `self.book.cancel_all_orders()` pass (upstream transitions every order to `Cancelled`/`MassCancelAll`, fires the level-changed listener, updates the order tracker, and clears `risk_state`).
- `expire()` → sets `InstrumentStatus::Expired` first (so no new flow slips in), then one `cancel_all_orders()` pass, returning its `cancelled_order_ids` (`Vec<OrderId>`, return type unchanged). No double-cancel.
- The symbol-preserving `restore_from_snapshot` path remains only for genuine restore.

## Behavior change

`expire()`/`clear()` now correctly report `active_order_count()==0`, terminal `Cancelled` statuses, an advanced cancelled counter, reset per-account risk, **and emit book-change/cancel listener events** (a wired `NatsBookChangePublisher` / order-state listener now sees the removals on expiry where before it saw nothing). The per-order reason is `CancelReason::MassCancelAll` (there is no expiry-specific reason in the orderbook-rs 0.9 API — reimplementing one would mean hand-rolling the cancel path, which is delegated); `InstrumentStatus::Expired` is the contract-level expiry signal.

## Testing

- [x] `test_clear_transitions_orders_to_cancelled_terminal` — after `clear()`: count 0, statuses `Cancelled`, cancelled counter == 2
- [x] `test_expire_transitions_orders_to_cancelled_and_rejects_new_adds` — same + status `Expired` + new add rejected (`InstrumentNotActive`)
- [x] `test_strike_clear_transitions_both_legs_to_terminal` — both legs to 0 / terminal through the shared `Arc`
- [x] Existing clear/expire tests still pass; `cargo test --all-features` 731+5+88, 0 fail; `make pre-push` clean

## Checklist

- [x] `rules/global_rules.md`; matching/cancel delegated to `orderbook-rs` (not reimplemented); no unwrap/expect/unsafe; no new deps
- [x] No public signature / re-export change (`README.md` regenerated identical)

Closes #54
