### PR TITLE
fix(nats): wire publishers pre-Arc and remove the leaf->nats inversion (#58)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "option-chain-orderbook"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance Rust library for options market making infrastructure, providing a complete Option Chain Order Book system built on top of OrderBook-rs, PriceLevel, and OptionStratLib."

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -8,9 +8,11 @@ use super::quote::Quote;
 use super::validation::ValidationConfig;
 use crate::Result;
 use optionstratlib::OptionStyle;
+#[cfg(feature = "nats")]
+use orderbook_rs::PriceLevelChangedListener;
 use orderbook_rs::{
     DefaultOrderBook, FeeSchedule, MassCancelResult, OrderBookSnapshot, OrderId, OrderStateTracker,
-    OrderStatus, STPMode, Side, TimeInForce, TradeResult,
+    OrderStatus, STPMode, Side, TimeInForce, TradeListener, TradeResult,
 };
 use pricelevel::{Hash32, MatchResult, Quantity};
 use std::collections::hash_map::DefaultHasher;
@@ -19,12 +21,36 @@ use std::sync::atomic::{AtomicU8, AtomicU32, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+/// Pre-built NATS publisher listeners to install on the inner order book
+/// *before* it is wrapped in `Arc`.
+///
+/// `orderbook_rs` only allows a single trade listener and a single book-change
+/// listener, and both must be registered while the `OrderBook<T>` is still
+/// owned mutably (pre-`Arc`). This struct ferries the already-constructed
+/// listeners — typed purely as `orderbook_rs`-native callbacks — into
+/// [`OptionOrderBook::new_with_config`] so the leaf never imports the eventing
+/// `nats` module. The dependency direction is therefore `nats` → `book`, never
+/// the reverse.
+///
+/// Constructed by the `nats` module's `build_option_order_book_with_nats`
+/// free function (kept as a plain reference, not an intra-doc link, so the leaf
+/// carries no path into the eventing layer).
+#[cfg(feature = "nats")]
+#[derive(Clone)]
+pub(crate) struct PreparedNatsListeners {
+    /// Trade publisher listener, multiplexed with the internal trade-capture
+    /// listener into a single [`TradeListener`].
+    pub trade_listener: TradeListener,
+    /// Book-change publisher listener installed via `set_price_level_listener`.
+    pub book_listener: PriceLevelChangedListener,
+}
+
 /// Internal configuration for constructing an [`OptionOrderBook`].
 ///
 /// Consolidates all optional configuration (instrument ID, validation,
 /// STP mode, fee schedule) into a single struct, avoiding constructor
 /// explosion as new features are added.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub(crate) struct BookConfig {
     /// Numeric instrument ID (0 for standalone books).
     pub instrument_id: u32,
@@ -40,6 +66,26 @@ pub(crate) struct BookConfig {
     /// due to status recording. For extreme low-latency scenarios where every
     /// microsecond matters, set this to `false` to disable tracking entirely.
     pub enable_state_tracking: bool,
+    /// Pre-built NATS publisher listeners installed before the inner book is
+    /// wrapped in `Arc` (feature `nats`). `None` for every non-NATS path.
+    #[cfg(feature = "nats")]
+    pub nats_listeners: Option<PreparedNatsListeners>,
+}
+
+impl std::fmt::Debug for BookConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct("BookConfig");
+        dbg.field("instrument_id", &self.instrument_id)
+            .field("validation", &self.validation)
+            .field("stp_mode", &self.stp_mode)
+            .field("fee_schedule", &self.fee_schedule)
+            .field("enable_state_tracking", &self.enable_state_tracking);
+        // The NATS listeners are boxed closures and carry no `Debug`; surface
+        // only whether they are present so the impl stays informative.
+        #[cfg(feature = "nats")]
+        dbg.field("nats_listeners", &self.nats_listeners.is_some());
+        dbg.finish()
+    }
 }
 
 impl Default for BookConfig {
@@ -50,6 +96,8 @@ impl Default for BookConfig {
             stp_mode: STPMode::None,
             fee_schedule: None,
             enable_state_tracking: true,
+            #[cfg(feature = "nats")]
+            nats_listeners: None,
         }
     }
 }
