### PR TITLE
fix(error): preserve the orderbook_rs source chain via #[from] (#64)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -48,12 +48,30 @@ pub enum Error {
         message: String,
     },
 
-    /// Error when an order book operation fails.
+    /// Error when an order book operation fails, carrying a manual string
+    /// message.
+    ///
+    /// Used for failures that originate in this crate (e.g. validation
+    /// strings) rather than the upstream matching engine. For typed failures
+    /// propagated from `orderbook_rs`, use [`OrderBookEngine`](Self::OrderBookEngine)
+    /// instead, which preserves the source chain.
     #[error("order book error: {message}")]
     OrderBookError {
         /// Description of the order book error.
         message: String,
     },
+
+    /// Error propagated from the upstream `orderbook_rs` matching engine.
+    ///
+    /// Wraps [`orderbook_rs::prelude::OrderBookError`] via `#[from]` so the
+    /// typed upstream error and its source chain are preserved: callers can
+    /// reach the underlying reason through [`std::error::Error::source`] and
+    /// downcast to the concrete `OrderBookError` to match on the rejection
+    /// (duplicate order id, self-trade prevented, risk breach, etc.). The
+    /// upstream type is `#[non_exhaustive]`, so it can only be obtained by
+    /// triggering a real engine failure, never constructed directly.
+    #[error("order-book engine error: {0}")]
+    OrderBookEngine(#[from] orderbook_rs::prelude::OrderBookError),
 
     /// Error when pricing calculation fails.
     #[error("pricing error: {message}")]

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -684,8 +684,7 @@ impl OptionOrderBook {
     ) -> Result<()> {
         self.check_active()?;
         self.book
-            .add_limit_order(order_id, price, quantity, side, TimeInForce::Gtc, None)
-            .map_err(|e| crate::Error::orderbook(e.to_string()))?;
+            .add_limit_order(order_id, price, quantity, side, TimeInForce::Gtc, None)?;
         Ok(())
     }
 
@@ -713,8 +712,7 @@ impl OptionOrderBook {
     ) -> Result<()> {
         self.check_active()?;
         self.book
-            .add_limit_order(order_id, price, quantity, side, tif, None)
-            .map_err(|e| crate::Error::orderbook(e.to_string()))?;
+            .add_limit_order(order_id, price, quantity, side, tif, None)?;
         Ok(())
     }
 
@@ -735,7 +733,7 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`OrderBookError`](crate::Error::OrderBookError) if the upstream book rejects the order
+    /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order
     ///   (e.g., `MissingUserId` when STP is enabled and `user_id` is zero).
     pub fn add_limit_order_with_user(
         &self,
@@ -746,17 +744,15 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<()> {
         self.check_active()?;
-        self.book
-            .add_limit_order_with_user(
-                order_id,
-                price,
-                quantity,
-                side,
-                TimeInForce::Gtc,
-                user_id,
-                None,
-            )
-            .map_err(|e| crate::Error::orderbook(e.to_string()))?;
+        self.book.add_limit_order_with_user(
+            order_id,
+            price,
+            quantity,
+            side,
+            TimeInForce::Gtc,
+            user_id,
+            None,
+        )?;
         Ok(())
     }
 
@@ -777,7 +773,7 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`OrderBookError`](crate::Error::OrderBookError) if the upstream book rejects the order.
+    /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order.
     pub fn add_limit_order_with_tif_and_user(
         &self,
         order_id: OrderId,
@@ -789,8 +785,7 @@ impl OptionOrderBook {
     ) -> Result<()> {
         self.check_active()?;
         self.book
-            .add_limit_order_with_user(order_id, price, quantity, side, tif, user_id, None)
-            .map_err(|e| crate::Error::orderbook(e.to_string()))?;
+            .add_limit_order_with_user(order_id, price, quantity, side, tif, user_id, None)?;
         Ok(())
     }
 
@@ -845,8 +840,7 @@ impl OptionOrderBook {
         self.check_active()?;
         self.clear_trade_capture();
         self.book
-            .add_limit_order(order_id, price, quantity, side, TimeInForce::Gtc, None)
-            .map_err(|e| crate::Error::orderbook(e.to_string()))?;
+            .add_limit_order(order_id, price, quantity, side, TimeInForce::Gtc, None)?;
         Ok(self.extract_trade_result(order_id, quantity))
     }
 
@@ -856,7 +850,7 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`OrderBookError`](crate::Error::OrderBookError) if the upstream book rejects the order.
+    /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order.
     pub fn add_limit_order_with_tif_full(
         &self,
         order_id: OrderId,
@@ -868,8 +862,7 @@ impl OptionOrderBook {
         self.check_active()?;
         self.clear_trade_capture();
         self.book
-            .add_limit_order(order_id, price, quantity, side, tif, None)
-            .map_err(|e| crate::Error::orderbook(e.to_string()))?;
+            .add_limit_order(order_id, price, quantity, side, tif, None)?;
         Ok(self.extract_trade_result(order_id, quantity))
     }
 
@@ -879,7 +872,7 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`OrderBookError`](crate::Error::OrderBookError) if the upstream book rejects the order.
+    /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order.
     pub fn add_limit_order_with_user_full(
         &self,
         order_id: OrderId,
@@ -890,17 +883,15 @@ impl OptionOrderBook {
     ) -> Result<TradeResult> {
         self.check_active()?;
         self.clear_trade_capture();
-        self.book
-            .add_limit_order_with_user(
-                order_id,
-                price,
-                quantity,
-                side,
-                TimeInForce::Gtc,
-                user_id,
-                None,
-            )
-            .map_err(|e| crate::Error::orderbook(e.to_string()))?;
+        self.book.add_limit_order_with_user(
+            order_id,
+            price,
+            quantity,
+            side,
+            TimeInForce::Gtc,
+            user_id,
+            None,
+        )?;
         Ok(self.extract_trade_result(order_id, quantity))
     }
 
@@ -911,7 +902,7 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`OrderBookError`](crate::Error::OrderBookError) if the upstream book rejects the order.
+    /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order.
     pub fn add_limit_order_with_tif_and_user_full(
         &self,
         order_id: OrderId,
@@ -924,8 +915,7 @@ impl OptionOrderBook {
         self.check_active()?;
         self.clear_trade_capture();
         self.book
-            .add_limit_order_with_user(order_id, price, quantity, side, tif, user_id, None)
-            .map_err(|e| crate::Error::orderbook(e.to_string()))?;
+            .add_limit_order_with_user(order_id, price, quantity, side, tif, user_id, None)?;
         Ok(self.extract_trade_result(order_id, quantity))
     }
 
@@ -942,9 +932,9 @@ impl OptionOrderBook {
     ///
     /// # Errors
     ///
-    /// Returns [`Error::orderbook`](crate::Error::orderbook) if the underlying
-    /// engine reports a real cancellation failure (distinct from a benign
-    /// not-found).
+    /// Returns [`OrderBookEngine`](crate::Error::OrderBookEngine) if the
+    /// underlying engine reports a real cancellation failure (distinct from a
+    /// benign not-found).
     pub fn cancel_order(&self, order_id: OrderId) -> Result<bool> {
         // orderbook_rs::cancel_order returns Ok(Some(_)) when an order was
         // cancelled, Ok(None) when no such order was resting, and Err(_) on a
@@ -954,7 +944,7 @@ impl OptionOrderBook {
         match self.book.cancel_order(order_id) {
             Ok(Some(_)) => Ok(true),
             Ok(None) => Ok(false),
-            Err(e) => Err(crate::Error::orderbook(e.to_string())),
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -1523,6 +1513,44 @@ mod tests {
         assert_eq!(book.order_count(), 2);
         assert_eq!(book.bid_level_count(), 1);
         assert_eq!(book.ask_level_count(), 1);
+    }
+
+    #[test]
+    fn test_orderbook_engine_error_preserves_source_chain() {
+        use orderbook_rs::prelude::OrderBookError;
+        use std::error::Error as _;
+
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+
+        // Admit a resting order, then submit a second order reusing the same
+        // OrderId. orderbook_rs rejects the duplicate id with a typed
+        // OrderBookError::DuplicateOrderId; the wrapper must propagate it as
+        // Error::OrderBookEngine with the upstream source chain intact (rather
+        // than flattening it to a string and dropping the typed cause).
+        let order_id = OrderId::new();
+        book.add_limit_order(order_id, Side::Buy, 100, 10)
+            .expect("first add should succeed");
+
+        let err = book
+            .add_limit_order(order_id, Side::Buy, 100, 10)
+            .expect_err("duplicate order id must be rejected");
+
+        // The wrapper maps the upstream failure to the typed engine variant.
+        assert!(
+            matches!(err, crate::Error::OrderBookEngine(_)),
+            "expected OrderBookEngine variant, got: {err:?}"
+        );
+
+        // The typed upstream error is reachable via std::error::Error::source()
+        // and downcasts back to the concrete orderbook_rs error.
+        let source = err.source().expect("source chain must be preserved");
+        let downcast = source
+            .downcast_ref::<OrderBookError>()
+            .expect("source must downcast to orderbook_rs OrderBookError");
+        assert!(
+            matches!(downcast, OrderBookError::DuplicateOrderId { .. }),
+            "expected DuplicateOrderId from the engine, got: {downcast:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Every upstream `orderbook_rs` failure was flattened to `Error::orderbook(e.to_string())`, discarding the typed error and its source chain — so `std::error::Error::source()` always returned `None` for order-book failures and callers could not match on the upstream reason. This contradicts the rule to wrap lower-level errors with `#[from]` where unambiguous.

## Changes (additive)

- New `Error::OrderBookEngine(#[from] orderbook_rs::prelude::OrderBookError)` (the upstream type is `Debug + Display + std::error::Error + Send + Sync + 'static`, so the derive wires `source()`).
- Replaced the 9 `.map_err(|e| Error::orderbook(e.to_string()))` sites in `book.rs` (the 8 `add_limit_order*` and the `cancel_order` arm) with `?` / `.into()`.
- Kept the existing string `OrderBookError { message }` variant + `orderbook()` constructor for manual/validation messages; refreshed the affected `# Errors` docs.

## Testing

- [x] `test_orderbook_engine_error_preserves_source_chain` — a duplicate-`OrderId` add triggers a real `OrderBookError::DuplicateOrderId`; asserts the returned `Error` is `OrderBookEngine(_)`, `source()` is `Some`, and downcasts to `orderbook_rs::prelude::OrderBookError`
- [x] `cargo test --all-features` 765+5+88, 0 fail; `clippy -D warnings`, `make pre-push` clean

## Notes

Additive new variant; version stays **0.5.0**. The Display prefix for upstream-propagated order-book failures changed from `order book error:` to `order-book engine error:`.

## Checklist

- [x] `rules/global_rules.md`: `#[from]` on the unambiguous upstream mapping; `source()` preserved; no unwrap/expect/unsafe; no new deps; leaf-only (layering intact)

Closes #64
