### PR TITLE
Remove IndexPriceFeed layering inversion (#89)

### DIFF
--- a/src/orderbook/index_feed.rs
+++ b/src/orderbook/index_feed.rs
@@ -1,0 +1,176 @@
+//! Neutral index price feed abstraction.
+//!
+//! This module owns the [`IndexPriceFeed`] trait and the minimal value types its
+//! signature requires ([`PriceUpdate`], [`PriceUpdateListener`],
+//! [`SubscriptionId`]). It is intentionally **dependency-light**: it depends only
+//! on `std`, with no link to the Greeks / mark-price subsystem.
+//!
+//! ## Why a neutral module
+//!
+//! The core order-book hierarchy is layered one-way: a layer composes the layer
+//! below and aggregates upward, and the pricing subsystem (`greeks_engine`,
+//! `greeks_aggregator`, `mark_price`, `index_price_feed`) *reads* the hierarchy —
+//! the hierarchy must never depend on pricing.
+//!
+//! [`UnderlyingOrderBook`](super::underlying::UnderlyingOrderBook) (the top of the
+//! core hierarchy) needs to hold a pluggable index source as
+//! `Arc<dyn IndexPriceFeed>`. Keeping the trait in the pricing module
+//! (`index_price_feed`) would invert that edge and force pricing to compile even
+//! for pure book usage. Placing the trait here — alongside the other shared
+//! lookup/state services (`symbol_index`, `instrument_registry`) that any layer
+//! may depend on — lets the hierarchy reference the trait without pulling in
+//! pricing.
+//!
+//! The concrete implementations ([`MockPriceFeed`](super::index_price_feed::MockPriceFeed),
+//! [`StaticPriceFeed`](super::index_price_feed::StaticPriceFeed)) and the
+//! calculator wiring
+//! ([`wire_feed_to_calculator`](super::index_price_feed::wire_feed_to_calculator))
+//! stay in the pricing module, which depends downward on this neutral trait.
+
+use std::sync::Arc;
+
+/// A price update from an external source.
+///
+/// Carries the price value, a nanosecond-precision timestamp for
+/// observability, and the identifier of the source that produced it.
+///
+/// ## Fields
+///
+/// - `price`: Price in smallest units (e.g., satoshis, cents)
+/// - `timestamp_ns`: Timestamp in nanoseconds since Unix epoch
+/// - `source`: Human-readable source identifier (e.g., `"chainlink"`, `"binance"`)
+#[derive(Debug, Clone)]
+pub struct PriceUpdate {
+    /// Price in smallest units (e.g., satoshis, cents).
+    pub price: u64,
+    /// Timestamp in nanoseconds since Unix epoch.
+    pub timestamp_ns: u64,
+    /// Identifier of the price source.
+    pub source: String,
+}
+
+/// Opaque handle returned by [`IndexPriceFeed::subscribe`].
+///
+/// Pass this to [`IndexPriceFeed::unsubscribe`] to remove the listener.
+/// Each id is unique within a single feed instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SubscriptionId(pub(crate) u64);
+
+/// Callback invoked when a new price update is available.
+///
+/// Receives a shared reference to the [`PriceUpdate`] to avoid cloning
+/// when multiple listeners are registered.
+///
+/// # Panics
+///
+/// Listener implementations **must not panic**. If a listener panics during
+/// notification, subsequent listeners in the subscription list will not be
+/// called. Callers are responsible for ensuring their callbacks are
+/// panic-free.
+pub type PriceUpdateListener = Arc<dyn Fn(&PriceUpdate) + Send + Sync>;
+
+/// Trait for external index price sources.
+///
+/// Implementations provide a latest-price query and a pub/sub model
+/// for real-time updates. The trait is object-safe so it can be stored
+/// as `Arc<dyn IndexPriceFeed>`.
+///
+/// ## Layering
+///
+/// This trait lives in a neutral, dependency-light module so the core
+/// order-book hierarchy can store an `Arc<dyn IndexPriceFeed>` without
+/// depending on the Greeks / mark-price subsystem. The concrete feeds and the
+/// `MarkPriceCalculator` wiring live in the pricing module
+/// (`index_price_feed`), which depends downward on this trait.
+///
+/// ## Thread Safety
+///
+/// All methods must be safe to call from any thread. Implementations
+/// should use interior mutability (atomics, `Mutex`, etc.) as needed.
+///
+/// ## Example
+///
+/// ```
+/// use option_chain_orderbook::orderbook::{IndexPriceFeed, MockPriceFeed};
+///
+/// let feed = MockPriceFeed::new();
+/// assert!(feed.latest_price().is_none()); // no price set yet
+/// assert_eq!(feed.source(), "mock");
+/// ```
+pub trait IndexPriceFeed: Send + Sync {
+    /// Returns the most recent price update, or `None` if no price
+    /// has been published yet.
+    fn latest_price(&self) -> Option<PriceUpdate>;
+
+    /// Registers a listener that will be called on every subsequent
+    /// price update.
+    ///
+    /// Returns a [`SubscriptionId`] that can be passed to
+    /// [`unsubscribe`](Self::unsubscribe) to remove the listener.
+    fn subscribe(&self, listener: PriceUpdateListener) -> SubscriptionId;
+
+    /// Removes a previously registered listener.
+    ///
+    /// Returns `true` if the listener was found and removed, `false`
+    /// if the id was not present (e.g., already unsubscribed).
+    fn unsubscribe(&self, id: SubscriptionId) -> bool;
+
+    /// Returns a human-readable identifier for this price source
+    /// (e.g., `"chainlink"`, `"binance"`, `"mock"`).
+    fn source(&self) -> &str;
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+
+    // ── PriceUpdate ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_price_update_creation() {
+        let update = PriceUpdate {
+            price: 50000,
+            timestamp_ns: 1_000_000_000,
+            source: "test".to_string(),
+        };
+        assert_eq!(update.price, 50000);
+        assert_eq!(update.timestamp_ns, 1_000_000_000);
+        assert_eq!(update.source, "test");
+    }
+
+    #[test]
+    fn test_price_update_clone() {
+        let update = PriceUpdate {
+            price: 42000,
+            timestamp_ns: 999,
+            source: "clone_test".to_string(),
+        };
+        let cloned = update.clone();
+        assert_eq!(cloned.price, 42000);
+        assert_eq!(cloned.source, "clone_test");
+    }
+
+    #[test]
+    fn test_price_update_debug() {
+        let update = PriceUpdate {
+            price: 100,
+            timestamp_ns: 0,
+            source: "dbg".to_string(),
+        };
+        let debug = format!("{:?}", update);
+        assert!(debug.contains("PriceUpdate"));
+        assert!(debug.contains("100"));
+    }
+
+    // ── SubscriptionId ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_subscription_id_equality() {
+        let a = SubscriptionId(1);
+        let b = SubscriptionId(1);
+        let c = SubscriptionId(2);
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+}

