### PR TITLE
refactor(lib): normalize crate-root public re-exports (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,19 @@ This architecture enables:
 | [`error`] | Error types and `Result` type alias |
 | [`utils`] | Utility functions (e.g., date formatting) |
 
+### Re-export Convention
+
+Every public item is available at the crate root **and** under
+[`orderbook`]: `option_chain_orderbook::OptionOrderBook` and
+`option_chain_orderbook::orderbook::OptionOrderBook` resolve to the same
+type. Prefer the shorter crate-root path; the `orderbook::` path remains
+valid.
+
+The boundary newtypes — `OrderId`, `OrderType`, `Side`, `TimeInForce`, and
+`Hash32` — are re-exported here from `orderbook_rs` / `pricelevel`, so
+consumers need **no direct `orderbook_rs` dependency** to use the hierarchy.
+(Price and quantity cross the leaf boundary as plain `u128` / `u64`.)
+
 ### Core Components
 
 #### Order Book Hierarchy ([`orderbook`])
@@ -94,10 +107,9 @@ This architecture enables:
 #### Creating a Hierarchical Order Book
 
 ```rust
-use option_chain_orderbook::orderbook::UnderlyingOrderBookManager;
+use option_chain_orderbook::{OrderId, Side, UnderlyingOrderBookManager};
 use optionstratlib::prelude::pos_or_panic;
 use optionstratlib::ExpirationDate;
-use orderbook_rs::{OrderId, Side};
 
 let manager = UnderlyingOrderBookManager::new();
 let exp_date = ExpirationDate::Days(pos_or_panic!(30.0));
@@ -126,9 +138,8 @@ let stats = manager.stats();
 #### Creating a Single Option Order Book
 
 ```rust
-use option_chain_orderbook::orderbook::OptionOrderBook;
+use option_chain_orderbook::{OptionOrderBook, OrderId, Side};
 use optionstratlib::OptionStyle;
-use orderbook_rs::{OrderId, Side};
 
 // Create an order book for a specific option
 let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,19 @@
 //! | [`error`] | Error types and `Result` type alias |
 //! | [`utils`] | Utility functions (e.g., date formatting) |
 //!
+//! ## Re-export Convention
+//!
+//! Every public item is available at the crate root **and** under
+//! [`orderbook`]: `option_chain_orderbook::OptionOrderBook` and
+//! `option_chain_orderbook::orderbook::OptionOrderBook` resolve to the same
+//! type. Prefer the shorter crate-root path; the `orderbook::` path remains
+//! valid.
+//!
+//! The boundary newtypes — `OrderId`, `OrderType`, `Side`, `TimeInForce`, and
+//! `Hash32` — are re-exported here from `orderbook_rs` / `pricelevel`, so
+//! consumers need **no direct `orderbook_rs` dependency** to use the hierarchy.
+//! (Price and quantity cross the leaf boundary as plain `u128` / `u64`.)
+//!
 //! ## Core Components
 //!
 //! ### Order Book Hierarchy ([`orderbook`])
@@ -80,10 +93,9 @@
 //! ### Creating a Hierarchical Order Book
 //!
 //! ```rust
-//! use option_chain_orderbook::orderbook::UnderlyingOrderBookManager;
+//! use option_chain_orderbook::{OrderId, Side, UnderlyingOrderBookManager};
 //! use optionstratlib::prelude::pos_or_panic;
 //! use optionstratlib::ExpirationDate;
-//! use orderbook_rs::{OrderId, Side};
 //!
 //! let manager = UnderlyingOrderBookManager::new();
 //! let exp_date = ExpirationDate::Days(pos_or_panic!(30.0));
@@ -112,9 +124,8 @@
 //! ### Creating a Single Option Order Book
 //!
 //! ```rust
-//! use option_chain_orderbook::orderbook::OptionOrderBook;
+//! use option_chain_orderbook::{OptionOrderBook, OrderId, Side};
 //! use optionstratlib::OptionStyle;
-//! use orderbook_rs::{OrderId, Side};
 //!
 //! // Create an order book for a specific option
 //! let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
@@ -220,14 +231,42 @@ pub mod orderbook;
 pub mod utils;
 
 pub use error::{Error, Result};
+
+// Every public item of the [`orderbook`] module is also re-exported at the crate
+// root, so each type is reachable both as `option_chain_orderbook::X` and as
+// `option_chain_orderbook::orderbook::X`. This includes the primary hierarchy
+// types, the side subsystems, and the boundary newtypes (`OrderId`, `OrderType`,
+// `Side`, `TimeInForce`, `Hash32`) re-exported from `orderbook_rs` / `pricelevel`.
 pub use orderbook::{
-    AggregatedGreeks, CleanupResult, CycleRule, ExpirationCallback, ExpiryCycleConfig,
-    ExpiryLifecycleManager, ExpiryScheduler, ExpiryType, FlatVolSurface, GreeksAggregator,
-    GreeksEngine, GreeksRecalcTrigger, GreeksUpdate, GreeksUpdateListener, IndexPriceFeed,
-    InstrumentInfo, InstrumentRegistry, LifecycleConfig, LifecycleEvent, LifecycleListener,
-    LifecycleResult, MarkPriceCalculator, MarkPriceConfig, MarkPriceConfigBuilder, MockPriceFeed,
-    Position, PriceUpdate, PriceUpdateListener, RefreshResult, StaticPriceFeed, StrikeGenerator,
-    StrikeRangeConfig, StrikeRangeConfigBuilder, SubscriptionId, SymbolIndex, SymbolRef,
-    VolSurface, calculate_tte_years, wire_feed_to_calculator,
+    AggregatedGreeks, CancelReason, ChainMassCancelResult, CleanupResult, ContractSpecs,
+    ContractSpecsBuilder, CycleRule, ExerciseStyle, ExpirationCallback, ExpirationManagerStats,
+    ExpirationMassCancelResult, ExpirationOrderBook, ExpirationOrderBookManager, ExpiryCycleConfig,
+    ExpiryLifecycleManager, ExpiryScheduler, ExpiryType, FeeSchedule, FlatVolSurface,
+    GlobalMassCancelResult, GlobalStats, GreeksAggregator, GreeksEngine, GreeksRecalcTrigger,
+    GreeksUpdate, GreeksUpdateListener, Hash32, IndexPriceFeed, InstrumentInfo, InstrumentRegistry,
+    InstrumentStatus, LifecycleConfig, LifecycleEvent, LifecycleListener, LifecycleResult,
+    MarkPriceCalculator, MarkPriceConfig, MarkPriceConfigBuilder, MassCancelResult, MockPriceFeed,
+    OptionChainOrderBook, OptionChainOrderBookManager, OptionChainStats, OptionOrderBook, OrderId,
+    OrderStateTracker, OrderStatus, OrderType, Position, PriceUpdate, PriceUpdateListener, Quote,
+    QuoteUpdate, RefreshResult, STPMode, SettlementType, Side, StaticPriceFeed, StrikeGenerator,
+    StrikeMassCancelResult, StrikeOrderBook, StrikeOrderBookManager, StrikeRangeConfig,
+    StrikeRangeConfigBuilder, SubscriptionId, SymbolIndex, SymbolRef, TerminalOrderSummary,
+    TimeInForce, TradeResult, UnderlyingMassCancelResult, UnderlyingOrderBook,
+    UnderlyingOrderBookManager, UnderlyingStats, ValidationConfig, VolSurface, calculate_tte_years,
+    wire_feed_to_calculator,
 };
+
+#[cfg(feature = "nats")]
+pub use orderbook::{
+    NatsPublisherHandles, OptionChainNatsConfig, OptionChainSubjectBuilder,
+    build_option_order_book_with_nats,
+};
+
+#[cfg(feature = "sequencer")]
+pub use orderbook::{
+    InMemoryOptionChainJournal, MassCancelScope, MassCancelType, OptionChainCommand,
+    OptionChainEvent, OptionChainJournal, OptionChainReceipt, OptionChainResult,
+    SequencedUnderlyingOrderBook,
+};
+
 pub use utils::{ParsedSymbol, SymbolParser};

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -971,9 +971,8 @@ impl OptionOrderBook {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::OptionOrderBook;
+    /// use option_chain_orderbook::{OptionOrderBook, OrderId, Side};
     /// use optionstratlib::OptionStyle;
-    /// use orderbook_rs::{OrderId, Side};
     ///
     /// let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
     /// if let Err(err) = book.add_limit_order(OrderId::new(), Side::Buy, 100, 1) {
@@ -1012,9 +1011,8 @@ impl OptionOrderBook {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::OptionOrderBook;
+    /// use option_chain_orderbook::{OptionOrderBook, OrderId, Side};
     /// use optionstratlib::OptionStyle;
-    /// use orderbook_rs::{OrderId, Side};
     ///
     /// let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
     /// if let Err(err) = book.add_limit_order(OrderId::new(), Side::Buy, 100, 1) {
@@ -1053,9 +1051,8 @@ impl OptionOrderBook {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::OptionOrderBook;
+    /// use option_chain_orderbook::{OptionOrderBook, OrderId, Side};
     /// use optionstratlib::OptionStyle;
-    /// use orderbook_rs::{OrderId, Side};
     /// use pricelevel::Hash32;
     ///
     /// let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
@@ -1098,9 +1095,8 @@ impl OptionOrderBook {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::OptionOrderBook;
+    /// use option_chain_orderbook::{OptionOrderBook, OrderId, Side};
     /// use optionstratlib::OptionStyle;
-    /// use orderbook_rs::{OrderId, Side};
     ///
     /// let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
     /// let id = OrderId::new();
@@ -1136,9 +1132,8 @@ impl OptionOrderBook {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::OptionOrderBook;
+    /// use option_chain_orderbook::{OptionOrderBook, OrderId, Side};
     /// use optionstratlib::OptionStyle;
-    /// use orderbook_rs::{OrderId, Side};
     ///
     /// let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
     /// let id = OrderId::new();
@@ -1276,9 +1271,8 @@ impl OptionOrderBook {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::OptionOrderBook;
+    /// use option_chain_orderbook::{OptionOrderBook, OrderId, Side};
     /// use optionstratlib::OptionStyle;
-    /// use orderbook_rs::{OrderId, Side};
     /// use pricelevel::Hash32;
     ///
     /// let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);

--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -348,10 +348,9 @@ impl OptionChainOrderBook {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::OptionChainOrderBook;
+    /// use option_chain_orderbook::{OptionChainOrderBook, Side};
     /// use optionstratlib::ExpirationDate;
     /// use optionstratlib::prelude::pos_or_panic;
-    /// use orderbook_rs::Side;
     ///
     /// let chain = OptionChainOrderBook::new("BTC", ExpirationDate::Days(pos_or_panic!(30.0)));
     /// let result = match chain.cancel_by_side(Side::Buy) {

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -300,10 +300,9 @@ impl ExpirationOrderBook {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::ExpirationOrderBook;
+    /// use option_chain_orderbook::{ExpirationOrderBook, Side};
     /// use optionstratlib::ExpirationDate;
     /// use optionstratlib::prelude::pos_or_panic;
-    /// use orderbook_rs::Side;
     ///
     /// let book = ExpirationOrderBook::new("BTC", ExpirationDate::Days(pos_or_panic!(30.0)));
     /// let result = match book.cancel_by_side(Side::Buy) {

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -128,9 +128,13 @@ pub use sequencer::{
     SequencedUnderlyingOrderBook,
 };
 
-// Re-export upstream types used in the public API
+// Re-export upstream types used in the public API.
+//
+// The boundary newtypes (`OrderId`, `OrderType`, `Side`, `TimeInForce`, `Hash32`)
+// are re-exported here so downstream consumers need no direct `orderbook_rs` /
+// `pricelevel` dependency to use this crate's public surface.
 pub use orderbook_rs::{
-    CancelReason, FeeSchedule, MassCancelResult, OrderStateTracker, OrderStatus, STPMode,
-    TradeResult,
+    CancelReason, FeeSchedule, MassCancelResult, OrderId, OrderStateTracker, OrderStatus,
+    OrderType, STPMode, Side, TimeInForce, TradeResult,
 };
 pub use pricelevel::Hash32;

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -453,7 +453,7 @@ impl Default for OptionChainSequencer {
 /// use option_chain_orderbook::orderbook::{
 ///     InstrumentRegistry, SequencedUnderlyingOrderBook, SymbolIndex,
 /// };
-/// use orderbook_rs::{OrderId, Side};
+/// use option_chain_orderbook::{OrderId, Side};
 ///
 /// // 1. Create shared registry & symbol index
 /// let registry = Arc::new(InstrumentRegistry::new());

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -348,10 +348,9 @@ impl StrikeOrderBook {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::StrikeOrderBook;
+    /// use option_chain_orderbook::{Side, StrikeOrderBook};
     /// use optionstratlib::ExpirationDate;
     /// use optionstratlib::prelude::pos_or_panic;
-    /// use orderbook_rs::Side;
     ///
     /// let strike = StrikeOrderBook::new("BTC", ExpirationDate::Days(pos_or_panic!(30.0)), 50000);
     /// let result = match strike.cancel_by_side(Side::Buy) {

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -620,8 +620,7 @@ impl UnderlyingOrderBook {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::UnderlyingOrderBook;
-    /// use orderbook_rs::Side;
+    /// use option_chain_orderbook::{Side, UnderlyingOrderBook};
     ///
     /// let book = UnderlyingOrderBook::new("BTC");
     /// let result = match book.cancel_by_side(Side::Buy) {
@@ -1188,8 +1187,7 @@ impl UnderlyingOrderBookManager {
     /// # Examples
     ///
     /// ```rust,no_run
-    /// use option_chain_orderbook::orderbook::UnderlyingOrderBookManager;
-    /// use orderbook_rs::Side;
+    /// use option_chain_orderbook::{Side, UnderlyingOrderBookManager};
     ///
     /// let manager = UnderlyingOrderBookManager::new();
     /// let result = match manager.cancel_by_side_across_underlyings(Side::Buy) {


### PR DESCRIPTION
## Summary

The public surface was inconsistent: the crate root flattened ~30 peripheral subsystem types (`GreeksEngine`, `AggregatedGreeks`, `CleanupResult`, …) but NOT the primary hierarchy types (`OptionOrderBook`, `StrikeOrderBook`, `Quote`, `ValidationConfig`, `InstrumentStatus`, …), which had to be spelled `orderbook::X`. And the boundary newtypes (`OrderId`, `OrderType`, `Side`, `TimeInForce`) were not re-exported at all, forcing consumers to add a direct `orderbook_rs` dependency — contradicting the CLAUDE.md claim.

## Changes (additive, non-breaking)

- Flattened **every** public item to the crate root alongside the subsystems. Root and `orderbook::` are now **set-equal** (91 names each, programmatically verified); existing `orderbook::X` spellings keep working. `nats`/`sequencer` items gated as in `mod.rs`.
- Re-exported the four boundary newtypes from `mod.rs`: `OrderId, OrderType, Side, TimeInForce` (no `Price`/`Quantity` newtypes exist — price/qty cross the leaf as raw `u128`/`u64`).
- Documented the re-export convention in the crate docs.
- Updated 14 crate doctests to import the hierarchy + newtypes from `option_chain_orderbook` (no direct `orderbook_rs` dep) — demonstrating the acceptance criterion.

## Testing

- [x] Acceptance: a consumer can call `OptionOrderBook::add_limit_order` with `OrderId`/`Side` imported from this crate, no direct `orderbook_rs` dep (the updated doctests prove it)
- [x] Root ↔ `orderbook::` consistency verified by set-equality
- [x] `cargo test --all-features` 765 lib + 88 doctests + 5 integration, 0 fail; `clippy -D warnings`, `make pre-push` clean; `README.md` regenerated via `make readme`

## Notes

Additive (no path removed); version stays **0.5.0**. Reviewer note: root and `mod.rs` are now two parallel explicit lists kept in sync — a future export goes in both (a set-equality CI guard is a possible devops follow-up).

## Checklist

- [x] `rules/global_rules.md`; consistent re-export convention documented; no unwrap/expect/unsafe; no new deps; `README.md` regenerated

Closes #66
