### PR TITLE
fix(instrument_registry): typed error on ID exhaustion, never panic (#62)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -191,6 +191,18 @@ pub enum Error {
         expected: String,
     },
 
+    /// Error when the instrument ID space is exhausted.
+    ///
+    /// The instrument registry allocates monotonically increasing `u32` IDs.
+    /// This variant is returned when the counter reaches its `u32::MAX` ceiling
+    /// and no further IDs can be handed out. The instrument ID is protocol state
+    /// (seeded across rebuilds, persisted via `current_id`, and exposed to
+    /// external sequencer consumers), so exhausting the reachable `2^32` space
+    /// surfaces as a recoverable, typed error rather than a process-aborting
+    /// panic. Reaching this ceiling is astronomically unlikely in practice.
+    #[error("instrument ID space exhausted: u32 counter reached its u32::MAX ceiling")]
+    InstrumentIdExhausted,
+
     /// Error when a journal operation fails.
     #[error("journal error: {message}")]
     JournalError {
@@ -395,6 +407,16 @@ impl Error {
         }
     }
 
+    /// Creates a new instrument ID exhaustion error.
+    ///
+    /// Returned by the instrument registry when the `u32` ID counter reaches
+    /// its `u32::MAX` ceiling and can allocate no further IDs.
+    #[must_use]
+    #[cold]
+    pub fn instrument_id_exhausted() -> Self {
+        Self::InstrumentIdExhausted
+    }
+
     /// Creates a new journal error.
     #[must_use]
     pub fn journal_error(message: impl Into<String>) -> Self {
@@ -579,6 +601,15 @@ mod tests {
         assert!(msg.contains("ETH-20240329-3000-C"));
         assert!(msg.contains("ETH"));
         assert!(msg.contains("BTC"));
+    }
+
+    #[test]
+    fn test_instrument_id_exhausted_error() {
+        let err = Error::instrument_id_exhausted();
+        let msg = err.to_string();
+        assert!(msg.contains("instrument ID space exhausted"));
+        assert!(msg.contains("u32::MAX"));
+        assert!(matches!(err, Error::InstrumentIdExhausted));
     }
 
     #[test]

--- a/src/orderbook/instrument_registry.rs
+++ b/src/orderbook/instrument_registry.rs
@@ -10,6 +10,7 @@
 //! each call/put [`OptionOrderBook`](super::book::OptionOrderBook) is assigned a
 //! unique ID from the registry.
 
+use crate::error::{Error, Result};
 use dashmap::DashMap;
 use optionstratlib::{ExpirationDate, OptionStyle};
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -150,16 +151,20 @@ impl InstrumentRegistry {
     /// Uses `Ordering::Relaxed` since the only invariant is uniqueness,
     /// not ordering relative to other memory operations.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if the `u32` counter is exhausted (> 4 billion instruments).
+    /// Returns [`Error::InstrumentIdExhausted`] if the `u32` counter has
+    /// reached its `u32::MAX` ceiling (after roughly 4 billion allocations).
+    /// The instrument ID is protocol state, so exhaustion is surfaced as a
+    /// recoverable typed error rather than a panic. Reaching this ceiling is
+    /// astronomically unlikely in practice.
     #[inline]
-    pub fn allocate(&self) -> u32 {
+    pub fn allocate(&self) -> Result<u32> {
         self.next_id
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
                 current.checked_add(1)
             })
-            .expect("instrument ID counter exhausted")
+            .map_err(|_| Error::instrument_id_exhausted())
     }
 
     /// Registers an instrument in the reverse index.
@@ -223,7 +228,7 @@ impl InstrumentRegistry {
     /// use optionstratlib::prelude::pos_or_panic;
     ///
     /// let registry = InstrumentRegistry::new();
-    /// let id = registry.allocate();
+    /// let id = registry.allocate().expect("fresh registry has IDs available");
     /// registry.register(id, InstrumentInfo::new(
     ///     "BTC-20240329-50000-C",
     ///     ExpirationDate::Days(pos_or_panic!(30.0)),
@@ -275,9 +280,9 @@ mod tests {
     #[test]
     fn test_allocate_monotonic() {
         let registry = InstrumentRegistry::new();
-        let id1 = registry.allocate();
-        let id2 = registry.allocate();
-        let id3 = registry.allocate();
+        let id1 = registry.allocate().expect("id available");
+        let id2 = registry.allocate().expect("id available");
+        let id3 = registry.allocate().expect("id available");
 
         assert_eq!(id1, 1);
         assert_eq!(id2, 2);
@@ -288,15 +293,44 @@ mod tests {
     #[test]
     fn test_allocate_with_seed() {
         let registry = InstrumentRegistry::new_with_seed(50);
-        assert_eq!(registry.allocate(), 50);
-        assert_eq!(registry.allocate(), 51);
+        assert_eq!(registry.allocate().expect("id available"), 50);
+        assert_eq!(registry.allocate().expect("id available"), 51);
         assert_eq!(registry.current_id(), 52);
+    }
+
+    #[test]
+    fn test_allocate_exhaustion_returns_typed_error() {
+        // Seeding at u32::MAX means checked_add(1) immediately overflows: the
+        // very first allocation must surface a typed error, never panic.
+        let registry = InstrumentRegistry::new_with_seed(u32::MAX);
+        let result = registry.allocate();
+        assert!(matches!(result, Err(Error::InstrumentIdExhausted)));
+    }
+
+    #[test]
+    fn test_allocate_exhaustion_after_last_id() {
+        // Seeding one below the ceiling allows exactly one successful allocation
+        // (returning u32::MAX - 1, advancing the counter to u32::MAX); the next
+        // allocation overflows and returns the typed exhaustion error.
+        let registry = InstrumentRegistry::new_with_seed(u32::MAX - 1);
+        assert_eq!(registry.allocate().expect("one id remains"), u32::MAX - 1);
+        assert_eq!(registry.current_id(), u32::MAX);
+        assert!(matches!(
+            registry.allocate(),
+            Err(Error::InstrumentIdExhausted)
+        ));
+        // Counter stays pinned at the ceiling; repeated calls keep erroring.
+        assert_eq!(registry.current_id(), u32::MAX);
+        assert!(matches!(
+            registry.allocate(),
+            Err(Error::InstrumentIdExhausted)
+        ));
     }
 
     #[test]
     fn test_register_and_get() {
         let registry = InstrumentRegistry::new();
-        let id = registry.allocate();
+        let id = registry.allocate().expect("id available");
 
         let info = InstrumentInfo::new(
             "BTC-20240329-50000-C",
@@ -330,7 +364,7 @@ mod tests {
         assert!(registry.is_empty());
         assert_eq!(registry.len(), 0);
 
-        let id = registry.allocate();
+        let id = registry.allocate().expect("id available");
         registry.register(
             id,
             InstrumentInfo::new(
@@ -350,7 +384,7 @@ mod tests {
         let registry = InstrumentRegistry::new();
 
         for i in 0..10 {
-            let id = registry.allocate();
+            let id = registry.allocate().expect("id available");
             registry.register(
                 id,
                 InstrumentInfo::new(
@@ -396,7 +430,7 @@ mod tests {
             handles.push(thread::spawn(move || {
                 let mut ids = Vec::new();
                 for _ in 0..100 {
-                    ids.push(reg.allocate());
+                    ids.push(reg.allocate().expect("id available"));
                 }
                 ids
             }));
@@ -456,7 +490,7 @@ mod tests {
     fn test_seed_zero_clamped_to_one() {
         let registry = InstrumentRegistry::new_with_seed(0);
         assert_eq!(registry.current_id(), 1);
-        assert_eq!(registry.allocate(), 1);
+        assert_eq!(registry.allocate().expect("id available"), 1);
     }
 
     #[test]
@@ -471,7 +505,7 @@ mod tests {
         let registry = InstrumentRegistry::new();
 
         for i in 0..5 {
-            let id = registry.allocate();
+            let id = registry.allocate().expect("id available");
             registry.register(
                 id,
                 InstrumentInfo::new(

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -914,6 +914,17 @@ impl StrikeOrderBookManager {
     /// immediately after creation under contention should resolve them via the
     /// [`InstrumentRegistry`] / [`SymbolIndex`] once creation has settled rather
     /// than reading `instrument_id()` synchronously off the returned handle.
+    ///
+    /// ## Instrument-ID exhaustion
+    ///
+    /// This method is infallible by design so that the whole hierarchy and the
+    /// sequencer can create books without threading a `Result`. If the
+    /// instrument registry's `u32` ID space is ever exhausted (after roughly 4
+    /// billion allocations — astronomically unlikely), the winner logs a
+    /// `tracing::error!` and returns the strike book with its call/put pair left
+    /// at `instrument_id == 0`. The registry degrades gracefully; it never
+    /// panics. The symbol index is still populated, so symbol-based lookups
+    /// continue to work.
     pub fn get_or_create(&self, strike: u64) -> Arc<StrikeOrderBook> {
         if let Some(entry) = self.strikes.get(&strike) {
             return Arc::clone(entry.value());
@@ -931,7 +942,22 @@ impl StrikeOrderBookManager {
         let winner = Arc::clone(entry.value());
         if Arc::ptr_eq(&winner, &fresh) {
             // We won the race — allocate IDs and register symbols exactly once.
-            self.assign_instrument_ids(&winner, strike);
+            //
+            // On the astronomically-rare instrument-ID-space exhaustion we log
+            // and degrade rather than propagating a fallible signature through
+            // the entire hierarchy and the sequencer's
+            // `find_or_create_book_by_symbol`: the call/put pair is left at
+            // `instrument_id == 0` (the same value as the transient
+            // pre-assignment window described above), the symbol index stays
+            // populated, and no thread panics.
+            if let Err(err) = self.assign_instrument_ids(&winner, strike) {
+                tracing::error!(
+                    underlying = %self.underlying,
+                    strike,
+                    error = %err,
+                    "instrument-id exhaustion: registry full; strike books left with instrument_id 0",
+                );
+            }
         }
         winner
     }
@@ -978,15 +1004,40 @@ impl StrikeOrderBookManager {
     /// Assigns unique instrument IDs and registers the call/put books in the
     /// reverse index. Also registers symbols in the symbol index if present.
     /// Called only after confirming this book won the insertion race.
-    fn assign_instrument_ids(&self, book: &StrikeOrderBook, strike: u64) {
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::InstrumentIdExhausted`] if the instrument registry's
+    /// `u32` ID space is exhausted. On that error the call/put pair is left at
+    /// `instrument_id == 0`: IDs are allocated before being written to the
+    /// books, so a mid-pair exhaustion never leaves a half-assigned pair. The
+    /// symbol index is populated first (it is independent of numeric IDs and
+    /// never fails), so symbol lookups stay functional even when the registry
+    /// is full.
+    fn assign_instrument_ids(&self, book: &StrikeOrderBook, strike: u64) -> Result<()> {
         let exp_str = format_expiration_yyyymmdd(&self.expiration)
             .unwrap_or_else(|_| self.expiration.to_string());
         let call_symbol = format!("{}-{}-{}-C", self.underlying, exp_str, strike);
         let put_symbol = format!("{}-{}-{}-P", self.underlying, exp_str, strike);
 
+        // Symbol-index registration is independent of numeric ID allocation and
+        // never fails; run it first so symbol lookups stay functional even if
+        // the registry is exhausted below.
+        if let Some(idx) = &self.symbol_index {
+            let call_ref =
+                SymbolRef::new(&self.underlying, self.expiration, strike, OptionStyle::Call);
+            let put_ref =
+                SymbolRef::new(&self.underlying, self.expiration, strike, OptionStyle::Put);
+            idx.register(&call_symbol, call_ref);
+            idx.register(&put_symbol, put_ref);
+        }
+
         if let Some(reg) = &self.registry {
-            let call_id = reg.allocate();
-            let put_id = reg.allocate();
+            // Allocate both IDs before mutating the books so that a mid-pair
+            // exhaustion leaves the pair untouched at `instrument_id == 0`
+            // rather than half-assigned.
+            let call_id = reg.allocate()?;
+            let put_id = reg.allocate()?;
 
             book.call().set_instrument_id(call_id);
             book.put().set_instrument_id(put_id);
@@ -1002,14 +1053,7 @@ impl StrikeOrderBookManager {
             );
         }
 
-        if let Some(idx) = &self.symbol_index {
-            let call_ref =
-                SymbolRef::new(&self.underlying, self.expiration, strike, OptionStyle::Call);
-            let put_ref =
-                SymbolRef::new(&self.underlying, self.expiration, strike, OptionStyle::Put);
-            idx.register(&call_symbol, call_ref);
-            idx.register(&put_symbol, put_ref);
-        }
+        Ok(())
     }
 
     /// Registers a call/put pair in the instrument registry.
@@ -1281,6 +1325,55 @@ mod tests {
         assert_ne!(call_id, 0);
         assert_ne!(put_id, 0);
         assert_ne!(call_id, put_id);
+    }
+
+    #[test]
+    fn test_get_or_create_degrades_on_id_exhaustion() {
+        use super::super::symbol_index::SymbolIndex;
+
+        // Seed the registry at its u32 ceiling so the very first allocation in
+        // `assign_instrument_ids` overflows. `get_or_create` must NOT panic: it
+        // logs and degrades, returning a fully usable strike book whose call/put
+        // pair is left at `instrument_id == 0`.
+        let registry = Arc::new(InstrumentRegistry::new_with_seed(u32::MAX));
+        let symbol_index = Arc::new(SymbolIndex::new());
+        let manager = StrikeOrderBookManager::new_with_registry_and_index(
+            "BTC",
+            test_expiration(),
+            Arc::clone(&registry),
+            Arc::clone(&symbol_index),
+        );
+
+        let book = manager.get_or_create(50000);
+
+        // No panic; the strike book exists and is mapped.
+        assert_eq!(manager.len(), 1);
+
+        // Degraded: both legs sit at the reserved id 0 (no IDs were allocated).
+        assert_eq!(book.call().instrument_id(), 0);
+        assert_eq!(book.put().instrument_id(), 0);
+
+        // Registry stayed pinned at the ceiling and registered nothing.
+        assert_eq!(registry.current_id(), u32::MAX);
+        assert_eq!(registry.len(), 0);
+
+        // Symbol lookups still work — the symbol index does not depend on the
+        // numeric instrument id, so it is populated even at exhaustion.
+        assert_eq!(symbol_index.len(), 2);
+    }
+
+    #[test]
+    fn test_get_or_create_idempotent_after_id_exhaustion() {
+        // A repeat call with the same strike returns the SAME handle even when
+        // the registry is exhausted (the degrade path does not break the
+        // idempotent `get_or_insert` contract).
+        let registry = Arc::new(InstrumentRegistry::new_with_seed(u32::MAX));
+        let manager = StrikeOrderBookManager::new_with_registry("BTC", test_expiration(), registry);
+
+        let first = manager.get_or_create(50000);
+        let second = manager.get_or_create(50000);
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(manager.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`InstrumentRegistry::allocate()` used `checked_add` but then `.expect()`'d the `None`, **panicking** when the u32 ID space is exhausted — violating the zero-panic rule and the rule that protocol-state counters surface overflow as a typed error. The instrument ID is protocol state (seeded across rebuilds, persisted via `current_id`, exposed to external sequencer consumers), so exhausting the reachable 2^32 space must be recoverable, not a process abort.

## Changes

- New `Error::InstrumentIdExhausted` (`#[cold]` ctor, documented).
- `allocate() -> Result<u32>` maps the overflow to the typed error (no panic; the counter pins at `u32::MAX` and keeps returning the error).
- `assign_instrument_ids -> Result<()>`, allocating both call+put ids **before** writing them (a mid-pair exhaustion leaves the pair cleanly at id 0; symbol-index registration runs first and is ID-independent).
- `get_or_create_strike` stays infallible: on the astronomically-rare exhaustion it logs `tracing::error!` and returns the book at `instrument_id == 0` (the same value as the #49 transient pre-assignment window).

## Design decision: log-and-degrade vs fallible `get_or_create`

Making `get_or_create_strike` fallible would force a `Result` through the entire hierarchy (`strike → chain → expiration → underlying` `get_or_create_*`) **and** the #52 sequencer `find_or_create_book_by_symbol`, plus every example/test — a large breaking ripple for a 2^32 event. Log-and-degrade keeps all those signatures intact, nothing panics, the registry/hierarchy degrade gracefully, and symbol lookups keep working. The only public break is `allocate()`'s signature.

## Testing

- [x] `test_allocate_exhaustion_returns_typed_error` (seed `u32::MAX` → `Err`, no panic) and `test_allocate_exhaustion_after_last_id` (seed `u32::MAX-1` → one success then pinned error)
- [x] `test_get_or_create_degrades_on_id_exhaustion` (no panic; pair at id 0; symbol index still populated) and `test_get_or_create_idempotent_after_id_exhaustion` (degrade preserves get_or_create idempotency)
- [x] `cargo test --all-features` 764+5+88, 0 fail; `clippy -D warnings`, `make pre-push` clean

## Public API impact

`InstrumentRegistry::allocate()` signature `u32 → Result<u32>` (the registry is exposed to external consumers per #6). Absorbed under the single **0.5.0** release (version unchanged).

## Checklist

- [x] `rules/global_rules.md`: zero panic in production; protocol counter overflow → typed error; no unwrap/expect in prod; no `unsafe`; no new deps
- [x] Version stays 0.5.0 (no per-PR bump)

Closes #62