@@ -226,12 +274,33 @@ impl OptionOrderBook {
         // Install trade-capture listener so `_full` methods can return TradeResult
         let capture: Arc<Mutex<Option<TradeResult>>> = Arc::new(Mutex::new(None));
         let capture_clone = Arc::clone(&capture);
-        book.set_trade_listener(Arc::new(move |tr: &TradeResult| {
+        let capture_listener: TradeListener = Arc::new(move |tr: &TradeResult| {
             let mut guard = capture_clone
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
             *guard = Some(tr.clone());
-        }));
+        });
+
+        // When NATS publishers were prepared (feature `nats`), multiplex the
+        // trade-capture listener with the NATS trade publisher into the single
+        // `TradeListener` that `orderbook_rs` supports, and install the
+        // book-change publisher listener. This is done here — before the book
+        // is wrapped in `Arc` — because that is the only window in which the
+        // inner `OrderBook<T>` can have listeners registered.
+        #[cfg(feature = "nats")]
+        match config.nats_listeners {
+            Some(prepared) => {
+                let nats_trade = prepared.trade_listener;
+                book.set_trade_listener(Arc::new(move |tr: &TradeResult| {
+                    capture_listener(tr);
+                    nats_trade(tr);
+                }));
+                book.set_price_level_listener(prepared.book_listener);
+            }
+            None => book.set_trade_listener(capture_listener),
+        }
+        #[cfg(not(feature = "nats"))]
+        book.set_trade_listener(capture_listener);
 
         // Install order state tracker for lifecycle tracking (enabled by default)
         let terminal_counters = if config.enable_state_tracking {
@@ -1424,88 +1493,6 @@ impl OptionOrderBook {
     pub fn market_impact(&self, quantity: u64, side: Side) -> orderbook_rs::MarketImpact {
         self.book.market_impact(quantity, side)
     }
-
-    // ── NATS Integration ─────────────────────────────────────────────────
-
-    /// Connects NATS trade and book change publishers to this order book.
-    ///
-    /// This method creates NATS publishers for trade events and price level
-    /// changes, using hierarchical subjects based on the option symbol.
-    ///
-    /// # Subject Format
-    ///
-    /// - Trades: `{prefix}.trades.{underlying}.{expiry}.{strike}.{type}`
-    /// - Book changes: `{prefix}.book.{underlying}.{expiry}.{strike}.{type}`
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - NATS configuration with JetStream context and subject prefix
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if the symbol cannot be parsed into its components.
-    ///
-    /// # Feature Gate
-    ///
-    /// This method is only available when the `nats` feature is enabled.
-    #[cfg(feature = "nats")]
-    pub fn connect_nats(
-        &self,
-        config: &super::nats::OptionChainNatsConfig,
-    ) -> crate::Result<NatsPublisherHandles> {
-        use super::nats::OptionChainSubjectBuilder;
-        use orderbook_rs::prelude::{NatsBookChangePublisher, NatsTradePublisher};
-
-        let subject = OptionChainSubjectBuilder::from_symbol(&self.symbol)?;
-        let trade_subject = subject.trade_subject(config.subject_prefix());
-        let book_subject = subject.book_subject(config.subject_prefix());
-
-        // Create trade publisher
-        let trade_publisher = NatsTradePublisher::new(
-            config.jetstream().clone(),
-            trade_subject,
-            config.runtime().clone(),
-        );
-        let (trade_handle, trade_listener) = trade_publisher.into_listener();
-
-        // Create book change publisher
-        let book_change_publisher = NatsBookChangePublisher::new(
-            config.jetstream().clone(),
-            self.symbol.clone(),
-            book_subject,
-            config.runtime().clone(),
-        );
-        let (book_handle, book_listener) = book_change_publisher.into_listener();
-
-        // Note: The underlying DefaultOrderBook is wrapped in Arc, so we cannot
-        // modify listeners after construction. This is a limitation - NATS
-        // integration should ideally be configured at construction time.
-        // For now, we return the handles and listeners for the caller to use.
-
-        Ok(NatsPublisherHandles {
-            trade_handle,
-            trade_listener,
-            book_handle,
-            book_listener,
-        })
-    }
-}
-
-/// Handles and listeners for NATS publishers.
-///
-/// Returned by [`OptionOrderBook::connect_nats`] when the `nats` feature is enabled.
-/// The handles can be used to read metrics (publish counts, error counts), and
-/// the listeners should be attached to the order book during construction.
-#[cfg(feature = "nats")]
-pub struct NatsPublisherHandles {
-    /// Handle to the trade publisher for reading metrics.
-    pub trade_handle: std::sync::Arc<orderbook_rs::prelude::NatsTradePublisher>,
-    /// Trade listener to attach to the order book.
-    pub trade_listener: orderbook_rs::prelude::TradeListener,
-    /// Handle to the book change publisher for reading metrics.
-    pub book_handle: std::sync::Arc<orderbook_rs::prelude::NatsBookChangePublisher>,
-    /// Book change listener to attach to the order book.
-    pub book_listener: orderbook_rs::orderbook::book_change_event::PriceLevelChangedListener,
 }
 
 #[cfg(test)]
@@ -2596,6 +2583,8 @@ mod tests {
                 stp_mode: STPMode::CancelTaker,
                 fee_schedule: Some(schedule),
                 enable_state_tracking: true,
+                #[cfg(feature = "nats")]
+                nats_listeners: None,
             },
         );
         assert_eq!(book.instrument_id(), 42);
@@ -2938,5 +2927,91 @@ mod tests {
         assert!(book.get_order_status(id).is_none());
         assert_eq!(book.active_order_count(), 0);
         assert_eq!(book.terminal_order_count(), 0);
+    }
+
+    /// A matched trade must drive the prepared NATS trade publisher listener
+    /// (carrying the configured subject), while the internal trade-capture
+    /// listener and the book-change publisher listener stay wired too.
+    ///
+    /// This is a fully in-process check: the prepared listeners are capturable
+    /// stand-ins for the real `NatsTradePublisher` / `NatsBookChangePublisher`
+    /// callbacks (which capture their subject the same way), so no live NATS
+    /// server is required.
+    #[cfg(feature = "nats")]
+    #[test]
+    fn test_new_with_config_nats_listener_publishes_to_subject_on_match() {
+        use orderbook_rs::PriceLevelChangedEvent;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let symbol = "BTC-20240329-50000-C";
+
+        // The trade subject the production free function computes for this
+        // symbol with prefix "optionchain" (subject derivation is covered by
+        // `OptionChainSubjectBuilder`'s own tests; kept literal here so the leaf
+        // test stays free of the eventing `nats` module).
+        let expected_subject = "optionchain.trades.BTC.20240329.50000.C".to_string();
+
+        // Capturable stand-in for the NATS trade publisher's listener: it
+        // records the (captured) subject and counts the trades it receives,
+        // exactly as the real publisher's listener closure does.
+        let trade_count = Arc::new(AtomicU64::new(0));
+        let captured_subject = Arc::new(Mutex::new(None::<String>));
+        let trade_count_c = Arc::clone(&trade_count);
+        let captured_subject_c = Arc::clone(&captured_subject);
+        let subject_for_closure = expected_subject.clone();
+        let trade_listener: TradeListener = Arc::new(move |_tr: &TradeResult| {
+            trade_count_c.fetch_add(1, Ordering::Relaxed);
+            *captured_subject_c.lock().unwrap_or_else(|p| p.into_inner()) =
+                Some(subject_for_closure.clone());
+        });
+
+        // Capturable stand-in for the book-change publisher's listener.
+        let book_change_count = Arc::new(AtomicU64::new(0));
+        let book_change_count_c = Arc::clone(&book_change_count);
+        let book_listener: PriceLevelChangedListener =
+            Arc::new(move |_ev: PriceLevelChangedEvent| {
+                book_change_count_c.fetch_add(1, Ordering::Relaxed);
+            });
+
+        let book = OptionOrderBook::new_with_config(
+            symbol,
+            OptionStyle::Call,
+            BookConfig {
+                nats_listeners: Some(PreparedNatsListeners {
+                    trade_listener,
+                    book_listener,
+                }),
+                ..BookConfig::default()
+            },
+        );
+
+        // Rest a sell, then cross it with a marketable buy to force a trade.
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 5)
+            .expect("rest sell");
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 5)
+            .expect("cross buy");
+
+        // The NATS trade listener fired on the match, carrying the subject.
+        assert!(
+            trade_count.load(Ordering::Relaxed) >= 1,
+            "nats trade listener must fire on a matched trade"
+        );
+        let got = captured_subject
+            .lock()
+            .unwrap_or_else(|p| p.into_inner())
+            .clone();
+        assert_eq!(got, Some(expected_subject));
+
+        // The internal trade-capture listener is preserved by the multiplex.
+        assert!(
+            book.last_trade_result().is_some(),
+            "trade-capture listener must remain wired alongside NATS"
+        );
+
+        // The book-change publisher listener was installed and fired.
+        assert!(
+            book_change_count.load(Ordering::Relaxed) >= 1,
+            "book-change listener must fire on price-level changes"
+        );
     }
 }