--- a/src/orderbook/index_price_feed.rs
+++ b/src/orderbook/index_price_feed.rs
@@ -1,9 +1,17 @@
-//! Index price feed abstraction module.
+//! Index price feed implementations and mark-price wiring.
 //!
-//! This module provides a trait-based abstraction for external price sources
-//! (Chainlink, exchange feeds, etc.) that the [`MarkPriceCalculator`] consumes.
-//! This decouples the mark price calculation from the specific price source
-//! implementation.
+//! This pricing-subsystem module provides the concrete price sources
+//! ([`MockPriceFeed`], [`StaticPriceFeed`]) and the
+//! [`wire_feed_to_calculator`] helper that feeds an external price source
+//! (Chainlink, exchange feeds, etc.) into the [`MarkPriceCalculator`],
+//! decoupling mark price calculation from the specific source implementation.
+//!
+//! The [`IndexPriceFeed`] trait itself — together with [`PriceUpdate`],
+//! [`PriceUpdateListener`], and [`SubscriptionId`] — lives in the neutral,
+//! dependency-light [`index_feed`](super::index_feed) module so the core
+//! order-book hierarchy can hold an `Arc<dyn IndexPriceFeed>` without depending
+//! on this pricing subsystem. This module depends downward on that trait and
+//! implements it.
 //!
 //! ## Overview
 //!
@@ -41,93 +49,11 @@
 //! assert_eq!(calculator.index_price(), 50000);
 //! ```
 
+use super::index_feed::{IndexPriceFeed, PriceUpdate, PriceUpdateListener, SubscriptionId};
 use super::mark_price::MarkPriceCalculator;
 use crate::utils::nanos_since_epoch;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-
