### PR TITLE
Make set_status a CAS loop to close the status race (#116)

### DIFF
--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -578,24 +578,39 @@ impl OptionOrderBook {
 
     /// Stores the lifecycle status without validating the transition.
     ///
-    /// Internal raw setter used by the validated [`set_status`](Self::set_status)
-    /// path *after* the transition has been checked against the enforced
-    /// lifecycle state machine. It bypasses that check, so callers are
-    /// responsible for legality.
+    /// Test-only raw setter used to seed lifecycle states that no legal edge of
+    /// the enforced state machine can reach (e.g.
+    /// [`Pending`](InstrumentStatus::Pending), which every book leaves at
+    /// construction). It bypasses the transition check entirely, so it must
+    /// never be used on the production order path — [`set_status`](Self::set_status)
+    /// is the only validated, race-free way to mutate status.
+    #[cfg(test)]
     #[inline]
     fn store_status(&self, status: InstrumentStatus) {
         self.status.store(status as u8, Ordering::Release);
     }
 
     /// Sets the lifecycle status of this instrument, enforcing the lifecycle
-    /// state machine.
+    /// state machine atomically.
     ///
     /// The transition from the current status to `status` must be a legal edge
     /// in the state machine documented on [`InstrumentStatus`]. A self-transition
     /// (`X -> X`) is a legal no-op. Any illegal transition (e.g. reactivating an
     /// [`Expired`](InstrumentStatus::Expired) book, or pulling a
     /// [`Settling`](InstrumentStatus::Settling) book back to
-    /// [`Halted`](InstrumentStatus::Halted)) leaves the status unchanged.
+    /// [`Halted`](InstrumentStatus::Halted)) leaves the status unchanged and
+    /// returns an error.
+    ///
+    /// Validation and write form a single atomic compare-and-swap loop over the
+    /// underlying status, so this is race-free with respect to concurrent status
+    /// updates — for example the expiry-lifecycle CAS-forward setter
+    /// ([`compare_and_set_status`](Self::compare_and_set_status)) running on
+    /// another thread. In particular, the terminal
+    /// [`Expired`](InstrumentStatus::Expired) status is never overwritten: if a
+    /// concurrent thread advances the book to `Expired` after this call loads an
+    /// earlier status, the lost CAS forces a re-load, the loop re-validates
+    /// against `Expired`, finds no legal edge to the requested target, and
+    /// returns [`Error::IllegalStatusTransition`] instead of clobbering it.
     ///
     /// # Arguments
     ///
@@ -607,12 +622,36 @@ impl OptionOrderBook {
     /// if the current status cannot legally transition to `status`.
     #[inline]
     pub fn set_status(&self, status: InstrumentStatus) -> Result<()> {
-        let current = self.status();
-        if !current.can_transition(status) {
-            return Err(Error::illegal_status_transition(current, status));
+        // CAS loop closing the former check-then-act race. It is lock-free with
+        // guaranteed system-wide progress: every real (non-spurious) CAS failure
+        // reflects another thread's *successful* transition, so the system always
+        // advances. The status space is finite (5 states); the only cycle is the
+        // rare operator-driven `Active <-> Halted` (halt/resume), and the terminal
+        // `Expired` is absorbing, so once expiry wins the loop cannot spin. A
+        // single caller is only starvable under an adversarial unbounded stream of
+        // external halt/resume calls, which are infrequent operator events, not a
+        // tight loop — hence bounded in practice.
+        loop {
+            let current = self.status();
+            if !current.can_transition(status) {
+                return Err(Error::illegal_status_transition(current, status));
+            }
+            // Legal self-transition: idempotent no-op, skip the redundant store.
+            if current == status {
+                return Ok(());
+            }
+            match self.status.compare_exchange_weak(
+                current as u8,
+                status as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Ok(()),
+                // Lost the race: another thread advanced the status. Re-load and
+                // re-validate against the new current on the next iteration.
+                Err(_) => continue,
+            }
         }
-        self.store_status(status);
-        Ok(())
     }
 
     /// Atomically compares and sets the lifecycle status, validating the target.
@@ -714,6 +753,14 @@ impl OptionOrderBook {
     /// non-terminal status and an idempotent no-op from
     /// [`Expired`](InstrumentStatus::Expired), so in practice it always
     /// succeeds. The orders are only swept once the transition is accepted.
+    ///
+    /// The status transition is atomic (a CAS loop in
+    /// [`set_status`](Self::set_status)), but the sweep is *idempotent* rather
+    /// than exactly-once: two concurrent `expire()` callers both pass the status
+    /// step (one performs `live -> Expired`, the other a legal `Expired ->
+    /// Expired` no-op) and both call `cancel_all_orders`. The first empties the
+    /// book; the second is a no-op sweep, so each order is cancelled exactly once
+    /// while either caller may report it in its returned id list.
     ///
     /// # Returns
     ///
@@ -2345,6 +2392,84 @@ mod tests {
         // Expired -> Active is illegal: the CAS reports failure (no swap).
         assert!(!book.compare_and_set_status(InstrumentStatus::Expired, InstrumentStatus::Active,));
         assert_eq!(book.status(), InstrumentStatus::Expired);
+    }
+
+    #[test]
+    fn test_set_status_expired_is_terminal_under_concurrent_resume() {
+        use std::sync::{Arc, Barrier};
+        use std::thread;
+
+        // Spin the interleaving over many fresh books so the lost-CAS path is
+        // reliably exercised: one thread drives `Halted -> Expired` while another
+        // concurrently races `Halted -> Active` (resume), both released from the
+        // same barrier. The invariant under test is that once a book reaches the
+        // terminal `Expired` status it can NEVER end `Active` — `set_status(Active)`
+        // must either win the CAS before expiry (returning `Ok`) or lose it and
+        // return `IllegalStatusTransition`. The former check-then-act setter could
+        // clobber `Expired` with `Active` here; the CAS loop closes that race.
+        for _ in 0..2_000 {
+            let book = Arc::new(OptionOrderBook::new(
+                "BTC-20240329-50000-C",
+                OptionStyle::Call,
+            ));
+            // Seed `Halted` so resume (`-> Active`) and expire (`-> Expired`) both
+            // perform a real compare-exchange from the same starting state and
+            // genuinely contend (an `Active -> Active` resume is a no-op and would
+            // not exercise the race).
+            book.halt().expect("Active -> Halted is legal");
+
+            let barrier = Arc::new(Barrier::new(2));
+
+            let expirer = {
+                let book = Arc::clone(&book);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    book.set_status(InstrumentStatus::Expired)
+                        .expect("transition to Expired is legal from every live state");
+                })
+            };
+
+            let resumer = {
+                let book = Arc::clone(&book);
+                let barrier = Arc::clone(&barrier);
+                thread::spawn(move || {
+                    barrier.wait();
+                    book.resume()
+                })
+            };
+
+            expirer.join().expect("expirer thread panicked");
+            let resume_result = resumer.join().expect("resumer thread panicked");
+
+            // The book always ends terminal-`Expired`, never reactivated.
+            assert_eq!(
+                book.status(),
+                InstrumentStatus::Expired,
+                "book must remain Expired after a concurrent resume",
+            );
+
+            // Concurrent cross-check: IF resume happened to lose the race, it
+            // must have failed with the typed illegal-transition error
+            // (`Expired -> Active`), never silently. This branch is
+            // schedule-dependent (a resume that wins returns `Ok`), so we do not
+            // assert it fires here — the typed rejection is covered
+            // deterministically by `test_set_status_expired_to_active_rejected`
+            // and `test_resume_expired_rejected`. The deterministic invariant
+            // this concurrent test owns is the `status() == Expired` assert above.
+            if let Err(err) = resume_result {
+                assert!(
+                    matches!(
+                        err,
+                        Error::IllegalStatusTransition {
+                            from: InstrumentStatus::Expired,
+                            to: InstrumentStatus::Active,
+                        }
+                    ),
+                    "unexpected resume error: {err:?}",
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -578,12 +578,13 @@ impl OptionOrderBook {
 
     /// Stores the lifecycle status without validating the transition.
     ///
-    /// Test-only raw setter used to seed lifecycle states that no legal edge of
-    /// the enforced state machine can reach (e.g.
-    /// [`Pending`](InstrumentStatus::Pending), which every book leaves at
-    /// construction). It bypasses the transition check entirely, so it must
-    /// never be used on the production order path — [`set_status`](Self::set_status)
-    /// is the only validated, race-free way to mutate status.
+    /// Test-only raw setter used to seed lifecycle states that the enforced
+    /// state machine cannot reach from a constructed book (e.g.
+    /// [`Pending`](InstrumentStatus::Pending): books are constructed as
+    /// [`Active`](InstrumentStatus::Active) and no legal edge leads back to
+    /// `Pending`). It bypasses the transition check entirely, so it must never be
+    /// used on the production order path — [`set_status`](Self::set_status) is the
+    /// only validated, race-free way to mutate status.
     #[cfg(test)]
     #[inline]
     fn store_status(&self, status: InstrumentStatus) {
@@ -752,7 +753,7 @@ impl OptionOrderBook {
     /// Expiry is a terminal sweep: it is a legal transition from every
     /// non-terminal status and an idempotent no-op from
     /// [`Expired`](InstrumentStatus::Expired), so in practice it always
-    /// succeeds. The orders are only swept once the transition is accepted.
+    /// succeeds. The orders are only swept when the transition is accepted.
     ///
     /// The status transition is atomic (a CAS loop in
     /// [`set_status`](Self::set_status)), but the sweep is *idempotent* rather
@@ -2396,18 +2397,76 @@ mod tests {
 
     #[test]
     fn test_set_status_expired_is_terminal_under_concurrent_resume() {
-        use std::sync::{Arc, Barrier};
+        use std::sync::{Arc, Barrier, Mutex};
         use std::thread;
 
-        // Spin the interleaving over many fresh books so the lost-CAS path is
-        // reliably exercised: one thread drives `Halted -> Expired` while another
-        // concurrently races `Halted -> Active` (resume), both released from the
+        // Race one expirer (`Halted -> Expired`) against one resumer
+        // (`Halted -> Active`) on a fresh book each round, both released from the
         // same barrier. The invariant under test is that once a book reaches the
-        // terminal `Expired` status it can NEVER end `Active` — `set_status(Active)`
-        // must either win the CAS before expiry (returning `Ok`) or lose it and
-        // return `IllegalStatusTransition`. The former check-then-act setter could
-        // clobber `Expired` with `Active` here; the CAS loop closes that race.
-        for _ in 0..2_000 {
+        // terminal `Expired` status it can NEVER end `Active` — `resume()` must
+        // either win the CAS before expiry (returning `Ok`) or lose it and return
+        // `IllegalStatusTransition`. The former check-then-act setter could clobber
+        // `Expired` with `Active` here; the CAS loop closes that race.
+        //
+        // Two long-lived worker threads are reused across every round (only two
+        // spawns total) and synchronized per round by a pair of 3-party barriers,
+        // so the test stays cheap on constrained CI rather than spawning a thread
+        // pair per round. `round_ready` publishes the round's book to both workers
+        // (the barrier provides the happens-before for the slot write); `round_done`
+        // ensures both workers finished before the main thread asserts.
+        const ROUNDS: usize = 2_000;
+        let slot: Arc<Mutex<Option<Arc<OptionOrderBook>>>> = Arc::new(Mutex::new(None));
+        let round_ready = Arc::new(Barrier::new(3));
+        let round_done = Arc::new(Barrier::new(3));
+
+        let expirer = {
+            let slot = Arc::clone(&slot);
+            let round_ready = Arc::clone(&round_ready);
+            let round_done = Arc::clone(&round_done);
+            thread::spawn(move || {
+                for _ in 0..ROUNDS {
+                    round_ready.wait();
+                    let book = slot.lock().unwrap().clone().expect("book published");
+                    book.set_status(InstrumentStatus::Expired)
+                        .expect("transition to Expired is legal from every live state");
+                    round_done.wait();
+                }
+            })
+        };
+
+        let resumer = {
+            let slot = Arc::clone(&slot);
+            let round_ready = Arc::clone(&round_ready);
+            let round_done = Arc::clone(&round_done);
+            thread::spawn(move || {
+                for _ in 0..ROUNDS {
+                    round_ready.wait();
+                    let book = slot.lock().unwrap().clone().expect("book published");
+                    // Concurrent cross-check: IF resume happened to lose the race,
+                    // it must have failed with the typed illegal-transition error
+                    // (`Expired -> Active`), never silently. A resume that wins
+                    // returns `Ok`, so this branch is schedule-dependent and we do
+                    // not assert it fires — the typed rejection is covered
+                    // deterministically by `test_set_status_expired_to_active_rejected`
+                    // and `test_resume_expired_rejected`.
+                    if let Err(err) = book.resume() {
+                        assert!(
+                            matches!(
+                                err,
+                                Error::IllegalStatusTransition {
+                                    from: InstrumentStatus::Expired,
+                                    to: InstrumentStatus::Active,
+                                }
+                            ),
+                            "unexpected resume error: {err:?}",
+                        );
+                    }
+                    round_done.wait();
+                }
+            })
+        };
+
+        for _ in 0..ROUNDS {
             let book = Arc::new(OptionOrderBook::new(
                 "BTC-20240329-50000-C",
                 OptionStyle::Call,
@@ -2417,30 +2476,10 @@ mod tests {
             // genuinely contend (an `Active -> Active` resume is a no-op and would
             // not exercise the race).
             book.halt().expect("Active -> Halted is legal");
+            *slot.lock().unwrap() = Some(Arc::clone(&book));
 
-            let barrier = Arc::new(Barrier::new(2));
-
-            let expirer = {
-                let book = Arc::clone(&book);
-                let barrier = Arc::clone(&barrier);
-                thread::spawn(move || {
-                    barrier.wait();
-                    book.set_status(InstrumentStatus::Expired)
-                        .expect("transition to Expired is legal from every live state");
-                })
-            };
-
-            let resumer = {
-                let book = Arc::clone(&book);
-                let barrier = Arc::clone(&barrier);
-                thread::spawn(move || {
-                    barrier.wait();
-                    book.resume()
-                })
-            };
-
-            expirer.join().expect("expirer thread panicked");
-            let resume_result = resumer.join().expect("resumer thread panicked");
+            round_ready.wait(); // release both workers onto this round's book
+            round_done.wait(); // both have finished; safe to read the final status
 
             // The book always ends terminal-`Expired`, never reactivated.
             assert_eq!(
@@ -2448,28 +2487,10 @@ mod tests {
                 InstrumentStatus::Expired,
                 "book must remain Expired after a concurrent resume",
             );
-
-            // Concurrent cross-check: IF resume happened to lose the race, it
-            // must have failed with the typed illegal-transition error
-            // (`Expired -> Active`), never silently. This branch is
-            // schedule-dependent (a resume that wins returns `Ok`), so we do not
-            // assert it fires here — the typed rejection is covered
-            // deterministically by `test_set_status_expired_to_active_rejected`
-            // and `test_resume_expired_rejected`. The deterministic invariant
-            // this concurrent test owns is the `status() == Expired` assert above.
-            if let Err(err) = resume_result {
-                assert!(
-                    matches!(
-                        err,
-                        Error::IllegalStatusTransition {
-                            from: InstrumentStatus::Expired,
-                            to: InstrumentStatus::Active,
-                        }
-                    ),
-                    "unexpected resume error: {err:?}",
-                );
-            }
         }
+
+        expirer.join().expect("expirer thread panicked");
+        resumer.join().expect("resumer thread panicked");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`OptionOrderBook::set_status` validated a transition with a `status()` read
followed by an unconditional `store_status` — a check-then-act race. Under
concurrent callers, the expiry-lifecycle CAS could advance a book to the
terminal `Expired` between the read and the store, and `set_status(Active)`
would then clobber `Expired`, violating the "Expired is terminal" guarantee that
#71 added. This makes the validation and write a single atomic CAS loop so a
settled instrument can never silently flip back to accepting orders.

## Changes

- `set_status` is now a lock-free CAS loop over the existing `status` `AtomicU8`:
  load current → validate `current.can_transition(target)` → short-circuit a
  legal self-transition → `compare_exchange_weak(AcqRel, Acquire)`. A lost CAS
  re-loads and re-validates against the new current, so once a book reaches
  `Expired` a racing `set_status(Active)` re-reads `Expired`, finds no legal
  edge, and returns `Error::IllegalStatusTransition` instead of overwriting it.
- `halt()`, `resume()`, and `expire()` route through `set_status` and inherit
  the atomic behavior with no signature or semantic change to their legal edges.
- `store_status` is no longer on any production path; it is now `#[cfg(test)]`
  (a test-only raw seeder for the otherwise-unreachable `Pending` state).
- New `Barrier`-based concurrency test over 2000 fresh books: an expirer thread
  (`Halted -> Expired`) races a resumer thread (`Halted -> Active`), both
  released from one barrier; asserts the book never ends `Active` after reaching
  `Expired`.

## Technical decisions

The loop is lock-free with guaranteed system-wide progress: every real CAS
failure reflects another thread's successful transition. The status space is
finite (5 states), the only cycle is the rare operator-driven `Active <-> Halted`
(halt/resume), and terminal `Expired` is absorbing, so the loop cannot spin once
expiry wins. Memory orderings (`AcqRel`/`Acquire`) match the pre-existing
`compare_and_set_status` on the same atomic. The concurrent test deliberately
does not hard-assert that resume ever *loses* the race (that branch is
schedule-dependent and would risk flakiness on single-core CI); the typed
`Expired -> Active` rejection is instead covered deterministically by the
existing `test_set_status_expired_to_active_rejected` and
`test_resume_expired_rejected`.

## Testing

- [x] Unit tests added or updated
- [x] `make pre-push` run locally and clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic on protocol counters — no `saturating_*` / `wrapping_*`
- [x] No `unsafe` introduced
- [x] Layering respected (leaf-only change in `book.rs`)
- [x] Matching delegated to `orderbook-rs`; Greeks delegated to `optionstratlib`
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate

Closes #116
