### PR TITLE
fix(config): validating builders for ValidationConfig and ContractSpecs (#69)

### DIFF
--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -1640,7 +1640,11 @@ mod tests {
     fn test_manager_set_specs_propagates() {
         let manager = OptionChainOrderBookManager::new("BTC");
 
-        let specs = ContractSpecs::builder().tick_size(100).lot_size(1).build();
+        let specs = ContractSpecs::builder()
+            .tick_size(100)
+            .lot_size(1)
+            .build()
+            .expect("valid specs");
         manager.set_specs(specs);
 
         let chain = manager.get_or_create(test_expiration());
@@ -1652,7 +1656,11 @@ mod tests {
         let manager = OptionChainOrderBookManager::new("BTC");
         assert!(manager.specs().is_none());
 
-        let specs = ContractSpecs::builder().tick_size(100).lot_size(1).build();
+        let specs = ContractSpecs::builder()
+            .tick_size(100)
+            .lot_size(1)
+            .build()
+            .expect("valid specs");
         manager.set_specs(specs);
         assert!(manager.specs().is_some());
     }

--- a/src/orderbook/contract_specs.rs
+++ b/src/orderbook/contract_specs.rs
@@ -9,6 +9,7 @@
 //! by hierarchy managers to propagate specs to newly created children.
 
 use super::validation::ValidationConfig;
+use crate::error::{Error, Result};
 use serde::{Deserialize, Serialize};
 use std::sync::RwLock;
 
@@ -76,7 +77,8 @@ impl std::fmt::Display for SettlementType {
 ///     .settlement(SettlementType::Cash)
 ///     .exercise_style(ExerciseStyle::European)
 ///     .settlement_currency("USDC")
-///     .build();
+///     .build()
+///     .expect("valid contract specs");
 ///
 /// assert_eq!(specs.tick_size(), 100);
 /// assert_eq!(specs.exercise_style(), ExerciseStyle::European);
@@ -191,6 +193,56 @@ impl ContractSpecs {
             .with_min_order_size(self.min_order_size)
             .with_max_order_size(self.max_order_size)
     }
+
+    /// Validates these specifications, rejecting structurally-broken values.
+    ///
+    /// A zero tick / lot / contract / minimum size is rejected: the upstream
+    /// matching engine treats a zero tick / lot / minimum as "validation
+    /// disabled" (silently discarding an intended constraint), and a zero
+    /// contract size has no economic meaning. An inverted `[min, max]` window
+    /// is rejected because it would reject every order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ConfigurationError`] if:
+    /// - `tick_size` is zero
+    /// - `lot_size` is zero
+    /// - `contract_size` is zero
+    /// - `min_order_size` is zero
+    /// - `max_order_size < min_order_size`
+    pub fn validate(&self) -> Result<()> {
+        if self.tick_size == 0 {
+            return Err(Error::configuration(format!(
+                "tick_size must be at least 1, got {}",
+                self.tick_size
+            )));
+        }
+        if self.lot_size == 0 {
+            return Err(Error::configuration(format!(
+                "lot_size must be at least 1, got {}",
+                self.lot_size
+            )));
+        }
+        if self.contract_size == 0 {
+            return Err(Error::configuration(format!(
+                "contract_size must be at least 1, got {}",
+                self.contract_size
+            )));
+        }
+        if self.min_order_size == 0 {
+            return Err(Error::configuration(format!(
+                "min_order_size must be at least 1, got {}",
+                self.min_order_size
+            )));
+        }
+        if self.max_order_size < self.min_order_size {
+            return Err(Error::configuration(format!(
+                "max_order_size ({}) must be greater than or equal to min_order_size ({})",
+                self.max_order_size, self.min_order_size
+            )));
+        }
+        Ok(())
+    }
 }
 
 impl std::fmt::Display for ContractSpecs {
@@ -223,7 +275,8 @@ impl std::fmt::Display for ContractSpecs {
 /// let specs = ContractSpecs::builder()
 ///     .tick_size(100)
 ///     .settlement(SettlementType::Physical)
-///     .build();
+///     .build()
+///     .expect("valid contract specs");
 ///
 /// assert_eq!(specs.tick_size(), 100);
 /// assert_eq!(specs.settlement(), SettlementType::Physical);
@@ -293,10 +346,17 @@ impl ContractSpecsBuilder {
         self
     }
 
-    /// Consumes the builder and returns the constructed [`ContractSpecs`].
-    #[must_use]
-    pub fn build(self) -> ContractSpecs {
-        self.inner
+    /// Consumes the builder and returns a validated [`ContractSpecs`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ConfigurationError`]
+    /// if the assembled specs are structurally invalid (zero tick / lot /
+    /// contract / minimum size, or an inverted `[min, max]` order-size window);
+    /// see [`ContractSpecs::validate`].
+    pub fn build(self) -> Result<ContractSpecs> {
+        self.inner.validate()?;
+        Ok(self.inner)
     }
 }
 
@@ -386,7 +446,8 @@ mod tests {
             .settlement(SettlementType::Physical)
             .exercise_style(ExerciseStyle::American)
             .settlement_currency("BTC")
-            .build();
+            .build()
+            .expect("valid specs");
 
         assert_eq!(specs.tick_size(), 100);
         assert_eq!(specs.lot_size(), 10);
@@ -400,7 +461,10 @@ mod tests {
 
     #[test]
     fn test_builder_partial_override() {
-        let specs = ContractSpecs::builder().tick_size(500).build();
+        let specs = ContractSpecs::builder()
+            .tick_size(500)
+            .build()
+            .expect("valid specs");
 
         assert_eq!(specs.tick_size(), 500);
         // Rest should be defaults
@@ -417,7 +481,8 @@ mod tests {
             .lot_size(10)
             .min_order_size(5)
             .max_order_size(1000)
-            .build();
+            .build()
+            .expect("valid specs");
 
         let config = specs.to_validation_config();
         assert_eq!(config.tick_size(), Some(100));
@@ -449,7 +514,8 @@ mod tests {
             .settlement(SettlementType::Physical)
             .exercise_style(ExerciseStyle::American)
             .settlement_currency("ETH")
-            .build();
+            .build()
+            .expect("valid specs");
 
         let json = match serde_json::to_string(&specs) {
             Ok(j) => j,
@@ -484,7 +550,8 @@ mod tests {
             .settlement(SettlementType::Cash)
             .exercise_style(ExerciseStyle::European)
             .settlement_currency("USDC")
-            .build();
+            .build()
+            .expect("valid specs");
 
         let display = format!("{specs}");
         assert!(display.contains("tick=100"));
@@ -551,7 +618,8 @@ mod tests {
         let specs = ContractSpecs::builder()
             .tick_size(100)
             .settlement_currency("BTC")
-            .build();
+            .build()
+            .expect("valid specs");
         let cloned = specs.clone();
         assert_eq!(specs, cloned);
     }
@@ -565,7 +633,10 @@ mod tests {
     #[test]
     fn test_shared_contract_specs_set_get() {
         let shared = SharedContractSpecs::new();
-        let specs = ContractSpecs::builder().tick_size(100).build();
+        let specs = ContractSpecs::builder()
+            .tick_size(100)
+            .build()
+            .expect("valid specs");
         shared.set(specs.clone());
         assert_eq!(shared.get(), Some(specs));
     }
@@ -573,8 +644,18 @@ mod tests {
     #[test]
     fn test_shared_contract_specs_overwrite() {
         let shared = SharedContractSpecs::new();
-        shared.set(ContractSpecs::builder().tick_size(100).build());
-        shared.set(ContractSpecs::builder().tick_size(200).build());
+        shared.set(
+            ContractSpecs::builder()
+                .tick_size(100)
+                .build()
+                .expect("valid specs"),
+        );
+        shared.set(
+            ContractSpecs::builder()
+                .tick_size(200)
+                .build()
+                .expect("valid specs"),
+        );
         assert_eq!(shared.get().map(|s| s.tick_size()), Some(200));
     }
 
@@ -590,5 +671,88 @@ mod tests {
         let builder = ContractSpecs::builder().tick_size(100);
         let debug = format!("{builder:?}");
         assert!(debug.contains("ContractSpecsBuilder"));
+    }
+
+    // ========== ContractSpecsBuilder validation tests ==========
+
+    #[test]
+    fn test_contract_specs_builder_default_builds_ok() {
+        let result = ContractSpecs::builder().build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_contract_specs_builder_valid_builds_ok() {
+        let result = ContractSpecs::builder()
+            .tick_size(100)
+            .lot_size(1)
+            .contract_size(1)
+            .min_order_size(1)
+            .max_order_size(10_000)
+            .build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_contract_specs_builder_zero_tick_rejected() {
+        let result = ContractSpecs::builder().tick_size(0).build();
+        let err = match result {
+            Ok(_) => panic!("expected zero tick_size to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("tick_size"));
+        assert!(err.to_string().contains('0'));
+    }
+
+    #[test]
+    fn test_contract_specs_builder_zero_lot_rejected() {
+        let result = ContractSpecs::builder().lot_size(0).build();
+        let err = match result {
+            Ok(_) => panic!("expected zero lot_size to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("lot_size"));
+    }
+
+    #[test]
+    fn test_contract_specs_builder_zero_contract_size_rejected() {
+        let result = ContractSpecs::builder().contract_size(0).build();
+        let err = match result {
+            Ok(_) => panic!("expected zero contract_size to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("contract_size"));
+    }
+
+    #[test]
+    fn test_contract_specs_builder_zero_min_order_size_rejected() {
+        let result = ContractSpecs::builder().min_order_size(0).build();
+        let err = match result {
+            Ok(_) => panic!("expected zero min_order_size to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("min_order_size"));
+    }
+
+    #[test]
+    fn test_contract_specs_builder_inverted_order_size_window_rejected() {
+        let result = ContractSpecs::builder()
+            .min_order_size(100)
+            .max_order_size(10)
+            .build();
+        let err = match result {
+            Ok(_) => panic!("expected max < min to be rejected"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("max_order_size"));
+        assert!(msg.contains("10"));
+        assert!(msg.contains("100"));
+    }
+
+    #[test]
+    fn test_contract_specs_validate_default_ok() {
+        let specs = ContractSpecs::default();
+        assert!(specs.validate().is_ok());
     }
 }

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -2084,7 +2084,8 @@ mod tests {
             .settlement(SettlementType::Cash)
             .exercise_style(ExerciseStyle::European)
             .settlement_currency("USDC")
-            .build();
+            .build()
+            .expect("valid specs");
 
         book.set_specs(specs.clone());
 
@@ -2101,7 +2102,8 @@ mod tests {
             .lot_size(10)
             .min_order_size(5)
             .max_order_size(1000)
-            .build();
+            .build()
+            .expect("valid specs");
 
         book.set_specs(specs);
 
@@ -2128,7 +2130,8 @@ mod tests {
             .lot_size(10)
             .min_order_size(10)
             .max_order_size(1000)
-            .build();
+            .build()
+            .expect("valid specs");
 
         book.set_specs(specs);
 
@@ -2192,7 +2195,8 @@ mod tests {
             .settlement(SettlementType::Cash)
             .exercise_style(ExerciseStyle::European)
             .settlement_currency("USDC")
-            .build();
+            .build()
+            .expect("valid specs");
 
         btc.set_specs(specs.clone());
 
@@ -2231,7 +2235,12 @@ mod tests {
         let exp_before = book.get_or_create_expiration(ExpirationDate::Days(pos_or_panic!(30.0)));
 
         // Set specs after
-        book.set_specs(ContractSpecs::builder().tick_size(100).build());
+        book.set_specs(
+            ContractSpecs::builder()
+                .tick_size(100)
+                .build()
+                .expect("valid specs"),
+        );
 
         // Existing expiration's new strikes are NOT affected by validation
         let strike = exp_before.get_or_create_strike(50000);

--- a/src/orderbook/validation.rs
+++ b/src/orderbook/validation.rs
@@ -4,6 +4,7 @@
 //! pre-trade validation rules (tick size, lot size, min/max order size)
 //! across the option chain hierarchy.
 
+use crate::error::{Error, Result};
 use std::sync::RwLock;
 
 /// Configuration for order validation rules.
@@ -60,6 +61,14 @@ impl ValidationConfig {
     /// # Arguments
     ///
     /// * `tick_size` - Minimum price increment in smallest price units
+    ///
+    /// # Footgun
+    ///
+    /// This setter is infallible. Setting `0` does NOT disable the rule cleanly
+    /// here: the upstream matching engine treats a zero tick as "validation
+    /// disabled", so an intended constraint silently vanishes. To disable tick
+    /// validation, leave it unset (`None`); to reject a zero tick as an error,
+    /// call [`validate`](Self::validate).
     #[must_use]
     #[inline]
     pub const fn with_tick_size(mut self, tick_size: u128) -> Self {
@@ -72,6 +81,14 @@ impl ValidationConfig {
     /// # Arguments
     ///
     /// * `lot_size` - Minimum quantity increment in smallest quantity units
+    ///
+    /// # Footgun
+    ///
+    /// This setter is infallible. Setting `0` does NOT disable the rule cleanly
+    /// here: the upstream matching engine treats a zero lot as "validation
+    /// disabled", so an intended constraint silently vanishes. To disable lot
+    /// validation, leave it unset (`None`); to reject a zero lot as an error,
+    /// call [`validate`](Self::validate).
     #[must_use]
     #[inline]
     pub const fn with_lot_size(mut self, lot_size: u64) -> Self {
@@ -84,6 +101,14 @@ impl ValidationConfig {
     /// # Arguments
     ///
     /// * `min` - Minimum allowed order quantity
+    ///
+    /// # Footgun
+    ///
+    /// This setter is infallible. Setting `0` does NOT disable the rule cleanly
+    /// here: the upstream matching engine treats a zero minimum as "validation
+    /// disabled". Additionally, the minimum must not exceed the maximum (when
+    /// both are set), otherwise every order is rejected. To enforce these
+    /// invariants, call [`validate`](Self::validate).
     #[must_use]
     #[inline]
     pub const fn with_min_order_size(mut self, min: u64) -> Self {
@@ -96,6 +121,12 @@ impl ValidationConfig {
     /// # Arguments
     ///
     /// * `max` - Maximum allowed order quantity
+    ///
+    /// # Footgun
+    ///
+    /// This setter is infallible and does not check that `max >= min`. An
+    /// inverted window (`max < min`) rejects every order. Call
+    /// [`validate`](Self::validate) to reject an inverted window.
     #[must_use]
     #[inline]
     pub const fn with_max_order_size(mut self, max: u64) -> Self {
@@ -139,6 +170,49 @@ impl ValidationConfig {
             && self.lot_size.is_none()
             && self.min_order_size.is_none()
             && self.max_order_size.is_none()
+    }
+
+    /// Validates the configured rules, rejecting structurally-broken settings.
+    ///
+    /// A field left unset (`None`) means "rule disabled" and always passes — the
+    /// empty default is valid. A field explicitly set to zero is rejected,
+    /// because the upstream matching engine treats a zero tick / lot / minimum
+    /// as "validation disabled", which silently discards an intended
+    /// constraint. An inverted `[min, max]` window is rejected because it would
+    /// reject every order.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::ConfigurationError`] if:
+    /// - `tick_size` is set to zero
+    /// - `lot_size` is set to zero
+    /// - `min_order_size` is set to zero
+    /// - both `min_order_size` and `max_order_size` are set and
+    ///   `max_order_size < min_order_size`
+    pub fn validate(&self) -> Result<()> {
+        if self.tick_size == Some(0) {
+            return Err(Error::configuration(
+                "tick_size must be at least 1 (got 0); leave it unset to disable tick validation",
+            ));
+        }
+        if self.lot_size == Some(0) {
+            return Err(Error::configuration(
+                "lot_size must be at least 1 (got 0); leave it unset to disable lot validation",
+            ));
+        }
+        if self.min_order_size == Some(0) {
+            return Err(Error::configuration(
+                "min_order_size must be at least 1 (got 0); leave it unset to disable minimum-size validation",
+            ));
+        }
+        if let (Some(min), Some(max)) = (self.min_order_size, self.max_order_size)
+            && max < min
+        {
+            return Err(Error::configuration(format!(
+                "max_order_size ({max}) must be greater than or equal to min_order_size ({min})"
+            )));
+        }
+        Ok(())
     }
 }
 
@@ -335,5 +409,76 @@ mod tests {
         let shared = SharedValidationConfig::new();
         let debug = format!("{shared:?}");
         assert!(debug.contains("SharedValidationConfig"));
+    }
+
+    // ========== ValidationConfig::validate tests ==========
+
+    #[test]
+    fn test_validation_config_validate_empty_ok() {
+        let config = ValidationConfig::new();
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validation_config_validate_full_ok() {
+        let config = ValidationConfig::new()
+            .with_tick_size(100)
+            .with_lot_size(10)
+            .with_min_order_size(1)
+            .with_max_order_size(1_000_000);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validation_config_validate_zero_tick_rejected() {
+        let config = ValidationConfig::new().with_tick_size(0);
+        let err = match config.validate() {
+            Ok(()) => panic!("expected zero tick_size to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("tick_size"));
+        assert!(err.to_string().contains('0'));
+    }
+
+    #[test]
+    fn test_validation_config_validate_zero_lot_rejected() {
+        let config = ValidationConfig::new().with_lot_size(0);
+        let err = match config.validate() {
+            Ok(()) => panic!("expected zero lot_size to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("lot_size"));
+    }
+
+    #[test]
+    fn test_validation_config_validate_zero_min_rejected() {
+        let config = ValidationConfig::new().with_min_order_size(0);
+        let err = match config.validate() {
+            Ok(()) => panic!("expected zero min_order_size to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("min_order_size"));
+    }
+
+    #[test]
+    fn test_validation_config_validate_inverted_window_rejected() {
+        let config = ValidationConfig::new()
+            .with_min_order_size(100)
+            .with_max_order_size(10);
+        let err = match config.validate() {
+            Ok(()) => panic!("expected max < min to be rejected"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("max_order_size"));
+        assert!(msg.contains("10"));
+        assert!(msg.contains("100"));
+    }
+
+    #[test]
+    fn test_validation_config_validate_only_max_set_ok() {
+        // A max with no min is a valid one-sided window.
+        let config = ValidationConfig::new().with_max_order_size(500);
+        assert!(config.validate().is_ok());
     }
 }


### PR DESCRIPTION
## Summary

Both config builders were infallible and could silently produce structurally-invalid configs: `tick_size(0)`/`lot_size(0)` (upstream treats zero as "validation disabled", so an intended constraint vanishes), `max_order_size < min_order_size` (then rejects every order), and zero min/contract size. A quietly-broken trading instrument was producible with no error.

## Changes

- `ValidationConfig::validate(&self) -> Result<()>` — rejects (only for explicitly-set fields) `tick_size == 0`, `lot_size == 0`, `min_order_size == 0`, and an inverted `max < min` window. Empty default and one-sided windows still pass. The infallible `with_*` setters now carry a `# Footgun` note (zero disables the rule; `min <= max` required).
- `ContractSpecs::validate(&self) -> Result<()>` — rejects zero `tick`/`lot`/`contract_size`/`min_order_size` and `max < min`; `default()` (permissive) still validates.
- `ContractSpecsBuilder::build() -> Result<ContractSpecs, Error>` (was infallible) — calls `validate()`, matching `StrikeRangeConfigBuilder::build`. All rejections use `Error::configuration` with the offending value.

## Public API impact (breaking, absorbed under 0.5.0)

`ContractSpecsBuilder::build()` returns `Result` now. No in-repo production caller builds `ContractSpecs` (the hierarchy consumes already-built specs via `set_specs`); the 17 updated call sites are tests/doctests. `ValidationConfig` setters stay infallible (`validate()` is opt-in). Version stays **0.5.0**; `README.md` unchanged.

## Testing

- [x] ValidationConfig: zero tick/lot/min rejected, inverted window rejected, empty/one-sided OK
- [x] ContractSpecs/Builder: zero tick/lot/contract/min rejected, inverted window rejected, default + valid build OK
- [x] `cargo test --all-features` 780+5+88, 0 fail; `clippy -D warnings`, `make pre-push` clean

## Checklist

- [x] `rules/global_rules.md`: validating builder returns `Result`; typed error with offending value; no unwrap/expect/unsafe in prod; no new deps

Closes #69