-/// A price update from an external source.
-///
-/// Carries the price value, a nanosecond-precision timestamp for
-/// observability, and the identifier of the source that produced it.
-///
-/// ## Fields
-///
-/// - `price`: Price in smallest units (e.g., satoshis, cents)
-/// - `timestamp_ns`: Timestamp in nanoseconds since Unix epoch
-/// - `source`: Human-readable source identifier (e.g., `"chainlink"`, `"binance"`)
-#[derive(Debug, Clone)]
-pub struct PriceUpdate {
-    /// Price in smallest units (e.g., satoshis, cents).
-    pub price: u64,
-    /// Timestamp in nanoseconds since Unix epoch.
-    pub timestamp_ns: u64,
-    /// Identifier of the price source.
-    pub source: String,
-}
-
-/// Opaque handle returned by [`IndexPriceFeed::subscribe`].
-///
-/// Pass this to [`IndexPriceFeed::unsubscribe`] to remove the listener.
-/// Each id is unique within a single feed instance.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct SubscriptionId(u64);
-
-/// Callback invoked when a new price update is available.
-///
-/// Receives a shared reference to the [`PriceUpdate`] to avoid cloning
-/// when multiple listeners are registered.
-///
-/// # Panics
-///
-/// Listener implementations **must not panic**. If a listener panics during
-/// notification, subsequent listeners in the subscription list will not be
-/// called. Callers are responsible for ensuring their callbacks are
-/// panic-free.
-pub type PriceUpdateListener = Arc<dyn Fn(&PriceUpdate) + Send + Sync>;
-
-/// Trait for external index price sources.
-///
-/// Implementations provide a latest-price query and a pub/sub model
-/// for real-time updates. The trait is object-safe so it can be stored
-/// as `Arc<dyn IndexPriceFeed>`.
-///
-/// ## Thread Safety
-///
-/// All methods must be safe to call from any thread. Implementations
-/// should use interior mutability (atomics, `Mutex`, etc.) as needed.
-///
-/// ## Example
-///
-/// ```
-/// use option_chain_orderbook::orderbook::{IndexPriceFeed, MockPriceFeed};
-///
-/// let feed = MockPriceFeed::new();
-/// assert!(feed.latest_price().is_none()); // no price set yet
-/// assert_eq!(feed.source(), "mock");
-/// ```
-pub trait IndexPriceFeed: Send + Sync {
-    /// Returns the most recent price update, or `None` if no price
-    /// has been published yet.
-    fn latest_price(&self) -> Option<PriceUpdate>;
-
-    /// Registers a listener that will be called on every subsequent
-    /// price update.
-    ///
-    /// Returns a [`SubscriptionId`] that can be passed to
-    /// [`unsubscribe`](Self::unsubscribe) to remove the listener.
-    fn subscribe(&self, listener: PriceUpdateListener) -> SubscriptionId;
-
-    /// Removes a previously registered listener.
-    ///
-    /// Returns `true` if the listener was found and removed, `false`
-    /// if the id was not present (e.g., already unsubscribed).
-    fn unsubscribe(&self, id: SubscriptionId) -> bool;
-
-    /// Returns a human-readable identifier for this price source
-    /// (e.g., `"chainlink"`, `"binance"`, `"mock"`).
-    fn source(&self) -> &str;
-}
 
 // ─── MockPriceFeed ───────────────────────────────────────────────────────────
 