--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -49,15 +49,6 @@ pub struct OptionChainOrderBook {
     /// Stored for future use in hierarchy traversal.
     #[allow(dead_code)]
     symbol_index: Option<Arc<SymbolIndex>>,
-    /// Stored NATS publisher handles for lifecycle management.
-    /// Each entry is a `(call_handles, put_handles)` pair per strike.
-    #[cfg(feature = "nats")]
-    nats_handles: std::sync::Mutex<
-        Vec<(
-            super::book::NatsPublisherHandles,
-            super::book::NatsPublisherHandles,
-        )>,
-    >,
 }
 
 impl OptionChainOrderBook {
@@ -78,8 +69,6 @@ impl OptionChainOrderBook {
             id: OrderId::new(),
             registry: None,
             symbol_index: None,
-            #[cfg(feature = "nats")]
-            nats_handles: std::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -112,8 +101,6 @@ impl OptionChainOrderBook {
             id: OrderId::new(),
             registry: Some(registry),
             symbol_index: None,
-            #[cfg(feature = "nats")]
-            nats_handles: std::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -146,8 +133,6 @@ impl OptionChainOrderBook {
             id: OrderId::new(),
             registry: Some(registry),
             symbol_index: Some(symbol_index),
-            #[cfg(feature = "nats")]
-            nats_handles: std::sync::Mutex::new(Vec::new()),
         }
     }
 
@@ -583,51 +568,6 @@ impl OptionChainOrderBook {
             strike_count: self.strike_count(),
             total_orders: self.total_order_count(),
         }
-    }
-
-    // ── NATS Integration ─────────────────────────────────────────────────
-
-    /// Connects NATS publishers to all strikes in this chain.
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - NATS configuration with JetStream context and subject prefix
-    ///
-    /// # Returns
-    ///
-    /// The number of option books (call + put) successfully connected.
-    ///
-    /// # Errors
-    ///
-    /// Returns the first error encountered while connecting strikes.
-    #[cfg(feature = "nats")]
-    pub fn connect_nats(
-        &self,
-        config: &super::nats::OptionChainNatsConfig,
-    ) -> crate::Result<usize> {
-        let mut connected = 0usize;
-        let mut new_handles = Vec::new();
-        for entry in self.strikes.iter() {
-            let (call_handles, put_handles) = entry.value().connect_nats(config)?;
-            new_handles.push((call_handles, put_handles));
-            connected = connected.saturating_add(2); // call + put
-        }
-
-        // Store handles for lifecycle management (shutdown, metrics)
-        if let Ok(mut guard) = self.nats_handles.lock() {
-            guard.extend(new_handles);
-        }
-
-        Ok(connected)
-    }
-
-    /// Returns the number of stored NATS publisher handle pairs.
-    ///
-    /// Each pair represents the call and put publishers for one strike.
-    #[cfg(feature = "nats")]
-    #[must_use]
-    pub fn nats_handle_count(&self) -> usize {
-        self.nats_handles.lock().map(|g| g.len()).unwrap_or(0)
     }
 }
 
