### PR TITLE
fix(expiry_scheduler): derive is_new from the atomic get-or-create result (#72)

### DIFF
--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -729,9 +729,39 @@ impl ExpirationOrderBookManager {
     /// (instrument IDs and symbol-index entries are only allocated lazily at
     /// strike creation), so a dropped loser leaks nothing.
     pub fn get_or_create(&self, expiration: ExpirationDate) -> Arc<ExpirationOrderBook> {
+        self.get_or_create_inserted(expiration).0
+    }
+
+    /// Gets or creates an expiration order book, reporting whether this call
+    /// performed the insertion.
+    ///
+    /// Returns `(book, inserted)` where `inserted` is `true` for exactly one
+    /// caller across all concurrent callers for a given expiration — the one
+    /// whose freshly built book actually won the atomic
+    /// [`SkipMap::get_or_insert`] publish. Every other caller (including the
+    /// fast path that observes a pre-existing entry, and concurrent race losers
+    /// whose fresh book is dropped) receives `inserted == false`. The returned
+    /// `book` is always the single winning handle.
+    ///
+    /// The `inserted` bit is the canonical signal for "this expiration was
+    /// genuinely created now" — callers must NOT re-probe with
+    /// [`get`](Self::get) to decide newness, because a separate probe reopens a
+    /// check-then-act race that double-counts a date under concurrency.
+    ///
+    /// # Concurrency
+    ///
+    /// Identical guarantees to [`get_or_create`](Self::get_or_create): atomic,
+    /// idempotent, lock-free. The winner is detected via
+    /// [`Arc::ptr_eq`] against the locally built handle, so the `inserted` flag
+    /// is derived purely from the atomic insert result with no extra map probe.
+    #[must_use]
+    pub fn get_or_create_inserted(
+        &self,
+        expiration: ExpirationDate,
+    ) -> (Arc<ExpirationOrderBook>, bool) {
         let key = ExpirationKey::from(&expiration);
         if let Some(entry) = self.expirations.get(&key) {
-            return Arc::clone(entry.value());
+            return (Arc::clone(entry.value()), false);
         }
         // Build and fully configure the fresh book BEFORE publishing it, so the
         // winning book is configured-before-visible. Configuration only mutates
@@ -764,9 +794,15 @@ impl ExpirationOrderBookManager {
         if let Some(schedule) = self.fee_schedule.get() {
             fresh.set_fee_schedule(schedule);
         }
+        // Keep a handle to the locally built book so we can identify whether it
+        // won the race after the atomic publish.
+        let candidate = Arc::clone(&fresh);
         // Atomic, idempotent publish: first inserter wins and is never evicted.
         let entry = self.expirations.get_or_insert(key, fresh);
-        Arc::clone(entry.value())
+        // `inserted` is true iff the published value is the book we just built,
+        // i.e. this call is the unique `get_or_insert` winner for this key.
+        let inserted = Arc::ptr_eq(entry.value(), &candidate);
+        (Arc::clone(entry.value()), inserted)
     }
 
     /// Gets an expiration order book.

--- a/src/orderbook/expiry_scheduler.rs
+++ b/src/orderbook/expiry_scheduler.rs
@@ -118,9 +118,17 @@ impl ExpiryScheduler {
     /// # Algorithm
     ///
     /// 1. Generate expected dates from `expiry_config.generate_dates(now)`
-    /// 2. For each date, check if expiration already exists
-    /// 3. If new, create expiration and generate strikes
+    /// 2. For each date, atomically get-or-create the expiration, learning from
+    ///    the insert result whether this call created it
+    /// 3. If this call created it, generate strikes
     /// 4. Invoke callback for each newly created expiration
+    ///
+    /// # Concurrency
+    ///
+    /// Newness is derived from the atomic
+    /// [`UnderlyingOrderBook::get_or_create_expiration_inserted`] result rather
+    /// than a separate existence probe, so concurrent refreshes of the same
+    /// date create it, generate strikes, and invoke the callback exactly once.
     ///
     /// # Arguments
     ///
@@ -186,13 +194,15 @@ impl ExpiryScheduler {
         let mut result = RefreshResult::default();
 
         for date in expected_dates {
-            // Check if expiration already exists (not just empty)
-            let is_new = underlying.get_expiration(&date).is_err();
+            // Atomically get-or-create the expiration. `is_new` is the
+            // insert result of that single atomic publish, NOT a separate
+            // check-then-act probe: exactly one concurrent caller observes
+            // `is_new == true` for a given date (the `get_or_insert` winner),
+            // so strike generation and the callback run exactly once per date
+            // even under concurrent refreshes.
+            let (exp, is_new) = underlying.get_or_create_expiration_inserted(date);
 
-            // Get or create the expiration
-            let exp = underlying.get_or_create_expiration(date);
-
-            // Only process truly new expirations (not pre-existing empty ones)
+            // Only process truly new expirations (the unique creating caller).
             if is_new {
                 // Generate and apply strikes
                 let strikes =
@@ -568,6 +578,100 @@ mod tests {
             callback_count.load(Ordering::SeqCst),
             0,
             "callback should not be invoked for existing expirations"
+        );
+    }
+
+    // ── concurrent refresh race ────────────────────────────────────────────────
+
+    #[test]
+    fn test_refresh_expirations_concurrent_creates_each_date_once() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        // N threads race to refresh the SAME set of expiration dates at the
+        // SAME wall-clock instant, started in lockstep via a Barrier (no
+        // sleeps). With newness derived from the atomic get-or-create insert
+        // result, each date is created exactly once: the manager holds one
+        // entry per date AND the callback fires exactly once per date.
+        //
+        // Regression direction: against the old separate `get_expiration`
+        // probe (check-then-act), multiple threads could each observe
+        // `is_new == true` for the same date before any insert landed,
+        // double-invoking the callback and re-running strike generation. That
+        // logic would make `callback_count` and `total_created` exceed the
+        // distinct-date count, failing the assertions below.
+        const N: usize = 16;
+        const SPOT: u64 = 50_000;
+
+        let book = Arc::new(UnderlyingOrderBook::new("BTC"));
+        let expiry_config = minimal_expiry_config(); // 2 daily expirations
+        let strike_config = default_strike_config();
+        // Capture a single fixed instant so every thread computes the SAME
+        // dates deterministically (no day-boundary flakiness, no RNG).
+        let now = Utc::now();
+
+        let expected_dates = expiry_config
+            .generate_dates(now)
+            .expect("valid config")
+            .len();
+        assert_eq!(expected_dates, 2, "fixture should produce 2 dates");
+
+        let callback_count = Arc::new(AtomicUsize::new(0));
+        let callback_count_clone = Arc::clone(&callback_count);
+        let callback: Arc<ExpirationCallback> = Arc::new(Box::new(move |_date| {
+            callback_count_clone.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        let barrier = Arc::new(Barrier::new(N));
+
+        let mut handles = Vec::with_capacity(N);
+        for _ in 0..N {
+            let book = Arc::clone(&book);
+            let expiry_config = expiry_config.clone();
+            let strike_config = strike_config.clone();
+            let callback = Arc::clone(&callback);
+            let barrier = Arc::clone(&barrier);
+            handles.push(thread::spawn(move || {
+                barrier.wait();
+                ExpiryScheduler::refresh_expirations(
+                    &book,
+                    now,
+                    &expiry_config,
+                    &strike_config,
+                    SPOT,
+                    Some(callback.as_ref()),
+                )
+                .expect("refresh should succeed")
+            }));
+        }
+
+        let mut total_created = 0usize;
+        for handle in handles {
+            let result = handle.join().expect("thread panicked");
+            total_created = total_created
+                .checked_add(result.created.len())
+                .expect("created overflow");
+        }
+
+        // Exactly-once create: the manager holds one entry per date.
+        assert_eq!(
+            book.expiration_count(),
+            expected_dates,
+            "each date must be created exactly once in the manager"
+        );
+
+        // Exactly-once create across threads: summed `created` over all
+        // refreshes equals the distinct-date count (one winner per date).
+        assert_eq!(
+            total_created, expected_dates,
+            "exactly one thread should report creating each date"
+        );
+
+        // Exactly-once callback: callback fired once per distinct date.
+        assert_eq!(
+            callback_count.load(Ordering::SeqCst),
+            expected_dates,
+            "callback must fire exactly once per date"
         );
     }
 

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -526,6 +526,26 @@ impl UnderlyingOrderBook {
         self.expirations.get_or_create(expiration)
     }
 
+    /// Gets or creates an expiration order book, reporting whether this call
+    /// performed the insertion.
+    ///
+    /// Returns `(book, inserted)` where `inserted` is `true` for exactly one
+    /// caller across all concurrent callers for a given expiration — the one
+    /// whose freshly built book won the atomic publish. Delegates to
+    /// [`ExpirationOrderBookManager::get_or_create_inserted`].
+    ///
+    /// This is the race-free signal the expiry scheduler uses to decide that an
+    /// expiration was genuinely created now, replacing a separate
+    /// [`get_expiration`](Self::get_expiration) probe that reopens a
+    /// check-then-act race under concurrency.
+    #[must_use]
+    pub fn get_or_create_expiration_inserted(
+        &self,
+        expiration: ExpirationDate,
+    ) -> (Arc<ExpirationOrderBook>, bool) {
+        self.expirations.get_or_create_inserted(expiration)
+    }
+
     /// Gets an expiration order book.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

`ExpiryScheduler::refresh_expirations` computed `is_new` via a SEPARATE `get_expiration` probe before `get_or_create_expiration`, so two concurrent `refresh` calls could both observe `is_new == true` for the same date, both push it into `created`, both invoke the callback, and both run strike generation — breaking the documented idempotency. (The SkipMap itself was already idempotent after #49; the over-count was in the scheduler's probe-based newness check.)

## Changes (additive)

- `ExpirationOrderBookManager::get_or_create_inserted(&self, expiration) -> (Arc<ExpirationOrderBook>, bool)` — refactored from `get_or_create` (now a thin wrapper). The `bool` is the `Arc::ptr_eq` winner of #49's `SkipMap::get_or_insert` — `true` for exactly one caller (the unique insert winner), `false` for fast-path hits and race losers.
- `UnderlyingOrderBook::get_or_create_expiration_inserted` delegates to it.
- `refresh_expirations` derives `is_new` from that atomic result and **removes the separate `get_expiration` probe**, so exactly one concurrent caller per date generates strikes / pushes to `created` / fires the callback.

## Testing

- [x] `test_refresh_expirations_concurrent_creates_each_date_once` — 16 threads, `std::sync::Barrier` lockstep, shared callback counter: asserts `expiration_count == 2`, summed `created == 2`, and callback count `== 2` (exactly-once create AND callback per date). Fails against the old probe-based logic (callback/created over-count).
- [x] `cargo test --all-features` 809+5+88, 0 fail; `clippy -D warnings`, `make pre-push` clean

## Notes

Additive API (existing `get_or_create*` signatures unchanged); version stays **0.5.0**. No event/stats/mass-cancel shape change. Copilot code review is not enabled on the repo (the request silently no-ops) — internal review substitutes per the loop's fallback.

## Checklist

- [x] `rules/global_rules.md`: synchronous lock-free path, deterministic, idempotent under concurrency; no unwrap/expect/unsafe; no new deps

Closes #72