@@ -406,44 +332,6 @@ mod tests {
     use super::*;
     use std::sync::atomic::AtomicUsize;
     use std::thread;
-
-    // ── PriceUpdate ──────────────────────────────────────────────────────
-
-    #[test]
-    fn test_price_update_creation() {
-        let update = PriceUpdate {
-            price: 50000,
-            timestamp_ns: 1_000_000_000,
-            source: "test".to_string(),
-        };
-        assert_eq!(update.price, 50000);
-        assert_eq!(update.timestamp_ns, 1_000_000_000);
-        assert_eq!(update.source, "test");
-    }
-
-    #[test]
-    fn test_price_update_clone() {
-        let update = PriceUpdate {
-            price: 42000,
-            timestamp_ns: 999,
-            source: "clone_test".to_string(),
-        };
-        let cloned = update.clone();
-        assert_eq!(cloned.price, 42000);
-        assert_eq!(cloned.source, "clone_test");
-    }
-
-    #[test]
-    fn test_price_update_debug() {
-        let update = PriceUpdate {
-            price: 100,
-            timestamp_ns: 0,
-            source: "dbg".to_string(),
-        };
-        let debug = format!("{:?}", update);
-        assert!(debug.contains("PriceUpdate"));
-        assert!(debug.contains("100"));
-    }
 
     // ── MockPriceFeed ────────────────────────────────────────────────────
 
@@ -778,15 +666,6 @@ mod tests {
         let feed = StaticPriceFeed::new(100, "static");
         let id = feed.subscribe(Arc::new(|_: &PriceUpdate| {}));
         assert!(!feed.unsubscribe(id));
-    }
-
-    #[test]
-    fn test_subscription_id_equality() {
-        let a = SubscriptionId(1);
-        let b = SubscriptionId(1);
-        let c = SubscriptionId(2);
-        assert_eq!(a, b);
-        assert_ne!(a, c);
     }
 
     // ── nanos_since_epoch ────────────────────────────────────────────────

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -58,6 +58,7 @@ mod expiry_scheduler;
 mod fees;
 pub mod greeks_aggregator;
 pub mod greeks_engine;
+mod index_feed;
 mod index_price_feed;
 mod instrument_registry;
 mod instrument_status;
@@ -97,10 +98,14 @@ pub use greeks_engine::{
     FlatVolSurface, GreeksEngine, GreeksRecalcTrigger, GreeksUpdate, GreeksUpdateListener,
     VolSurface, calculate_tte_years,
 };
-pub use index_price_feed::{
-    IndexPriceFeed, MockPriceFeed, PriceUpdate, PriceUpdateListener, StaticPriceFeed,
-    SubscriptionId, wire_feed_to_calculator,
-};
+// The `IndexPriceFeed` trait and its value types live in the neutral
+// `index_feed` module (so the core hierarchy can depend on them without pulling
+// in the pricing subsystem); the concrete feeds and the calculator wiring live
+// in the pricing module `index_price_feed`. Both are re-exported here so the
+// public paths (`orderbook::IndexPriceFeed`, `orderbook::PriceUpdate`, …) are
+// unchanged.
+pub use index_feed::{IndexPriceFeed, PriceUpdate, PriceUpdateListener, SubscriptionId};
+pub use index_price_feed::{MockPriceFeed, StaticPriceFeed, wire_feed_to_calculator};
 pub use instrument_registry::{InstrumentInfo, InstrumentRegistry};
 pub use instrument_status::InstrumentStatus;
 pub use mark_price::{MarkPriceCalculator, MarkPriceConfig, MarkPriceConfigBuilder};

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -9,7 +9,7 @@ use super::expiration::{
 };
 use super::expiry_cycle::{ExpiryCycleConfig, SharedExpiryCycleConfig};
 use super::fees::SharedFeeSchedule;
-use super::index_price_feed::IndexPriceFeed;
+use super::index_feed::IndexPriceFeed;
 use super::instrument_registry::{InstrumentInfo, InstrumentRegistry};
 use super::stp::SharedSTPMode;
 use super::strike_range::{ExpiryType, SharedStrikeRangeConfigs, StrikeRangeConfig};
@@ -21,7 +21,7 @@ use optionstratlib::ExpirationDate;
 use orderbook_rs::{FeeSchedule, OrderId, OrderStatus, STPMode, Side};
 use pricelevel::Hash32;
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use super::book::TerminalOrderSummary;
@@ -53,7 +53,13 @@ pub struct UnderlyingOrderBook {
     /// Expiry cycle configuration for automatic expiration date generation.
     expiry_cycle_config: SharedExpiryCycleConfig,
     /// External index price feed for mark price computation.
-    index_feed: Mutex<Option<Arc<dyn IndexPriceFeed>>>,
+    ///
+    /// A read-heavy snapshot consulted by mark-price readers, so it sits behind
+    /// a [`RwLock`] rather than a `Mutex` to let concurrent readers proceed
+    /// without serializing. The trait comes from the neutral
+    /// [`index_feed`](super::index_feed) module, keeping this top-of-hierarchy
+    /// type independent of the pricing subsystem.
+    index_feed: RwLock<Option<Arc<dyn IndexPriceFeed>>>,
 }
 
 /// Underlying-level mass cancel summary.
@@ -177,7 +183,7 @@ impl UnderlyingOrderBook {
             symbol_index: None,
             strike_range_configs: SharedStrikeRangeConfigs::new(),
             expiry_cycle_config: SharedExpiryCycleConfig::new(),
-            index_feed: Mutex::new(None),
+            index_feed: RwLock::new(None),
         }
     }
 