@@ -1625,13 +1565,6 @@ mod tests {
         let summary = chain.terminal_order_summary();
         assert_eq!(summary.filled, 2);
         assert_eq!(summary.total(), 2);
-    }
-
-    #[cfg(feature = "nats")]
-    #[test]
-    fn test_nats_handle_count_initially_zero() {
-        let chain = OptionChainOrderBook::new("BTC", test_expiration());
-        assert_eq!(chain.nats_handle_count(), 0);
     }
 
     #[test]

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -524,31 +524,6 @@ impl ExpirationOrderBook {
     pub fn atm_strike(&self, spot: u64) -> Result<u64> {
         self.chain.atm_strike(spot)
     }
-
-    // ── NATS Integration ─────────────────────────────────────────────────
-
-    /// Connects NATS publishers to all strikes in this expiration.
-    ///
-    /// Delegates to the underlying [`OptionChainOrderBook`].
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - NATS configuration with JetStream context and subject prefix
-    ///
-    /// # Returns
-    ///
-    /// The number of option books successfully connected.
-    ///
-    /// # Errors
-    ///
-    /// Returns the first error encountered while connecting.
-    #[cfg(feature = "nats")]
-    pub fn connect_nats(
-        &self,
-        config: &super::nats::OptionChainNatsConfig,
-    ) -> crate::Result<usize> {
-        self.chain.connect_nats(config)
-    }
 }
 
 /// Manages expiration order books for a single underlying.

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -116,9 +116,10 @@ pub use underlying::{
 pub use validation::ValidationConfig;
 
 #[cfg(feature = "nats")]
-pub use book::NatsPublisherHandles;
-#[cfg(feature = "nats")]
-pub use nats::{OptionChainNatsConfig, OptionChainSubjectBuilder};
+pub use nats::{
+    NatsPublisherHandles, OptionChainNatsConfig, OptionChainSubjectBuilder,
+    build_option_order_book_with_nats,
+};
 
 #[cfg(feature = "sequencer")]
 pub use sequencer::{

--- a/src/orderbook/nats.rs
+++ b/src/orderbook/nats.rs
@@ -25,7 +25,10 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use option_chain_orderbook::orderbook::nats::OptionChainNatsConfig;
+//! use option_chain_orderbook::orderbook::nats::{
+//!     build_option_order_book_with_nats, OptionChainNatsConfig,
+//! };
+//! use optionstratlib::OptionStyle;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let client = async_nats::connect("nats://localhost:4222").await?;
@@ -33,14 +36,22 @@
 //! let handle = tokio::runtime::Handle::current();
 //!
 //! let config = OptionChainNatsConfig::new(jetstream, "optionchain".to_string(), handle);
-//! // Use underlying.connect_nats(&config) on any hierarchy level to wire up publishers
+//! // Build a contract order book with trade + book-change publishers attached
+//! // *before* the inner book is wrapped in `Arc` (the only valid install point).
+//! let (book, handles) =
+//!     build_option_order_book_with_nats("BTC-20240329-50000-C", OptionStyle::Call, &config)?;
+//! // `handles` exposes publish metrics and an async `shutdown()`.
+//! # let _ = (book, handles);
 //! # Ok(())
 //! # }
 //! ```
 
+use super::book::{BookConfig, OptionOrderBook, PreparedNatsListeners};
 use crate::error::Error;
 use crate::utils::SymbolParser;
 use optionstratlib::OptionStyle;
+use orderbook_rs::prelude::{NatsBookChangePublisher, NatsTradePublisher};
+use std::sync::Arc;
 
 /// Configuration for connecting NATS publishers to the option chain hierarchy.
 ///
@@ -288,6 +299,164 @@ impl OptionChainSubjectBuilder {
     pub fn subjects(&self, prefix: &str) -> (String, String) {
         (self.trade_subject(prefix), self.book_subject(prefix))
     }
+}
+
+/// Handles to the NATS publishers wired into an [`OptionOrderBook`].
+///
+/// Returned by [`build_option_order_book_with_nats`]. The listeners themselves
+/// are already installed on the inner order book; these handles are retained so
+/// the caller can read publish metrics and drive a clean async shutdown of the
+/// background batch tasks the publishers spawn.
+///
+/// Dropping the handles does **not** stop the background tasks immediately —
+/// call [`shutdown`](Self::shutdown) for a graceful drain.
+pub struct NatsPublisherHandles {
+    /// Handle to the trade publisher (metrics + shutdown).
+    pub trade_handle: Arc<NatsTradePublisher>,
+    /// Handle to the book-change publisher (metrics + shutdown).
+    pub book_handle: Arc<NatsBookChangePublisher>,
+}
+
+impl NatsPublisherHandles {
+    /// Returns the number of successfully published trades.
+    #[must_use]
+    #[inline]
+    pub fn trade_publish_count(&self) -> u64 {
+        self.trade_handle.publish_count()
+    }
+
+    /// Returns the number of permanently failed trade publishes.
+    #[must_use]
+    #[inline]
+    pub fn trade_error_count(&self) -> u64 {
+        self.trade_handle.error_count()
+    }
+
+    /// Returns the number of successfully published book-change events.
+    #[must_use]
+    #[inline]
+    pub fn book_publish_count(&self) -> u64 {
+        self.book_handle.publish_count()
+    }
+
+    /// Returns the number of permanently failed book-change publishes.
+    #[must_use]
+    #[inline]
+    pub fn book_error_count(&self) -> u64 {
+        self.book_handle.error_count()
+    }
+
+    /// Gracefully shuts down both publishers, draining and awaiting their
+    /// background batch tasks. Provides the cancellation/await path required of
+    /// every spawned task in this crate.
+    pub async fn shutdown(&self) {
+        self.trade_handle.shutdown().await;
+        self.book_handle.shutdown().await;
+    }
+}
+
+impl std::fmt::Debug for NatsPublisherHandles {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NatsPublisherHandles")
+            .field("trade_publish_count", &self.trade_publish_count())
+            .field("trade_error_count", &self.trade_error_count())
+            .field("book_publish_count", &self.book_publish_count())
+            .field("book_error_count", &self.book_error_count())
+            .finish_non_exhaustive()
+    }
+}
+
+/// Builds an [`OptionOrderBook`] with NATS trade and book-change publishers
+/// attached.
+///
+/// `orderbook_rs` only permits a single trade listener and a single book-change
+/// listener, both of which must be registered while the inner `OrderBook<T>`
+/// is still owned mutably — i.e. *before* it is wrapped in `Arc`. This function
+/// constructs both publishers, converts them into their `orderbook_rs`-native
+/// listener callbacks, and threads those callbacks into the contract order book
+/// at construction time via [`OptionOrderBook::new_with_config`]. The trade
+/// publisher listener is multiplexed with the internal trade-capture listener.
+///
+/// The dependency direction is `nats` → `book`: this eventing-layer function
+/// consumes the leaf; the leaf never imports this module.
+///
+/// # Subject Format
+///
+/// - Trades: `{prefix}.trades.{underlying}.{expiry}.{strike}.{type}`
+/// - Book changes: `{prefix}.book.{underlying}.{expiry}.{strike}.{type}`
+///
+/// # Arguments
+///
+/// * `symbol` - The option contract symbol (e.g. `"BTC-20240329-50000-C"`)
+/// * `option_style` - The option style (Call or Put)
+/// * `config` - NATS configuration with JetStream context, subject prefix, and
+///   Tokio runtime handle
+///
+/// # Returns
+///
+/// The constructed [`OptionOrderBook`] (with publishers already wired) and the
+/// [`NatsPublisherHandles`] for metrics and shutdown.
+///
+/// # Errors
+///
+/// Returns [`Error::InvalidSymbol`](crate::error::Error::InvalidSymbol) if the
+/// symbol cannot be parsed into its `{underlying}-{expiry}-{strike}-{type}`
+/// components or carries a NATS subject-reserved character.
+#[must_use = "the returned order book and publisher handles must be retained; \
+              dropping them tears the publishers down"]
+pub fn build_option_order_book_with_nats(
+    symbol: impl Into<String>,
+    option_style: OptionStyle,
+    config: &OptionChainNatsConfig,
+) -> crate::Result<(OptionOrderBook, NatsPublisherHandles)> {
+    let symbol = symbol.into();
+    let subject = OptionChainSubjectBuilder::from_symbol(&symbol)?;
+    let trade_subject = subject.trade_subject(config.subject_prefix());
+    let book_subject = subject.book_subject(config.subject_prefix());
+
+    // Build the trade publisher and convert it into its listener callback.
+    let trade_publisher = NatsTradePublisher::new(
+        config.jetstream().clone(),
+        trade_subject,
+        config.runtime().clone(),
+    );
+    let (trade_handle, trade_listener) = trade_publisher.into_listener();
+
+    // Build the book-change publisher and convert it into its listener callback.
+    let book_change_publisher = NatsBookChangePublisher::new(
+        config.jetstream().clone(),
+        symbol.clone(),
+        book_subject,
+        config.runtime().clone(),
+    );
+    let (book_handle, book_listener) = book_change_publisher.into_listener();
+
+    // Install both listeners on the inner book pre-`Arc` via the constructor.
+    let book = OptionOrderBook::new_with_config(
+        symbol,
+        option_style,
+        BookConfig {
+            nats_listeners: Some(PreparedNatsListeners {
+                trade_listener,
+                book_listener,
+            }),
+            ..BookConfig::default()
+        },
+    );
+
+    tracing::info!(
+        symbol = %book.symbol(),
+        prefix = %config.subject_prefix(),
+        "nats trade and book-change publishers attached to option order book"
+    );
+
+    Ok((
+        book,
+        NatsPublisherHandles {
+            trade_handle,
+            book_handle,
+        },
+    ))
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -575,35 +575,6 @@ impl StrikeOrderBook {
     pub const fn put_greeks(&self) -> Option<&Greek> {
         self.put_greeks.as_ref()
     }
-
-    // ── NATS Integration ─────────────────────────────────────────────────
-
-    /// Connects NATS publishers to both call and put order books at this strike.
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - NATS configuration with JetStream context and subject prefix
-    ///
-    /// # Returns
-    ///
-    /// A tuple of `(call_handles, put_handles)` containing the publisher handles
-    /// for each side.
-    ///
-    /// # Errors
-    ///
-    /// Returns an error if either book's symbol cannot be parsed.
-    #[cfg(feature = "nats")]
-    pub fn connect_nats(
-        &self,
-        config: &super::nats::OptionChainNatsConfig,
-    ) -> crate::Result<(
-        super::book::NatsPublisherHandles,
-        super::book::NatsPublisherHandles,
-    )> {
-        let call_handles = self.call.connect_nats(config)?;
-        let put_handles = self.put.connect_nats(config)?;
-        Ok((call_handles, put_handles))
-    }
 }
 
 /// Strike-level mass cancel summary.

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -836,34 +836,6 @@ impl UnderlyingOrderBook {
             total_orders: self.total_order_count(),
         }
     }
-
-    // ── NATS Integration ─────────────────────────────────────────────────
-
-    /// Connects NATS publishers to all expirations for this underlying.
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - NATS configuration with JetStream context and subject prefix
-    ///
-    /// # Returns
-    ///
-    /// The total number of option books successfully connected.
-    ///
-    /// # Errors
-    ///
-    /// Returns the first error encountered while connecting.
-    #[cfg(feature = "nats")]
-    pub fn connect_nats(
-        &self,
-        config: &super::nats::OptionChainNatsConfig,
-    ) -> crate::Result<usize> {
-        let mut total_connected = 0usize;
-        for (_, book) in self.expirations.iter() {
-            let connected = book.connect_nats(config)?;
-            total_connected = total_connected.saturating_add(connected);
-        }
-        Ok(total_connected)
-    }
 }
 
 /// Statistics about an underlying order book.
