### PR TITLE
fix(instrument_status): enforce the documented transition state machine (#71)

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -160,6 +160,26 @@ pub enum Error {
         status: InstrumentStatus,
     },
 
+    /// Error when an instrument status transition violates the enforced
+    /// lifecycle state machine.
+    ///
+    /// Returned by [`OptionOrderBook::set_status`](crate::orderbook::OptionOrderBook::set_status),
+    /// [`halt`](crate::orderbook::OptionOrderBook::halt),
+    /// [`resume`](crate::orderbook::OptionOrderBook::resume), and
+    /// [`expire`](crate::orderbook::OptionOrderBook::expire) when the requested
+    /// target status is not reachable from the current status (e.g. resuming an
+    /// [`Expired`](InstrumentStatus::Expired) book, or pulling a
+    /// [`Settling`](InstrumentStatus::Settling) book back to
+    /// [`Halted`](InstrumentStatus::Halted)). The legal edges are documented on
+    /// [`InstrumentStatus`]. The current status is left unchanged.
+    #[error("illegal status transition: {from} -> {to}")]
+    IllegalStatusTransition {
+        /// The current status the transition was attempted from.
+        from: InstrumentStatus,
+        /// The target status that was rejected.
+        to: InstrumentStatus,
+    },
+
     /// Error when serialization/deserialization fails.
     #[error("serialization error: {0}")]
     SerializationError(#[from] serde_json::Error),
@@ -385,6 +405,16 @@ impl Error {
         }
     }
 
+    /// Creates a new illegal status transition error.
+    ///
+    /// Returned when a requested instrument-status change is not a legal edge in
+    /// the enforced lifecycle state machine documented on [`InstrumentStatus`].
+    #[must_use]
+    #[cold]
+    pub fn illegal_status_transition(from: InstrumentStatus, to: InstrumentStatus) -> Self {
+        Self::IllegalStatusTransition { from, to }
+    }
+
     /// Creates a new decimal error.
     #[must_use]
     pub fn decimal(message: impl Into<String>) -> Self {
@@ -590,6 +620,23 @@ mod tests {
         assert!(msg.contains("BTC-20240329-50000-C"));
         assert!(msg.contains("Halted"));
         assert!(msg.contains("instrument not active"));
+    }
+
+    #[test]
+    fn test_illegal_status_transition_error() {
+        let err =
+            Error::illegal_status_transition(InstrumentStatus::Expired, InstrumentStatus::Active);
+        let msg = err.to_string();
+        assert!(msg.contains("illegal status transition"));
+        assert!(msg.contains("Expired"));
+        assert!(msg.contains("Active"));
+        assert!(matches!(
+            err,
+            Error::IllegalStatusTransition {
+                from: InstrumentStatus::Expired,
+                to: InstrumentStatus::Active,
+            }
+        ));
     }
 
     #[test]

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -7,6 +7,7 @@ use super::instrument_status::InstrumentStatus;
 use super::quote::Quote;
 use super::validation::ValidationConfig;
 use crate::Result;
+use crate::error::Error;
 use optionstratlib::OptionStyle;
 #[cfg(feature = "nats")]
 use orderbook_rs::PriceLevelChangedListener;
@@ -575,23 +576,60 @@ impl OptionOrderBook {
         InstrumentStatus::from_u8(raw).unwrap_or(InstrumentStatus::Halted)
     }
 
-    /// Sets the lifecycle status of this instrument.
+    /// Stores the lifecycle status without validating the transition.
     ///
-    /// # Arguments
-    ///
-    /// * `status` - The new status to set
+    /// Internal raw setter used by the validated [`set_status`](Self::set_status)
+    /// path *after* the transition has been checked against the enforced
+    /// lifecycle state machine. It bypasses that check, so callers are
+    /// responsible for legality.
     #[inline]
-    pub fn set_status(&self, status: InstrumentStatus) {
+    fn store_status(&self, status: InstrumentStatus) {
         self.status.store(status as u8, Ordering::Release);
     }
 
-    /// Atomically compares and sets the lifecycle status.
+    /// Sets the lifecycle status of this instrument, enforcing the lifecycle
+    /// state machine.
     ///
-    /// If the current status equals `expected`, sets it to `new` and returns `true`.
-    /// Otherwise, leaves the status unchanged and returns `false`.
+    /// The transition from the current status to `status` must be a legal edge
+    /// in the state machine documented on [`InstrumentStatus`]. A self-transition
+    /// (`X -> X`) is a legal no-op. Any illegal transition (e.g. reactivating an
+    /// [`Expired`](InstrumentStatus::Expired) book, or pulling a
+    /// [`Settling`](InstrumentStatus::Settling) book back to
+    /// [`Halted`](InstrumentStatus::Halted)) leaves the status unchanged.
     ///
-    /// This provides a thread-safe way to advance status without race conditions,
-    /// ensuring monotonic status progression under concurrent access.
+    /// # Arguments
+    ///
+    /// * `status` - The target status to transition to
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::IllegalStatusTransition`]
+    /// if the current status cannot legally transition to `status`.
+    #[inline]
+    pub fn set_status(&self, status: InstrumentStatus) -> Result<()> {
+        let current = self.status();
+        if !current.can_transition(status) {
+            return Err(Error::illegal_status_transition(current, status));
+        }
+        self.store_status(status);
+        Ok(())
+    }
+
+    /// Atomically compares and sets the lifecycle status, validating the target.
+    ///
+    /// If the current status equals `expected` **and** `expected -> new` is a
+    /// legal edge in the lifecycle state machine, sets the status to `new` and
+    /// returns `true`. Otherwise — either the current status differs from
+    /// `expected`, or the transition is illegal — leaves the status unchanged
+    /// and returns `false`.
+    ///
+    /// This provides a thread-safe way to advance status without race
+    /// conditions, ensuring monotonic status progression under concurrent
+    /// access. The expiry lifecycle's CAS-forward setter drives every chain book
+    /// through this method; its only requested edges
+    /// (`{Pending, Active, Halted} -> Settling` and
+    /// `{Pending, Active, Halted, Settling} -> Expired`) are all legal, so the
+    /// added validation never changes its behavior.
     ///
     /// # Arguments
     ///
@@ -600,7 +638,8 @@ impl OptionOrderBook {
     ///
     /// # Returns
     ///
-    /// `true` if the swap succeeded, `false` otherwise.
+    /// `true` if the swap succeeded, `false` otherwise (lost race or illegal
+    /// transition).
     #[inline]
     #[must_use]
     pub fn compare_and_set_status(
@@ -608,6 +647,11 @@ impl OptionOrderBook {
         expected: InstrumentStatus,
         new: InstrumentStatus,
     ) -> bool {
+        // Reject targets that are not a legal edge from `expected`, so a CAS can
+        // never be used to force an illegal transition (e.g. Expired -> Active).
+        if !expected.can_transition(new) {
+            return false;
+        }
         self.status
             .compare_exchange(
                 expected as u8,
@@ -621,16 +665,38 @@ impl OptionOrderBook {
     /// Halts the instrument, preventing new orders from being accepted.
     ///
     /// Existing resting orders are not cancelled. Use [`expire`](Self::expire)
-    /// to both halt and cancel all orders.
+    /// to both halt and cancel all orders. Halting is only legal from
+    /// [`Active`](InstrumentStatus::Active) (or the idempotent `Halted -> Halted`
+    /// no-op).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::IllegalStatusTransition`]
+    /// if the instrument cannot legally transition to
+    /// [`Halted`](InstrumentStatus::Halted) from its current status (e.g. it is
+    /// already [`Settling`](InstrumentStatus::Settling) or
+    /// [`Expired`](InstrumentStatus::Expired)).
     #[inline]
-    pub fn halt(&self) {
-        self.set_status(InstrumentStatus::Halted);
+    pub fn halt(&self) -> Result<()> {
+        self.set_status(InstrumentStatus::Halted)
     }
 
     /// Resumes the instrument, allowing new orders to be accepted.
+    ///
+    /// Resuming is legal from [`Halted`](InstrumentStatus::Halted) (the resume
+    /// edge) or [`Pending`](InstrumentStatus::Pending) (activation), plus the
+    /// idempotent `Active -> Active` no-op.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::IllegalStatusTransition`]
+    /// if the instrument cannot legally transition to
+    /// [`Active`](InstrumentStatus::Active) from its current status (e.g. it is
+    /// [`Settling`](InstrumentStatus::Settling) or
+    /// [`Expired`](InstrumentStatus::Expired)).
     #[inline]
-    pub fn resume(&self) {
-        self.set_status(InstrumentStatus::Active);
+    pub fn resume(&self) -> Result<()> {
+        self.set_status(InstrumentStatus::Active)
     }
 
     /// Expires the instrument, cancelling all resting orders.
@@ -644,12 +710,24 @@ impl OptionOrderBook {
     /// reset. The status is set first so the book stops accepting new orders
     /// before the sweep runs.
     ///
+    /// Expiry is a terminal sweep: it is a legal transition from every
+    /// non-terminal status and an idempotent no-op from
+    /// [`Expired`](InstrumentStatus::Expired), so in practice it always
+    /// succeeds. The orders are only swept once the transition is accepted.
+    ///
     /// # Returns
     ///
     /// A vector of order IDs that were cancelled, in engine processing order.
-    pub fn expire(&self) -> Vec<OrderId> {
-        self.set_status(InstrumentStatus::Expired);
-        self.book.cancel_all_orders().cancelled_order_ids().to_vec()
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::IllegalStatusTransition`]
+    /// if the current status cannot legally transition to
+    /// [`Expired`](InstrumentStatus::Expired). No orders are swept when the
+    /// transition is rejected.
+    pub fn expire(&self) -> Result<Vec<OrderId>> {
+        self.set_status(InstrumentStatus::Expired)?;
+        Ok(self.book.cancel_all_orders().cancelled_order_ids().to_vec())
     }
 
     /// Checks that the instrument is accepting orders, returning an error if not.
@@ -2091,19 +2169,105 @@ mod tests {
     }
 
     #[test]
-    fn test_set_status_and_get() {
+    fn test_set_status_walks_legal_path_and_get() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
 
-        for &status in &[
-            InstrumentStatus::Pending,
-            InstrumentStatus::Active,
-            InstrumentStatus::Halted,
-            InstrumentStatus::Settling,
-            InstrumentStatus::Expired,
-        ] {
-            book.set_status(status);
-            assert_eq!(book.status(), status);
-        }
+        // Active (default) -> Halted -> Active (resume) -> Settling -> Expired.
+        book.set_status(InstrumentStatus::Halted)
+            .expect("Active -> Halted is legal");
+        assert_eq!(book.status(), InstrumentStatus::Halted);
+
+        book.set_status(InstrumentStatus::Active)
+            .expect("Halted -> Active is legal");
+        assert_eq!(book.status(), InstrumentStatus::Active);
+
+        book.set_status(InstrumentStatus::Settling)
+            .expect("Active -> Settling is legal");
+        assert_eq!(book.status(), InstrumentStatus::Settling);
+
+        book.set_status(InstrumentStatus::Expired)
+            .expect("Settling -> Expired is legal");
+        assert_eq!(book.status(), InstrumentStatus::Expired);
+    }
+
+    #[test]
+    fn test_set_status_active_to_settling_succeeds() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        assert!(book.set_status(InstrumentStatus::Settling).is_ok());
+        assert_eq!(book.status(), InstrumentStatus::Settling);
+    }
+
+    #[test]
+    fn test_set_status_settling_to_expired_succeeds() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.set_status(InstrumentStatus::Settling)
+            .expect("Active -> Settling is legal");
+        assert!(book.set_status(InstrumentStatus::Expired).is_ok());
+        assert_eq!(book.status(), InstrumentStatus::Expired);
+    }
+
+    #[test]
+    fn test_set_status_self_transition_is_legal_noop() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        // Active -> Active is an idempotent no-op.
+        assert!(book.set_status(InstrumentStatus::Active).is_ok());
+        assert_eq!(book.status(), InstrumentStatus::Active);
+
+        // Settling -> Settling stays Settling (repeated lifecycle ticks).
+        book.set_status(InstrumentStatus::Settling)
+            .expect("Active -> Settling is legal");
+        assert!(book.set_status(InstrumentStatus::Settling).is_ok());
+        assert_eq!(book.status(), InstrumentStatus::Settling);
+    }
+
+    #[test]
+    fn test_set_status_expired_to_active_rejected() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.expire().expect("Active -> Expired is legal");
+
+        let err = book.set_status(InstrumentStatus::Active);
+        assert!(matches!(
+            err,
+            Err(Error::IllegalStatusTransition {
+                from: InstrumentStatus::Expired,
+                to: InstrumentStatus::Active,
+            })
+        ));
+        // Status is unchanged on rejection.
+        assert_eq!(book.status(), InstrumentStatus::Expired);
+    }
+
+    #[test]
+    fn test_set_status_expired_to_halted_rejected() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.expire().expect("Active -> Expired is legal");
+
+        let err = book.set_status(InstrumentStatus::Halted);
+        assert!(matches!(
+            err,
+            Err(Error::IllegalStatusTransition {
+                from: InstrumentStatus::Expired,
+                to: InstrumentStatus::Halted,
+            })
+        ));
+        assert_eq!(book.status(), InstrumentStatus::Expired);
+    }
+
+    #[test]
+    fn test_set_status_settling_to_halted_rejected() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.set_status(InstrumentStatus::Settling)
+            .expect("Active -> Settling is legal");
+
+        let err = book.set_status(InstrumentStatus::Halted);
+        assert!(matches!(
+            err,
+            Err(Error::IllegalStatusTransition {
+                from: InstrumentStatus::Settling,
+                to: InstrumentStatus::Halted,
+            })
+        ));
+        assert_eq!(book.status(), InstrumentStatus::Settling);
     }
 
     #[test]
@@ -2111,18 +2275,76 @@ mod tests {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
         assert_eq!(book.status(), InstrumentStatus::Active);
 
-        book.halt();
+        book.halt().expect("Active -> Halted is legal");
         assert_eq!(book.status(), InstrumentStatus::Halted);
+    }
+
+    #[test]
+    fn test_halt_settling_rejected() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.set_status(InstrumentStatus::Settling)
+            .expect("Active -> Settling is legal");
+
+        let err = book.halt();
+        assert!(matches!(
+            err,
+            Err(Error::IllegalStatusTransition {
+                from: InstrumentStatus::Settling,
+                to: InstrumentStatus::Halted,
+            })
+        ));
+        assert_eq!(book.status(), InstrumentStatus::Settling);
     }
 
     #[test]
     fn test_resume_sets_active() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-        book.halt();
+        book.halt().expect("Active -> Halted is legal");
         assert_eq!(book.status(), InstrumentStatus::Halted);
 
-        book.resume();
+        book.resume().expect("Halted -> Active is legal (resume)");
         assert_eq!(book.status(), InstrumentStatus::Active);
+    }
+
+    #[test]
+    fn test_resume_halted_to_active_succeeds() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.halt().expect("Active -> Halted is legal");
+        assert!(book.resume().is_ok());
+        assert_eq!(book.status(), InstrumentStatus::Active);
+    }
+
+    #[test]
+    fn test_resume_expired_rejected() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.expire().expect("Active -> Expired is legal");
+
+        let err = book.resume();
+        assert!(matches!(
+            err,
+            Err(Error::IllegalStatusTransition {
+                from: InstrumentStatus::Expired,
+                to: InstrumentStatus::Active,
+            })
+        ));
+        assert_eq!(book.status(), InstrumentStatus::Expired);
+    }
+
+    #[test]
+    fn test_compare_and_set_status_allows_legal_forward() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        assert!(book.compare_and_set_status(InstrumentStatus::Active, InstrumentStatus::Settling,));
+        assert_eq!(book.status(), InstrumentStatus::Settling);
+    }
+
+    #[test]
+    fn test_compare_and_set_status_rejects_illegal_target() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.expire().expect("Active -> Expired is legal");
+
+        // Expired -> Active is illegal: the CAS reports failure (no swap).
+        assert!(!book.compare_and_set_status(InstrumentStatus::Expired, InstrumentStatus::Active,));
+        assert_eq!(book.status(), InstrumentStatus::Expired);
     }
 
     #[test]
@@ -2139,7 +2361,7 @@ mod tests {
         }
         assert_eq!(book.order_count(), 2);
 
-        let cancelled = book.expire();
+        let cancelled = book.expire().expect("Active -> Expired is legal");
         assert_eq!(book.status(), InstrumentStatus::Expired);
         assert!(book.is_empty());
         assert_eq!(cancelled.len(), 2);
@@ -2150,7 +2372,7 @@ mod tests {
     #[test]
     fn test_expire_on_empty_book() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-        let cancelled = book.expire();
+        let cancelled = book.expire().expect("Active -> Expired is legal");
         assert_eq!(book.status(), InstrumentStatus::Expired);
         assert!(cancelled.is_empty());
     }
@@ -2166,7 +2388,7 @@ mod tests {
             .expect("add ask");
         assert_eq!(book.active_order_count(), 2);
 
-        let cancelled = book.expire();
+        let cancelled = book.expire().expect("Active -> Expired is legal");
 
         // All resting orders cancelled and transitioned to a terminal state.
         assert_eq!(cancelled.len(), 2);
@@ -2195,7 +2417,7 @@ mod tests {
     #[test]
     fn test_order_rejected_when_halted() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-        book.halt();
+        book.halt().expect("Active -> Halted is legal");
 
         let result = book.add_limit_order(OrderId::new(), Side::Buy, 100, 10);
         assert!(result.is_err());
@@ -2210,7 +2432,10 @@ mod tests {
     #[test]
     fn test_order_rejected_when_pending() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-        book.set_status(InstrumentStatus::Pending);
+        // Pending is the initial lifecycle state; books default to Active and no
+        // legal edge targets Pending, so seed it with the raw (unvalidated)
+        // setter to exercise the order-rejection path.
+        book.store_status(InstrumentStatus::Pending);
 
         let result = book.add_limit_order(OrderId::new(), Side::Buy, 100, 10);
         assert!(result.is_err());
@@ -2224,7 +2449,8 @@ mod tests {
     #[test]
     fn test_order_rejected_when_settling() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-        book.set_status(InstrumentStatus::Settling);
+        book.set_status(InstrumentStatus::Settling)
+            .expect("Active -> Settling is legal");
 
         let result = book.add_limit_order(OrderId::new(), Side::Buy, 100, 10);
         assert!(result.is_err());
@@ -2238,7 +2464,8 @@ mod tests {
     #[test]
     fn test_order_rejected_when_expired() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-        book.set_status(InstrumentStatus::Expired);
+        book.set_status(InstrumentStatus::Expired)
+            .expect("Active -> Expired is legal");
 
         let result = book.add_limit_order(OrderId::new(), Side::Buy, 100, 10);
         assert!(result.is_err());
@@ -2252,7 +2479,7 @@ mod tests {
     #[test]
     fn test_order_rejected_with_tif_when_not_active() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-        book.halt();
+        book.halt().expect("Active -> Halted is legal");
 
         let result =
             book.add_limit_order_with_tif(OrderId::new(), Side::Buy, 100, 10, TimeInForce::Gtc);
@@ -2268,13 +2495,13 @@ mod tests {
     fn test_orders_accepted_after_resume() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
 
-        book.halt();
+        book.halt().expect("Active -> Halted is legal");
         assert!(
             book.add_limit_order(OrderId::new(), Side::Buy, 100, 10)
                 .is_err()
         );
 
-        book.resume();
+        book.resume().expect("Halted -> Active is legal (resume)");
         assert!(
             book.add_limit_order(OrderId::new(), Side::Buy, 100, 10)
                 .is_ok()
@@ -2290,7 +2517,7 @@ mod tests {
         }
         assert_eq!(book.order_count(), 1);
 
-        book.halt();
+        book.halt().expect("Active -> Halted is legal");
         // Existing orders remain
         assert_eq!(book.order_count(), 1);
         assert_eq!(book.best_bid(), Some(100));
@@ -2304,7 +2531,7 @@ mod tests {
         if let Err(err) = book.add_limit_order(oid, Side::Buy, 100, 10) {
             panic!("add order failed: {}", err);
         }
-        book.halt();
+        book.halt().expect("Active -> Halted is legal");
 
         // Cancellation should still work on halted instruments
         let cancelled = match book.cancel_order(oid) {
@@ -2557,7 +2784,7 @@ mod tests {
     #[test]
     fn test_add_limit_order_with_user_rejected_when_halted() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-        book.halt();
+        book.halt().expect("Active -> Halted is legal");
         let user = Hash32::from([1u8; 32]);
         let result = book.add_limit_order_with_user(OrderId::new(), Side::Buy, 100, 10, user);
         assert!(result.is_err());
@@ -2782,7 +3009,7 @@ mod tests {
     #[test]
     fn test_full_method_rejected_when_halted() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-        book.halt();
+        book.halt().expect("Active -> Halted is legal");
         let result = book.add_limit_order_full(OrderId::new(), Side::Buy, 100, 10);
         assert!(result.is_err());
     }

--- a/src/orderbook/expiry_lifecycle.rs
+++ b/src/orderbook/expiry_lifecycle.rs
@@ -778,6 +778,42 @@ mod tests {
         assert_eq!(underlying.expirations().len(), 0);
     }
 
+    // ── test_set_all_book_status_legal_forward_edges_succeed ─────────────
+
+    // Issue #71 guard: the lifecycle's CAS-forward setter advances books via
+    // `compare_and_set_status`, which now validates the target against the
+    // enforced state machine. Every per-book edge it requests
+    // (Active -> Settling, Settling -> Expired) must remain legal so the
+    // forward-advance is never blocked by the new validation.
+    #[test]
+    fn test_set_all_book_status_legal_forward_edges_succeed() {
+        let exp = fixed_expiration(2026, 3, 10);
+        let underlying = setup_underlying_with_orders(exp);
+        let exp_book = underlying.expirations().get(&exp).unwrap();
+
+        // Active -> Settling for every call and put book.
+        set_all_book_status(exp_book.chain(), InstrumentStatus::Settling);
+        for entry in exp_book.chain().strikes().iter() {
+            assert_eq!(entry.value().call().status(), InstrumentStatus::Settling);
+            assert_eq!(entry.value().put().status(), InstrumentStatus::Settling);
+        }
+
+        // Settling -> Expired for every call and put book.
+        set_all_book_status(exp_book.chain(), InstrumentStatus::Expired);
+        for entry in exp_book.chain().strikes().iter() {
+            assert_eq!(entry.value().call().status(), InstrumentStatus::Expired);
+            assert_eq!(entry.value().put().status(), InstrumentStatus::Expired);
+        }
+
+        // The terminal Expired state is now sticky: a further forward request is
+        // an idempotent no-op (Expired -> Expired) and never regresses.
+        set_all_book_status(exp_book.chain(), InstrumentStatus::Expired);
+        for entry in exp_book.chain().strikes().iter() {
+            assert_eq!(entry.value().call().status(), InstrumentStatus::Expired);
+            assert_eq!(entry.value().put().status(), InstrumentStatus::Expired);
+        }
+    }
+
     // ── test_no_transition_before_expiry ─────────────────────────────────
 
     #[test]

--- a/src/orderbook/instrument_status.rs
+++ b/src/orderbook/instrument_status.rs
@@ -13,11 +13,40 @@ use serde::{Deserialize, Serialize};
 ///
 /// ## State Transitions
 ///
+/// The lifecycle is enforced: only the edges below are legal, checked by
+/// [`can_transition`](InstrumentStatus::can_transition). Any other transition is
+/// rejected with
+/// [`Error::IllegalStatusTransition`](crate::error::Error::IllegalStatusTransition).
+/// A self-transition (`X -> X`) is always a legal no-op so repeated lifecycle
+/// ticks stay idempotent.
+///
 /// ```text
-/// Pending → Active → Halted → Active (resume)
-///                  → Settling → Expired
-///                  → Expired (direct)
+///                  ┌──── resume ────┐
+///                  ▼                │
+/// Pending ──────► Active ───────► Halted
+///   │  │            │  │            │
+///   │  │ halt/      │  │ settle     │ settle
+///   │  └────────────┘  ▼            ▼
+///   │                Settling ──► Expired (terminal)
+///   └───────────────────────────► Expired
 /// ```
+///
+/// Legal edges:
+/// - `Pending -> Active` (activation)
+/// - `Pending -> Settling`, `Pending -> Expired` (lifecycle catch-up / expiry)
+/// - `Active -> Halted` (halt), `Active -> Settling`, `Active -> Expired`
+/// - `Halted -> Active` (resume), `Halted -> Settling`, `Halted -> Expired`
+/// - `Settling -> Expired`
+/// - `X -> X` (idempotent no-op)
+///
+/// [`Expired`](InstrumentStatus::Expired) is terminal: it has no outgoing edges
+/// other than the `Expired -> Expired` no-op. The transitions rejected by design
+/// include every `Expired -> *` move, `Settling -> Halted`, `Settling -> Active`,
+/// and any move back to `Pending`.
+///
+/// The forward edges (everything except `Halted -> Active`) advance the
+/// discriminant monotonically, which keeps them in lock-step with the expiry
+/// lifecycle's CAS-forward setter and the `min`-based chain-status read.
 ///
 /// ## Thread Safety
 ///
@@ -66,6 +95,51 @@ impl InstrumentStatus {
     #[inline]
     pub const fn is_accepting_orders(&self) -> bool {
         matches!(self, Self::Active)
+    }
+
+    /// Returns `true` if transitioning from `self` to `to` is a legal edge in
+    /// the enforced lifecycle state machine.
+    ///
+    /// A self-transition (`X -> X`) is always permitted as an idempotent no-op,
+    /// so repeated lifecycle ticks remain idempotent.
+    /// [`Expired`](Self::Expired) is terminal and has no outgoing edges other
+    /// than the `Expired -> Expired` no-op.
+    ///
+    /// The full set of legal edges is documented on the [`InstrumentStatus`]
+    /// type. This is the single source of truth that
+    /// [`OptionOrderBook::set_status`](super::book::OptionOrderBook::set_status),
+    /// `halt`, `resume`, `expire`, and `compare_and_set_status` validate
+    /// against. Every transition the expiry lifecycle performs through its
+    /// CAS-forward setter — `{Pending, Active, Halted} -> Settling` and
+    /// `{Pending, Active, Halted, Settling} -> Expired` — is included here, so
+    /// enforcing the state machine never blocks the lifecycle.
+    ///
+    /// # Arguments
+    ///
+    /// * `to` - The target status to transition to
+    #[must_use]
+    #[inline]
+    pub const fn can_transition(self, to: Self) -> bool {
+        // Idempotent self-transition is always a legal no-op.
+        if self as u8 == to as u8 {
+            return true;
+        }
+        matches!(
+            (self, to),
+            // Activation / resume.
+            (Self::Pending, Self::Active) | (Self::Halted, Self::Active)
+            // Halt of a live instrument.
+            | (Self::Active, Self::Halted)
+            // Settlement entry (lifecycle forward-advance).
+            | (Self::Pending, Self::Settling)
+            | (Self::Active, Self::Settling)
+            | (Self::Halted, Self::Settling)
+            // Expiry (terminal sweep, reachable from any live state).
+            | (Self::Pending, Self::Expired)
+            | (Self::Active, Self::Expired)
+            | (Self::Halted, Self::Expired)
+            | (Self::Settling, Self::Expired)
+        )
     }
 }
 
@@ -210,5 +284,84 @@ mod tests {
         assert_eq!(InstrumentStatus::Halted as u8, 2);
         assert_eq!(InstrumentStatus::Settling as u8, 3);
         assert_eq!(InstrumentStatus::Expired as u8, 4);
+    }
+
+    #[test]
+    fn test_can_transition_self_is_legal_noop() {
+        for &status in &[
+            InstrumentStatus::Pending,
+            InstrumentStatus::Active,
+            InstrumentStatus::Halted,
+            InstrumentStatus::Settling,
+            InstrumentStatus::Expired,
+        ] {
+            assert!(
+                status.can_transition(status),
+                "self-transition {status} -> {status} must be a legal no-op",
+            );
+        }
+    }
+
+    #[test]
+    fn test_can_transition_legal_edges_allowed() {
+        use InstrumentStatus::*;
+        let legal = [
+            (Pending, Active),
+            (Pending, Settling),
+            (Pending, Expired),
+            (Active, Halted),
+            (Active, Settling),
+            (Active, Expired),
+            (Halted, Active),
+            (Halted, Settling),
+            (Halted, Expired),
+            (Settling, Expired),
+        ];
+        for (from, to) in legal {
+            assert!(from.can_transition(to), "{from} -> {to} must be legal",);
+        }
+    }
+
+    #[test]
+    fn test_can_transition_expired_is_terminal() {
+        use InstrumentStatus::*;
+        for to in [Pending, Active, Halted, Settling] {
+            assert!(
+                !Expired.can_transition(to),
+                "Expired -> {to} must be rejected (terminal state)",
+            );
+        }
+    }
+
+    #[test]
+    fn test_can_transition_settling_backward_rejected() {
+        use InstrumentStatus::*;
+        assert!(!Settling.can_transition(Halted));
+        assert!(!Settling.can_transition(Active));
+        assert!(!Settling.can_transition(Pending));
+    }
+
+    #[test]
+    fn test_can_transition_back_to_pending_rejected() {
+        use InstrumentStatus::*;
+        for from in [Active, Halted, Settling, Expired] {
+            assert!(
+                !from.can_transition(Pending),
+                "{from} -> Pending must be rejected",
+            );
+        }
+    }
+
+    #[test]
+    fn test_can_transition_lifecycle_forward_edges_all_legal() {
+        // Every per-book edge the expiry lifecycle's CAS-forward setter can
+        // request must be legal so enforcing the state machine never blocks it.
+        use InstrumentStatus::*;
+        for from in [Pending, Active, Halted] {
+            assert!(from.can_transition(Settling), "{from} -> Settling");
+        }
+        for from in [Pending, Active, Halted, Settling] {
+            assert!(from.can_transition(Expired), "{from} -> Expired");
+        }
     }
 }


### PR DESCRIPTION
## Summary

`instrument_status.rs` documented a transition diagram (`Pending -> Active -> Halted/Settling -> Expired`) but `set_status`/`compare_and_set_status`/`halt`/`resume`/`expire` stored ANY status with no validation — so `resume()` reactivated an `Expired` book and `halt()` could pull a `Settling`/`Expired` book back to `Halted`, with no typed error.

## Changes

- `InstrumentStatus::can_transition(self, to) -> bool` encoding the legal edges: self-transition is an idempotent no-op; `Pending/Active/Halted -> Settling`, `* -> Expired` (from any live state), `Active -> Halted`, `Halted -> Active` (the only legal backward edge); `Expired` is terminal; back-to-`Pending` and `Settling -> Halted/Active` rejected.
- Typed `Error::IllegalStatusTransition { from, to }` (`#[cold]`).
- `set_status`/`halt`/`resume` → `Result<()>`, `expire` → `Result<Vec<OrderId>>` (route through the guard; status set before the expiry sweep). `compare_and_set_status` keeps `-> bool` but guards the target.

## Coordination with #61 (verified)

The expiry lifecycle never calls halt/resume/expire/set_status — it only advances via `set_all_book_status`'s CAS-forward loop (`compare_and_set_status`, gated `if current >= status break`), invoked with `Settling`/`Expired`. Every per-book edge it requests (`{Pending,Active,Halted} -> Settling`, `{…,Settling} -> Expired`) is in the legal set, so the guard never blocks the lifecycle and #61's min-based `chain_status` is untouched. `test_full_lifecycle` (end-to-end) still passes; added `test_set_all_book_status_legal_forward_edges_succeed`.

## Public API impact (breaking, absorbed under 0.5.0)

`set_status`/`halt`/`resume`/`expire` return type → `Result`. All callers are in-crate. Version stays **0.5.0**; README unchanged.

## Testing

- [x] Illegal edges rejected: `Expired->Active`, `Expired->Halted`, `Settling->Halted`, back-to-`Pending`; legal edges succeed; self-transition is a legal no-op
- [x] Lifecycle settle/expire end-to-end still green
- [x] `cargo test --all-features` 800+5+88, 0 fail; `clippy -D warnings`, `make pre-push` clean

## Checklist

- [x] `rules/global_rules.md`: typed error for illegal transition; documented state machine; no unwrap/expect/unsafe; no new deps

Closes #71