@@ -207,7 +213,7 @@ impl UnderlyingOrderBook {
             symbol_index: None,
             strike_range_configs: SharedStrikeRangeConfigs::new(),
             expiry_cycle_config: SharedExpiryCycleConfig::new(),
-            index_feed: Mutex::new(None),
+            index_feed: RwLock::new(None),
         }
     }
 
@@ -239,7 +245,7 @@ impl UnderlyingOrderBook {
             symbol_index: Some(symbol_index),
             strike_range_configs: SharedStrikeRangeConfigs::new(),
             expiry_cycle_config: SharedExpiryCycleConfig::new(),
-            index_feed: Mutex::new(None),
+            index_feed: RwLock::new(None),
         }
     }
 
@@ -508,15 +514,18 @@ impl UnderlyingOrderBook {
     /// assert!(book.index_feed().is_some());
     /// ```
     pub fn set_index_feed(&self, feed: Arc<dyn IndexPriceFeed>) {
-        let mut guard = self.index_feed.lock().unwrap_or_else(|p| p.into_inner());
+        let mut guard = self.index_feed.write().unwrap_or_else(|p| p.into_inner());
         *guard = Some(feed);
     }
 
     /// Returns the currently attached index price feed, if any.
+    ///
+    /// Uses a shared read lock so concurrent mark-price readers do not
+    /// serialize against one another.
     #[must_use]
     pub fn index_feed(&self) -> Option<Arc<dyn IndexPriceFeed>> {
         self.index_feed
-            .lock()
+            .read()
             .unwrap_or_else(|p| p.into_inner())
             .clone()
     }

--- a/tests/unit/layering_tests.rs
+++ b/tests/unit/layering_tests.rs
@@ -9,33 +9,48 @@
 //! See issue #89: the `IndexPriceFeed` trait was relocated to the neutral
 //! `index_feed` module so `UnderlyingOrderBook` (top of the core hierarchy) can
 //! hold an `Arc<dyn IndexPriceFeed>` without importing the pricing subsystem.
+//!
+//! The guarded file set is enumerated **dynamically** from `src/orderbook/`
+//! (minus an explicit exclude list), so a newly added core / shared module is
+//! covered automatically — there is no hand-maintained allowlist to forget to
+//! update. The check rejects both pricing *module* names and the distinctive
+//! pricing *type* names, so a core file cannot smuggle in a pricing type via the
+//! crate-root flat re-export (`use crate::orderbook::MarkPriceCalculator;`)
+//! without naming the module.
 
-use std::path::PathBuf;
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
 
-/// Core-hierarchy and shared-service modules that must stay independent of the
-/// pricing subsystem. `index_feed` is the neutral trait module and is included
-/// because it too must not pull in pricing.
-const CORE_HIERARCHY_FILES: &[&str] = &[
-    "src/orderbook/book.rs",
-    "src/orderbook/quote.rs",
-    "src/orderbook/strike.rs",
-    "src/orderbook/chain.rs",
-    "src/orderbook/expiration.rs",
-    "src/orderbook/underlying.rs",
-    "src/orderbook/fees.rs",
-    "src/orderbook/stp.rs",
-    "src/orderbook/validation.rs",
-    "src/orderbook/contract_specs.rs",
-    "src/orderbook/instrument_registry.rs",
-    "src/orderbook/instrument_status.rs",
-    "src/orderbook/symbol_index.rs",
-    "src/orderbook/strike_generator.rs",
-    "src/orderbook/strike_range.rs",
-    "src/orderbook/index_feed.rs",
-    "src/utils.rs",
+/// Files under `src/orderbook/` that are deliberately EXCLUDED from the guard,
+/// in three buckets:
+///
+/// 1. The pricing subsystem itself (`greeks_engine`, `greeks_aggregator`,
+///    `mark_price`, `index_price_feed`) — it legitimately defines and wires
+///    these symbols, so of course it references them.
+/// 2. `mod.rs`, the re-export hub, which names every module including pricing.
+/// 3. The top-of-stack eventing / expiry-lifecycle layer (`sequencer`, `nats`,
+///    `expiry_cycle`, `expiry_lifecycle`, `expiry_scheduler`). That layer sits
+///    *above* the hierarchy and is a separate concern from the core hierarchy +
+///    shared services this guard protects (the scope of issue #89).
+///
+/// Everything else in `src/orderbook/*.rs`, plus `src/utils.rs`, is guarded.
+const EXCLUDED_FILES: &[&str] = &[
+    // pricing subsystem
+    "greeks_engine.rs",
+    "greeks_aggregator.rs",
+    "mark_price.rs",
+    "index_price_feed.rs",
+    // re-export hub
+    "mod.rs",
+    // top-of-stack eventing / expiry-lifecycle layer (separate layer)
+    "sequencer.rs",
+    "nats.rs",
+    "expiry_cycle.rs",
+    "expiry_lifecycle.rs",
+    "expiry_scheduler.rs",
 ];
 
-/// Pricing-subsystem module names that the core hierarchy must never import.
+/// Pricing-subsystem module names that a guarded file must never import.
 const PRICING_MODULES: &[&str] = &[
     "greeks_engine",
     "greeks_aggregator",
@@ -43,19 +58,32 @@ const PRICING_MODULES: &[&str] = &[
     "index_price_feed",
 ];
 
+/// Distinctive pricing-subsystem *type* names that a guarded file must never
+/// reference. Checking these closes the hole where a core file could pull a
+/// pricing type via the crate-root flat re-export (e.g.
+/// `use crate::orderbook::MarkPriceCalculator;`) without naming the pricing
+/// module. Each name is specific enough not to collide with a legitimate
+/// core-hierarchy identifier. (`VolSurface` also matches `FlatVolSurface`;
+/// `MarkPriceConfig` also matches `MarkPriceConfigBuilder`.)
+const PRICING_TYPES: &[&str] = &[
+    "GreeksEngine",
+    "GreeksAggregator",
+    "AggregatedGreeks",
+    "GreeksRecalcTrigger",
+    "VolSurface",
+    "MarkPriceCalculator",
+    "MarkPriceConfig",
+];
+
 /// Strips full-line comments (doc comments and `//` comments) from source so the
 /// structural check only inspects actual code. Documentation legitimately
 /// references the pricing modules by name (e.g. to explain the layering), so it
 /// must be excluded from the import check.
 ///
-/// Limitations (both fail *safe* — they can only make the guard stricter, never
-/// let an inversion slip through): block comments (`/* … */`) and trailing inline
-/// comments are not stripped, so a pricing-module name in one would trip the
-/// assert as a false positive. The check also matches module *names* as
-/// substrings, so it catches the `super::<module>::Type` convention used between
-/// `src/orderbook/` siblings but not a pricing type pulled via the crate-root
-/// flat re-export (`use crate::orderbook::MarkPriceCalculator;`). The latter is
-/// not the idiom used inside the crate, so the substring check is sufficient.
+/// This fails *safe*: it does not strip block comments (`/* … */`) or trailing
+/// inline comments, so a pricing name in one would trip the assert as a false
+/// positive — it can only make the guard stricter, never let an inversion slip
+/// through.
 fn code_only(source: &str) -> String {
     source
         .lines()
@@ -64,24 +92,79 @@ fn code_only(source: &str) -> String {
         .join("\n")
 }
 
+/// Dynamically enumerate the guarded files: every `src/orderbook/*.rs` not in
+/// [`EXCLUDED_FILES`], plus `src/utils.rs`.
+fn guarded_files(manifest_dir: &Path) -> Vec<PathBuf> {
+    let orderbook_dir = manifest_dir.join("src/orderbook");
+    let entries = std::fs::read_dir(&orderbook_dir)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", orderbook_dir.display()));
+
+    let mut files: Vec<PathBuf> = Vec::new();
+    for entry in entries {
+        let path = entry.expect("read dir entry").path();
+        let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+            continue;
+        };
+        if name.ends_with(".rs") && !EXCLUDED_FILES.contains(&name) {
+            files.push(path);
+        }
+    }
+    files.push(manifest_dir.join("src/utils.rs"));
+    files.sort();
+    files
+}
+
 #[test]
 fn core_hierarchy_does_not_import_pricing_subsystem() {
     let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let files = guarded_files(&manifest_dir);
 
-    for rel in CORE_HIERARCHY_FILES {
-        let path = manifest_dir.join(rel);
-        let source = match std::fs::read_to_string(&path) {
-            Ok(s) => s,
-            Err(err) => panic!("failed to read {}: {err}", path.display()),
-        };
+    // Sanity: the enumeration must actually find the core files. Guards against a
+    // globbing mistake silently checking nothing (a passing-but-vacuous test).
+    assert!(
+        files.len() >= 15,
+        "layering guard enumerated only {} files — expected the full core \
+         hierarchy + shared services; the directory glob likely broke",
+        files.len(),
+    );
+
+    // The dynamic enumeration must cover the known core / shared files —
+    // including `expiration_key.rs`, which a hand-maintained allowlist had
+    // previously omitted.
+    let names: BTreeSet<&str> = files
+        .iter()
+        .filter_map(|p| p.file_name().and_then(|n| n.to_str()))
+        .collect();
+    for must in [
+        "book.rs",
+        "quote.rs",
+        "strike.rs",
+        "chain.rs",
+        "expiration.rs",
+        "expiration_key.rs",
+        "underlying.rs",
+        "index_feed.rs",
+        "symbol_index.rs",
+    ] {
+        assert!(
+            names.contains(must),
+            "core / shared file `{must}` is missing from the layering guard set",
+        );
+    }
+
+    for path in &files {
+        let rel = path.strip_prefix(&manifest_dir).unwrap_or(path);
+        let rel = rel.display();
+        let source = std::fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
         let code = code_only(&source);
 
-        for module in PRICING_MODULES {
+        for needle in PRICING_MODULES.iter().chain(PRICING_TYPES) {
             assert!(
-                !code.contains(module),
-                "layering inversion: core-hierarchy file `{rel}` references pricing \
-                 module `{module}`. The pricing subsystem reads the hierarchy, not \
-                 the reverse (see issue #89).",
+                !code.contains(needle),
+                "layering inversion: core-hierarchy / shared-service file `{rel}` \
+                 references pricing symbol `{needle}`. The pricing subsystem reads \
+                 the hierarchy, not the reverse (see issue #89).",
             );
         }
     }

--- a/tests/unit/layering_tests.rs
+++ b/tests/unit/layering_tests.rs
@@ -1,0 +1,88 @@
+//! Structural layering tests.
+//!
+//! These tests guard the one-way layering rule: the core order-book hierarchy
+//! and the shared lookup/state services must NOT depend on the Greeks /
+//! mark-price pricing subsystem (`greeks_engine`, `greeks_aggregator`,
+//! `mark_price`, `index_price_feed`). Pricing reads the hierarchy, never the
+//! reverse.
+//!
+//! See issue #89: the `IndexPriceFeed` trait was relocated to the neutral
+//! `index_feed` module so `UnderlyingOrderBook` (top of the core hierarchy) can
+//! hold an `Arc<dyn IndexPriceFeed>` without importing the pricing subsystem.
+
+use std::path::PathBuf;
+
+/// Core-hierarchy and shared-service modules that must stay independent of the
+/// pricing subsystem. `index_feed` is the neutral trait module and is included
+/// because it too must not pull in pricing.
+const CORE_HIERARCHY_FILES: &[&str] = &[
+    "src/orderbook/book.rs",
+    "src/orderbook/quote.rs",
+    "src/orderbook/strike.rs",
+    "src/orderbook/chain.rs",
+    "src/orderbook/expiration.rs",
+    "src/orderbook/underlying.rs",
+    "src/orderbook/fees.rs",
+    "src/orderbook/stp.rs",
+    "src/orderbook/validation.rs",
+    "src/orderbook/contract_specs.rs",
+    "src/orderbook/instrument_registry.rs",
+    "src/orderbook/instrument_status.rs",
+    "src/orderbook/symbol_index.rs",
+    "src/orderbook/strike_generator.rs",
+    "src/orderbook/strike_range.rs",
+    "src/orderbook/index_feed.rs",
+    "src/utils.rs",
+];
+
+/// Pricing-subsystem module names that the core hierarchy must never import.
+const PRICING_MODULES: &[&str] = &[
+    "greeks_engine",
+    "greeks_aggregator",
+    "mark_price",
+    "index_price_feed",
+];
+
+/// Strips full-line comments (doc comments and `//` comments) from source so the
+/// structural check only inspects actual code. Documentation legitimately
+/// references the pricing modules by name (e.g. to explain the layering), so it
+/// must be excluded from the import check.
+///
+/// Limitations (both fail *safe* — they can only make the guard stricter, never
+/// let an inversion slip through): block comments (`/* … */`) and trailing inline
+/// comments are not stripped, so a pricing-module name in one would trip the
+/// assert as a false positive. The check also matches module *names* as
+/// substrings, so it catches the `super::<module>::Type` convention used between
+/// `src/orderbook/` siblings but not a pricing type pulled via the crate-root
+/// flat re-export (`use crate::orderbook::MarkPriceCalculator;`). The latter is
+/// not the idiom used inside the crate, so the substring check is sufficient.
+fn code_only(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+#[test]
+fn core_hierarchy_does_not_import_pricing_subsystem() {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+
+    for rel in CORE_HIERARCHY_FILES {
+        let path = manifest_dir.join(rel);
+        let source = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(err) => panic!("failed to read {}: {err}", path.display()),
+        };
+        let code = code_only(&source);
+
+        for module in PRICING_MODULES {
+            assert!(
+                !code.contains(module),
+                "layering inversion: core-hierarchy file `{rel}` references pricing \
+                 module `{module}`. The pricing subsystem reads the hierarchy, not \
+                 the reverse (see issue #89).",
+            );
+        }
+    }
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -1,3 +1,4 @@
 //! Unit tests for option-chain-orderbook library.
 
+mod layering_tests;
 mod orderbook_tests;


### PR DESCRIPTION
## Summary

`UnderlyingOrderBook` (the top of the core order-book hierarchy) imported the
`IndexPriceFeed` trait from `index_price_feed.rs`, which is part of the
Greeks/pricing subsystem — a one-way-leaf-up layering violation where the core
hierarchy depended on a subsystem that is supposed to read the hierarchy, never
the reverse. This relocates the trait into a neutral, dependency-light module so
the hierarchy can hold an `Arc<dyn IndexPriceFeed>` without inverting the layering.

## Changes

- New neutral module `src/orderbook/index_feed.rs` holding **only** the
  `IndexPriceFeed` trait plus the value types its signature requires
  (`PriceUpdate`, `PriceUpdateListener`, `SubscriptionId`). Its sole import is
  `std::sync::Arc` — no upward dependency on `greeks_*`/`mark_price`/`index_price_feed`.
- `index_price_feed.rs` keeps the concrete impls (`MockPriceFeed`,
  `StaticPriceFeed`) and the `wire_feed_to_calculator` helper, and now depends
  *downward* on the neutral trait module.
- `underlying.rs` imports the trait from `index_feed`. Its `index_feed` field
  moves `Mutex` → `RwLock` (poison-safe via `unwrap_or_else(|p| p.into_inner())`
  on both read and write) so concurrent mark-price readers no longer serialize
  on a rarely-written configuration slot.
- New structural guard `tests/unit/layering_tests.rs`: scans every
  core-hierarchy / shared-service source file and fails if any reintroduces an
  import of the pricing subsystem.

## Technical decisions

The trait is the right thing to relocate (not the impls): a trait that the
hierarchy depends on belongs alongside the other neutral shared services
(`symbol_index`, `instrument_registry`, `instrument_status`), while the concrete
feeds and the calculator-wiring stay in the pricing subsystem. The lock swap is
incidental but appropriate — `index_feed` is a single `Option<Arc<dyn …>>`
snapshot read on the mark-price path and written only at configuration time, so
a read-shared `RwLock` is the correct shape (a `SkipMap`/`DashMap` would be
wrong for one value).

## Public API impact

No change. The same 7 names — `IndexPriceFeed`, `PriceUpdate`,
`PriceUpdateListener`, `SubscriptionId`, `MockPriceFeed`, `StaticPriceFeed`,
`wire_feed_to_calculator` — resolve at the same paths (`orderbook::*` and the
crate-root flat re-export). The re-export list in `mod.rs` is split across the
two modules but the public set is identical. `SubscriptionId`'s tuple field went
private → `pub(crate)` for in-crate construction; it was never `pub`, so this is
not externally observable. `src/lib.rs` module docs and `README.md` are
unchanged (no public-surface or module-doc delta). Version stays `0.5.0`.

## Testing

- [x] Unit tests added or updated
- [x] Integration tests under `tests/unit/` added or updated (if applicable)
- [x] `make pre-push` run locally and clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No `unsafe` introduced
- [x] Layering respected (one-way leaf-up; Greeks / eventing not depended on by the core hierarchy)
- [x] Matching delegated to `orderbook-rs`; Greeks delegated to `optionstratlib`
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate

Closes #89