@@ -1492,34 +1464,6 @@ impl UnderlyingOrderBookManager {
             total_strikes: self.total_strike_count(),
             total_orders: self.total_order_count(),
         }
-    }
-
-    // ── NATS Integration ─────────────────────────────────────────────────
-
-    /// Connects NATS publishers to all underlyings in the system.
-    ///
-    /// # Arguments
-    ///
-    /// * `config` - NATS configuration with JetStream context and subject prefix
-    ///
-    /// # Returns
-    ///
-    /// The total number of option books successfully connected.
-    ///
-    /// # Errors
-    ///
-    /// Returns the first error encountered while connecting.
-    #[cfg(feature = "nats")]
-    pub fn connect_nats(
-        &self,
-        config: &super::nats::OptionChainNatsConfig,
-    ) -> crate::Result<usize> {
-        let mut total_connected = 0usize;
-        for entry in self.underlyings.iter() {
-            let connected = entry.value().connect_nats(config)?;
-            total_connected = total_connected.saturating_add(connected);
-        }
-        Ok(total_connected)
     }
 }
 


### PR DESCRIPTION
## Summary

`OptionOrderBook::connect_nats` built trade/book-change publishers, but `orderbook_rs` only exposes `set_trade_listener`/`set_price_level_listener` (`&mut`, pre-`Arc`, replace-only), so listeners could not attach after the `Arc` wrap and NATS publishing was a **silent no-op** — callers got handles that never fired. It also created a **layering inversion**: the leaf `book.rs` imported `super::nats`, which the boundary forbids (eventing sits on top of the hierarchy).

## Changes

- Install publisher listeners **before** the `Arc` wrap via a new `pub(crate)` `BookConfig.nats_listeners: Option<PreparedNatsListeners>` holding only `orderbook_rs`-native `TradeListener`/`PriceLevelChangedListener` — the leaf never names a `nats`-module type.
- The trade publisher is **multiplexed** with the existing trade-capture listener into the single trade slot (capture first, NATS second — both fire per trade); the book-change publisher uses the price-level slot.
- Wiring moves to a free function `nats::build_option_order_book_with_nats(symbol, style, &config) -> Result<(OptionOrderBook, NatsPublisherHandles)>` (direction is `nats` → `book`).
- Removed `connect_nats` (×5) and every `super::nats` import from the core hierarchy (`book`/`strike`/`chain`/`expiration`/`underlying`). `NatsPublisherHandles` redefined in `nats.rs` with a graceful async `shutdown()` draining both background tasks.

## Public API impact (breaking → 0.5.1 → 0.6.0)

Removed `connect_nats` (×5), removed the `book::NatsPublisherHandles` re-export, changed `NatsPublisherHandles` fields, dropped `nats_handle_count`; `BookConfig` now hand-writes `Debug`. New public surface: `build_option_order_book_with_nats`, `NatsPublisherHandles { shutdown() }`. `mod.rs` re-exports updated. `lib.rs` module docs unchanged (`README.md` regenerated identical).

## Scope note

The hierarchy still constructs contract books via `OptionOrderBook::new` (no NATS); the working way to attach publishers is `build_option_order_book_with_nats` on a standalone book. The removed manager-level `connect_nats` cascade was already a non-functional no-op (listeners could not attach post-`Arc`), so this is a **net correctness win**. Attaching NATS to hierarchy-created (lazy) books is a larger follow-up (filed).

## Testing

- [x] `#[cfg(feature="nats")]` `test_new_with_config_nats_listener_publishes_to_subject_on_match` — fully in-process (no live server): a matched trade fires the NATS trade listener with the configured subject, the trade-capture listener is preserved by the multiplex, and the book-change listener fires
- [x] Layering verified: grep shows no core-hierarchy file imports the `nats` module; leaf compiles under `--no-default-features`
- [x] Determinism re-audited (multiplex order fixed, subjects deterministic, listener non-blocking `try_send`); architect-validated
- [x] `cargo test --all-features` 740+5+88, 0 fail; per-feature clippy matrix (default/nats/sequencer) clean; `make pre-push` clean

## Checklist

- [x] Layering inversion removed (core hierarchy no longer imports eventing); no unwrap/expect/unsafe in prod; no new deps
- [x] Spawned NATS tasks have a shutdown path; `tracing` only; `#[cfg(feature="nats")]` gating correct

Closes #58
