### PR TITLE
Wire NATS publishers for hierarchy-created contract books (#102)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ pub use orderbook::{
 #[cfg(feature = "nats")]
 pub use orderbook::{
     NatsPublisherHandles, OptionChainNatsConfig, OptionChainSubjectBuilder,
-    build_option_order_book_with_nats,
+    build_option_order_book_with_nats, build_underlying_manager_with_nats,
 };
 
 #[cfg(feature = "sequencer")]

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -46,6 +46,82 @@ pub(crate) struct PreparedNatsListeners {
     pub book_listener: PriceLevelChangedListener,
 }
 
+/// Factory that builds the per-contract NATS publisher listeners for one option
+/// contract, given its symbol.
+///
+/// The hierarchy threads this factory down to the leaf so that every contract
+/// book it lazily creates installs its own publishers *before* the inner book
+/// is wrapped in `Arc` (the only valid install point — the `orderbook_rs`
+/// listener setters take `&mut self`). The factory is typed purely in terms of
+/// `orderbook_rs`-native listeners (via [`PreparedNatsListeners`]) so the core
+/// hierarchy never imports the eventing `nats` module: it only invokes this
+/// `book`-layer callback with each contract's symbol and installs whatever
+/// listeners come back. The dependency direction stays `nats` → hierarchy →
+/// `book`, never the reverse.
+///
+/// Returns `None` when no publishers should be attached for the given symbol
+/// (e.g. the symbol cannot be turned into a valid subject); the contract book
+/// is then built exactly as on the non-NATS path.
+///
+/// The concrete factory is constructed by the `nats` module's
+/// `build_underlying_manager_with_nats` builder (kept as a plain reference, not
+/// an intra-doc link, so the leaf carries no path into the eventing layer).
+#[cfg(feature = "nats")]
+pub(crate) type ContractNatsListenerFactory =
+    Arc<dyn Fn(&str) -> Option<PreparedNatsListeners> + Send + Sync>;
+
+/// Thread-safe holder for an optional [`ContractNatsListenerFactory`].
+///
+/// Mirrors [`SharedFeeSchedule`](super::fees::SharedFeeSchedule): hierarchy
+/// managers store the factory behind a lock so it can be propagated to children
+/// through `&self` setters — exactly like the STP mode and fee schedule —
+/// without threading it through every constructor signature (keeping the public
+/// constructor surface additive). The factory is an `Arc`, so [`get`](Self::get)
+/// is a cheap clone.
+#[cfg(feature = "nats")]
+#[derive(Default)]
+pub(crate) struct SharedNatsFactory {
+    /// The inner factory, protected by a read-write lock.
+    inner: std::sync::RwLock<Option<ContractNatsListenerFactory>>,
+}
+
+#[cfg(feature = "nats")]
+impl SharedNatsFactory {
+    /// Creates an empty holder (no factory configured).
+    #[must_use]
+    #[inline]
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stores (or clears) the factory. Recovers from a poisoned lock so the
+    /// factory is always written.
+    pub(crate) fn set(&self, factory: Option<ContractNatsListenerFactory>) {
+        *self
+            .inner
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = factory;
+    }
+
+    /// Returns a clone of the current factory, or `None` if none is configured.
+    #[must_use]
+    pub(crate) fn get(&self) -> Option<ContractNatsListenerFactory> {
+        self.inner
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+}
+
+#[cfg(feature = "nats")]
+impl std::fmt::Debug for SharedNatsFactory {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SharedNatsFactory")
+            .field("configured", &self.get().is_some())
+            .finish()
+    }
+}
+
 /// Internal configuration for constructing an [`OptionOrderBook`].
 ///
 /// Consolidates all optional configuration (instrument ID, validation,

--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -19,6 +19,8 @@ use pricelevel::Hash32;
 use std::sync::Arc;
 use std::time::Duration;
 
+#[cfg(feature = "nats")]
+use super::book::ContractNatsListenerFactory;
 use super::book::TerminalOrderSummary;
 
 /// Option chain order book for a single expiration.
@@ -240,6 +242,17 @@ impl OptionChainOrderBook {
     #[inline]
     pub fn fee_schedule(&self) -> Option<FeeSchedule> {
         self.strikes.fee_schedule()
+    }
+
+    /// Propagates the per-contract NATS listener factory down to the strike
+    /// manager so every strike created within this chain installs publishers.
+    ///
+    /// Delegates to [`StrikeOrderBookManager::set_nats_factory`]. Existing
+    /// strikes are not affected.
+    #[cfg(feature = "nats")]
+    #[inline]
+    pub(crate) fn set_nats_factory(&self, factory: Option<ContractNatsListenerFactory>) {
+        self.strikes.set_nats_factory(factory);
     }
 
     /// Gets or creates a strike order book, returning an Arc reference.

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -21,6 +21,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::book::TerminalOrderSummary;
+#[cfg(feature = "nats")]
+use super::book::{ContractNatsListenerFactory, SharedNatsFactory};
 
 /// Order book for a single expiration date.
 ///
@@ -233,6 +235,17 @@ impl ExpirationOrderBook {
     #[inline]
     pub fn fee_schedule(&self) -> Option<FeeSchedule> {
         self.chain.fee_schedule()
+    }
+
+    /// Propagates the per-contract NATS listener factory down to this
+    /// expiration's chain (and onward to its strike manager).
+    ///
+    /// Delegates to [`OptionChainOrderBook::set_nats_factory`]. Existing books
+    /// are not affected.
+    #[cfg(feature = "nats")]
+    #[inline]
+    pub(crate) fn set_nats_factory(&self, factory: Option<ContractNatsListenerFactory>) {
+        self.chain.set_nats_factory(factory);
     }
 
     /// Cancels all resting orders across the expiration's option chain.
@@ -552,6 +565,11 @@ pub struct ExpirationOrderBookManager {
     stp_mode: SharedSTPMode,
     /// Fee schedule propagated to newly created expiration books.
     fee_schedule: SharedFeeSchedule,
+    /// Per-contract NATS listener factory propagated to newly created
+    /// expiration books (and onward to their strikes). `None` (the default)
+    /// reproduces the non-NATS path exactly.
+    #[cfg(feature = "nats")]
+    nats_factory: SharedNatsFactory,
 }
 
 impl ExpirationOrderBookManager {
@@ -571,6 +589,8 @@ impl ExpirationOrderBookManager {
             symbol_index: None,
             stp_mode: SharedSTPMode::new(),
             fee_schedule: SharedFeeSchedule::new(),
+            #[cfg(feature = "nats")]
+            nats_factory: SharedNatsFactory::new(),
         }
     }
 
@@ -598,6 +618,8 @@ impl ExpirationOrderBookManager {
             symbol_index: None,
             stp_mode: SharedSTPMode::new(),
             fee_schedule: SharedFeeSchedule::new(),
+            #[cfg(feature = "nats")]
+            nats_factory: SharedNatsFactory::new(),
         }
     }
 
@@ -623,6 +645,8 @@ impl ExpirationOrderBookManager {
             symbol_index: Some(symbol_index),
             stp_mode: SharedSTPMode::new(),
             fee_schedule: SharedFeeSchedule::new(),
+            #[cfg(feature = "nats")]
+            nats_factory: SharedNatsFactory::new(),
         }
     }
 
@@ -693,6 +717,18 @@ impl ExpirationOrderBookManager {
     #[inline]
     pub fn fee_schedule(&self) -> Option<FeeSchedule> {
         self.fee_schedule.get()
+    }
+
+    /// Stores the per-contract NATS listener factory propagated from the top of
+    /// the hierarchy and forwarded to every future expiration book.
+    ///
+    /// Existing expiration books are not affected; only books created by a
+    /// later [`get_or_create`](Self::get_or_create) carry the factory down to
+    /// their strikes. Mirrors [`set_fee_schedule`](Self::set_fee_schedule)
+    /// propagation.
+    #[cfg(feature = "nats")]
+    pub(crate) fn set_nats_factory(&self, factory: Option<ContractNatsListenerFactory>) {
+        self.nats_factory.set(factory);
     }
 
     /// Returns the underlying asset symbol.
@@ -793,6 +829,15 @@ impl ExpirationOrderBookManager {
         }
         if let Some(schedule) = self.fee_schedule.get() {
             fresh.set_fee_schedule(schedule);
+        }
+        // Propagate the per-contract NATS factory down to the fresh chain/strike
+        // manager BEFORE publishing, so the configured-before-visible invariant
+        // holds: any later strike created under this expiration installs its
+        // publishers. Done only when a factory is configured to keep the
+        // no-factory path identical.
+        #[cfg(feature = "nats")]
+        if let Some(factory) = self.nats_factory.get() {
+            fresh.set_nats_factory(Some(factory));
         }
         // Keep a handle to the locally built book so we can identify whether it
         // won the race after the atomic publish.

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -123,7 +123,7 @@ pub use validation::ValidationConfig;
 #[cfg(feature = "nats")]
 pub use nats::{
     NatsPublisherHandles, OptionChainNatsConfig, OptionChainSubjectBuilder,
-    build_option_order_book_with_nats,
+    build_option_order_book_with_nats, build_underlying_manager_with_nats,
 };
 
 #[cfg(feature = "sequencer")]

--- a/src/orderbook/nats.rs
+++ b/src/orderbook/nats.rs
@@ -47,7 +47,10 @@
 //! # }
 //! ```
 
-use super::book::{BookConfig, OptionOrderBook, PreparedNatsListeners};
+use super::book::{
+    BookConfig, ContractNatsListenerFactory, OptionOrderBook, PreparedNatsListeners,
+};
+use super::underlying::UnderlyingOrderBookManager;
 use crate::error::Error;
 use crate::utils::SymbolParser;
 use optionstratlib::OptionStyle;
@@ -562,6 +565,111 @@ pub fn build_option_order_book_with_nats(
     ))
 }
 
+/// Builds the per-contract NATS listener factory backing
+/// [`build_underlying_manager_with_nats`].
+///
+/// The returned factory, when invoked by the hierarchy with a contract symbol,
+/// derives that contract's hierarchical trade/book subjects via
+/// [`OptionChainSubjectBuilder`], constructs the trade and book-change
+/// publishers, and converts them into their `orderbook_rs`-native listeners for
+/// the hierarchy to install pre-`Arc`. The publisher handles are intentionally
+/// dropped, leaving each publisher owned by its background batch task and its
+/// listener closure; teardown is therefore drop-driven (see
+/// [`build_underlying_manager_with_nats`]).
+///
+/// A symbol that cannot be turned into a valid subject yields `None` (logged at
+/// `ERROR`), so the contract book is still created — just without publishers —
+/// rather than failing book creation.
+#[must_use]
+fn make_contract_nats_factory(config: OptionChainNatsConfig) -> ContractNatsListenerFactory {
+    Arc::new(move |symbol: &str| {
+        let subject = match OptionChainSubjectBuilder::from_symbol(symbol) {
+            Ok(subject) => subject,
+            Err(err) => {
+                tracing::error!(
+                    symbol,
+                    error = %err,
+                    "nats: cannot derive subject for lazily-created contract; \
+                     publishers not attached"
+                );
+                return None;
+            }
+        };
+        let trade_subject = subject.trade_subject(config.subject_prefix());
+        let book_subject = subject.book_subject(config.subject_prefix());
+
+        // Build the trade publisher and convert it into its listener callback.
+        let trade_publisher = NatsTradePublisher::new(
+            config.jetstream().clone(),
+            trade_subject,
+            config.runtime().clone(),
+        );
+        let (_trade_handle, trade_listener) = trade_publisher.into_listener();
+
+        // Build the book-change publisher and convert it into its listener.
+        let book_change_publisher = NatsBookChangePublisher::new(
+            config.jetstream().clone(),
+            symbol.to_string(),
+            book_subject,
+            config.runtime().clone(),
+        );
+        let (_book_handle, book_listener) = book_change_publisher.into_listener();
+
+        tracing::debug!(
+            symbol,
+            prefix = %config.subject_prefix(),
+            "nats publishers attached to lazily-created contract book"
+        );
+
+        Some(PreparedNatsListeners {
+            trade_listener,
+            book_listener,
+        })
+    })
+}
+
+/// Builds an [`UnderlyingOrderBookManager`] that attaches per-contract NATS
+/// publishers to **every** contract book the hierarchy lazily creates.
+///
+/// Unlike [`build_option_order_book_with_nats`], which wires a single standalone
+/// [`OptionOrderBook`], this wires the whole hierarchy: each call/put book
+/// created on demand via `get_or_create_*` installs its own trade and
+/// book-change publishers — bound to that contract's hierarchical subjects —
+/// *before* the inner book is wrapped in `Arc`. The wiring rides an
+/// `orderbook_rs`-native listener factory threaded down to the leaf, so the core
+/// hierarchy never imports this module.
+///
+/// # Subject Format
+///
+/// Each contract publishes to the same subjects as
+/// [`build_option_order_book_with_nats`]:
+///
+/// - Trades: `{prefix}.trades.{underlying}.{expiry}.{strike}.{type}`
+/// - Book changes: `{prefix}.book.{underlying}.{expiry}.{strike}.{type}`
+///
+/// # Shutdown
+///
+/// The publishers attached to lazily-created books are bound to their book's
+/// lifetime: dropping a contract book (strike/expiry cleanup, or dropping the
+/// manager) closes the publish channels, and each publisher's background batch
+/// task drains and exits deterministically. For standalone books that need
+/// explicit publish metrics or an awaitable async shutdown, use
+/// [`build_option_order_book_with_nats`], which returns [`NatsPublisherHandles`].
+#[must_use = "the returned manager owns the hierarchy whose contract books \
+              publish to NATS; dropping it tears the publishers down"]
+pub fn build_underlying_manager_with_nats(
+    config: OptionChainNatsConfig,
+) -> UnderlyingOrderBookManager {
+    let prefix = config.subject_prefix().to_string();
+    let factory = make_contract_nats_factory(config);
+    let manager = UnderlyingOrderBookManager::with_nats_factory(factory);
+    tracing::info!(
+        prefix = %prefix,
+        "underlying order book manager wired with per-contract nats publishers"
+    );
+    manager
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -812,6 +920,95 @@ mod tests {
     fn test_validate_subject_prefix_multi_token_ok() {
         // A dotted prefix is allowed: it simply prepends extra subject levels.
         assert!(validate_subject_prefix("exchange.optionchain").is_ok());
+    }
+
+    /// End-to-end (offline) check that a contract book created purely through
+    /// the lazy hierarchy (`get_or_create_*`) has its per-contract publishers
+    /// installed and that a matched trade reaches them on the configured
+    /// per-contract subject.
+    ///
+    /// Mirrors the leaf `nats` seam test in `book.rs` (#58): the factory installs
+    /// *capturable stand-in* listeners that derive the real per-contract subject
+    /// via [`OptionChainSubjectBuilder`] — the same derivation the production
+    /// factory uses — so no live NATS server is required. This exercises the
+    /// full factory threading: root manager → underlying → expiration → chain →
+    /// strike → leaf `OptionOrderBook`.
+    #[test]
+    fn test_lazily_created_contract_book_publishes_to_per_contract_subject() {
+        use optionstratlib::ExpirationDate;
+        use optionstratlib::prelude::pos_or_panic;
+        use orderbook_rs::{
+            OrderId, PriceLevelChangedEvent, PriceLevelChangedListener, Side, TradeListener,
+            TradeResult,
+        };
+        use std::collections::HashMap;
+        use std::sync::Mutex;
+        use std::sync::atomic::{AtomicU64, Ordering};
+
+        let prefix = "optionchain";
+
+        // symbol -> (derived trade subject, trade-listener fire count).
+        type Captured = HashMap<String, (String, Arc<AtomicU64>)>;
+        let captured: Arc<Mutex<Captured>> = Arc::new(Mutex::new(HashMap::new()));
+
+        // Stand-in factory: derives the same per-contract subject the production
+        // factory would, and installs a capturing trade listener — exactly the
+        // book.rs #58 seam, but reached through the lazy hierarchy.
+        let captured_factory = Arc::clone(&captured);
+        let prefix_owned = prefix.to_string();
+        let factory: ContractNatsListenerFactory = Arc::new(move |symbol: &str| {
+            let subject = OptionChainSubjectBuilder::from_symbol(symbol).ok()?;
+            let trade_subject = subject.trade_subject(&prefix_owned);
+            let count = Arc::new(AtomicU64::new(0));
+            captured_factory
+                .lock()
+                .unwrap_or_else(|p| p.into_inner())
+                .insert(symbol.to_string(), (trade_subject, Arc::clone(&count)));
+            let count_c = Arc::clone(&count);
+            let trade_listener: TradeListener = Arc::new(move |_tr: &TradeResult| {
+                count_c.fetch_add(1, Ordering::Relaxed);
+            });
+            let book_listener: PriceLevelChangedListener =
+                Arc::new(|_ev: PriceLevelChangedEvent| {});
+            Some(PreparedNatsListeners {
+                trade_listener,
+                book_listener,
+            })
+        });
+
+        let manager = UnderlyingOrderBookManager::with_nats_factory(factory);
+
+        // Create a contract book lazily through every hierarchy level.
+        let btc = manager.get_or_create("BTC");
+        let exp = btc.get_or_create_expiration(ExpirationDate::Days(pos_or_panic!(30.0)));
+        let strike = exp.get_or_create_strike(50_000);
+        let call = strike.call();
+        let call_symbol = call.symbol().to_string();
+
+        // The expected subject is derived from the actual lazily-built symbol,
+        // so the assertion is independent of today's date.
+        let expected_subject = OptionChainSubjectBuilder::from_symbol(&call_symbol)
+            .expect("lazily-built call symbol must parse")
+            .trade_subject(prefix);
+
+        // Rest a sell, then cross it with a marketable buy to force a trade.
+        call.add_limit_order(OrderId::new(), Side::Sell, 100, 5)
+            .expect("rest sell");
+        call.add_limit_order(OrderId::new(), Side::Buy, 100, 5)
+            .expect("cross buy");
+
+        let guard = captured.lock().unwrap_or_else(|p| p.into_inner());
+        let (subject, count) = guard
+            .get(&call_symbol)
+            .expect("publishers must be wired into the lazily-created call book");
+        assert_eq!(
+            subject, &expected_subject,
+            "lazily-created call book must publish to its per-contract subject"
+        );
+        assert!(
+            count.load(Ordering::Relaxed) >= 1,
+            "a matched trade on a get_or_create_* strike must reach its per-contract publisher"
+        );
     }
 
     // `OptionChainNatsConfig::try_new` delegates its prefix validation entirely

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -4,6 +4,8 @@
 //! for managing call/put pairs at a specific strike price.
 
 use super::book::{BookConfig, OptionOrderBook};
+#[cfg(feature = "nats")]
+use super::book::{ContractNatsListenerFactory, PreparedNatsListeners, SharedNatsFactory};
 use super::contract_specs::{ContractSpecs, SharedContractSpecs};
 use super::fees::SharedFeeSchedule;
 use super::instrument_registry::{InstrumentInfo, InstrumentRegistry};
@@ -735,6 +737,12 @@ pub struct StrikeOrderBookManager {
     stp_mode: SharedSTPMode,
     /// Fee schedule applied to newly created option books.
     fee_schedule: SharedFeeSchedule,
+    /// Per-contract NATS listener factory propagated from the top of the
+    /// hierarchy. When present, each lazily created call/put book installs its
+    /// own publishers pre-`Arc` in the [`get_or_create`](Self::get_or_create)
+    /// winner path. `None` (the default) reproduces the non-NATS path exactly.
+    #[cfg(feature = "nats")]
+    nats_factory: SharedNatsFactory,
 }
 
 impl StrikeOrderBookManager {
@@ -756,6 +764,8 @@ impl StrikeOrderBookManager {
             symbol_index: None,
             stp_mode: SharedSTPMode::new(),
             fee_schedule: SharedFeeSchedule::new(),
+            #[cfg(feature = "nats")]
+            nats_factory: SharedNatsFactory::new(),
         }
     }
 
@@ -785,6 +795,8 @@ impl StrikeOrderBookManager {
             symbol_index: None,
             stp_mode: SharedSTPMode::new(),
             fee_schedule: SharedFeeSchedule::new(),
+            #[cfg(feature = "nats")]
+            nats_factory: SharedNatsFactory::new(),
         }
     }
 
@@ -813,6 +825,8 @@ impl StrikeOrderBookManager {
             symbol_index: Some(symbol_index),
             stp_mode: SharedSTPMode::new(),
             fee_schedule: SharedFeeSchedule::new(),
+            #[cfg(feature = "nats")]
+            nats_factory: SharedNatsFactory::new(),
         }
     }
 
@@ -893,6 +907,19 @@ impl StrikeOrderBookManager {
         self.fee_schedule.get()
     }
 
+    /// Stores the per-contract NATS listener factory propagated from the top of
+    /// the hierarchy.
+    ///
+    /// Existing strike books are not affected; only call/put books created by a
+    /// later [`get_or_create`](Self::get_or_create) install publishers from this
+    /// factory. Mirrors [`set_fee_schedule`](Self::set_fee_schedule) /
+    /// [`set_stp_mode`](Self::set_stp_mode) propagation, so the factory rides
+    /// the same `&self` setter path instead of widening any constructor.
+    #[cfg(feature = "nats")]
+    pub(crate) fn set_nats_factory(&self, factory: Option<ContractNatsListenerFactory>) {
+        self.nats_factory.set(factory);
+    }
+
     /// Returns the underlying asset symbol.
     #[must_use]
     pub fn underlying(&self) -> &str {
@@ -959,6 +986,18 @@ impl StrikeOrderBookManager {
     pub fn get_or_create(&self, strike: u64) -> Arc<StrikeOrderBook> {
         if let Some(entry) = self.strikes.get(&strike) {
             return Arc::clone(entry.value());
+        }
+
+        // When a per-contract NATS listener factory is configured, the call/put
+        // publishers must be installed pre-`Arc` (the `orderbook_rs` listener
+        // setters take `&mut self`), which means they have to be built into the
+        // candidate book *before* it is published. To keep that build — and the
+        // background publish task each publisher spawns — gated to the winner,
+        // the NATS path elects the winner with `get_or_insert_with`. The
+        // non-NATS path below is left byte-for-byte unchanged.
+        #[cfg(feature = "nats")]
+        if let Some(factory) = self.nats_factory.get() {
+            return self.get_or_create_with_nats(strike, factory);
         }
 
         // Build the call/put pair WITHOUT allocating instrument IDs or touching
@@ -1030,6 +1069,109 @@ impl StrikeOrderBookManager {
             call,
             put,
         ))
+    }
+
+    /// NATS-aware variant of [`get_or_create`](Self::get_or_create).
+    ///
+    /// Elects the build winner with
+    /// [`SkipMap::get_or_insert_with`](crossbeam_skiplist::SkipMap::get_or_insert_with)
+    /// so the publisher-wired call/put pair — and the background publish task
+    /// each publisher spawns — is built lazily and, in the common (uncontended)
+    /// case, exactly once: by the thread whose book is actually inserted. The
+    /// one-time global side effects (instrument-ID allocation, symbol-index
+    /// registration) are gated to that same winner via [`Arc::ptr_eq`], exactly
+    /// as the non-NATS path gates them.
+    ///
+    /// Under genuine concurrent contention for the *same* strike a losing
+    /// thread's closure may build a publisher-wired pair that loses the insert
+    /// and is dropped; it is never published into the hierarchy, never receives
+    /// an order, and its publish tasks terminate deterministically when the
+    /// dropped book closes their channels. The single book that ends up in the
+    /// map is wired exactly once, with no double-install.
+    #[cfg(feature = "nats")]
+    fn get_or_create_with_nats(
+        &self,
+        strike: u64,
+        factory: ContractNatsListenerFactory,
+    ) -> Arc<StrikeOrderBook> {
+        // Track the handle our own closure built (if it ran at all) so we can
+        // detect whether *we* are the winning inserter after the atomic publish.
+        let mut built: Option<Arc<StrikeOrderBook>> = None;
+        let entry = self.strikes.get_or_insert_with(strike, || {
+            let book = self.create_strike_book_with_nats(strike, &factory);
+            built = Some(Arc::clone(&book));
+            book
+        });
+        let winner = Arc::clone(entry.value());
+
+        // Run the one-time global side effects only when our closure built the
+        // inserted book. If the closure did not run (`built` is `None`, key was
+        // already present) or our candidate lost the race, another caller is the
+        // winner and owns these side effects.
+        if let Some(candidate) = &built
+            && Arc::ptr_eq(candidate, &winner)
+            && let Err(err) = self.assign_instrument_ids(&winner, strike)
+        {
+            tracing::error!(
+                underlying = %self.underlying,
+                strike,
+                error = %err,
+                "instrument-id exhaustion: registry full; strike books left with instrument_id 0",
+            );
+        }
+        winner
+    }
+
+    /// Builds a [`StrikeOrderBook`] whose call/put books carry NATS publishers
+    /// produced by `factory`, installed pre-`Arc` via [`BookConfig`].
+    ///
+    /// Mirrors [`create_strike_book_without_ids`](Self::create_strike_book_without_ids)
+    /// (same validation / STP / fee configuration, no instrument-ID allocation)
+    /// and additionally invokes the factory with each leg's symbol. A factory
+    /// returning `None` for a symbol yields a book without publishers — identical
+    /// to the non-NATS path for that leg.
+    #[cfg(feature = "nats")]
+    fn create_strike_book_with_nats(
+        &self,
+        strike: u64,
+        factory: &ContractNatsListenerFactory,
+    ) -> Arc<StrikeOrderBook> {
+        let exp_str = format_expiration_yyyymmdd(&self.expiration)
+            .unwrap_or_else(|_| self.expiration.to_string());
+        let call_symbol = format!("{}-{}-{}-C", self.underlying, exp_str, strike);
+        let put_symbol = format!("{}-{}-{}-P", self.underlying, exp_str, strike);
+
+        let call = Arc::new(OptionOrderBook::new_with_config(
+            &call_symbol,
+            OptionStyle::Call,
+            self.book_config_with_listeners(factory(&call_symbol)),
+        ));
+        let put = Arc::new(OptionOrderBook::new_with_config(
+            &put_symbol,
+            OptionStyle::Put,
+            self.book_config_with_listeners(factory(&put_symbol)),
+        ));
+
+        Arc::new(StrikeOrderBook::from_books(
+            &self.underlying,
+            self.expiration,
+            strike,
+            call,
+            put,
+        ))
+    }
+
+    /// Builds a [`BookConfig`] carrying this manager's validation / STP / fee
+    /// settings plus the supplied pre-built NATS listeners.
+    #[cfg(feature = "nats")]
+    fn book_config_with_listeners(&self, listeners: Option<PreparedNatsListeners>) -> BookConfig {
+        BookConfig {
+            validation: self.validation_config.get(),
+            stp_mode: self.stp_mode.get(),
+            fee_schedule: self.fee_schedule.get(),
+            nats_listeners: listeners,
+            ..BookConfig::default()
+        }
     }
 
     /// Assigns unique instrument IDs and registers the call/put books in the

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -25,6 +25,8 @@ use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use super::book::TerminalOrderSummary;
+#[cfg(feature = "nats")]
+use super::book::{ContractNatsListenerFactory, SharedNatsFactory};
 
 /// Order book for a single underlying asset.
 ///
@@ -350,6 +352,18 @@ impl UnderlyingOrderBook {
     #[inline]
     pub fn fee_schedule(&self) -> Option<FeeSchedule> {
         self.expirations.fee_schedule()
+    }
+
+    /// Propagates the per-contract NATS listener factory down to this
+    /// underlying's expiration manager.
+    ///
+    /// Delegates to [`ExpirationOrderBookManager::set_nats_factory`]. Existing
+    /// books are not affected; only later-created expirations and strikes carry
+    /// the factory.
+    #[cfg(feature = "nats")]
+    #[inline]
+    pub(crate) fn set_nats_factory(&self, factory: Option<ContractNatsListenerFactory>) {
+        self.expirations.set_nats_factory(factory);
     }
 
     /// Sets the strike range configuration for a specific expiry type.
@@ -917,6 +931,12 @@ pub struct UnderlyingOrderBookManager {
     stp_mode: SharedSTPMode,
     /// Fee schedule propagated to newly created underlying books.
     fee_schedule: SharedFeeSchedule,
+    /// Per-contract NATS listener factory propagated to every underlying book
+    /// (and onward to its expirations and strikes). Configured via
+    /// [`with_nats_factory`](UnderlyingOrderBookManager::with_nats_factory);
+    /// `None` (the default) reproduces the non-NATS path exactly.
+    #[cfg(feature = "nats")]
+    nats_factory: SharedNatsFactory,
 }
 
 impl Default for UnderlyingOrderBookManager {
@@ -939,6 +959,8 @@ impl UnderlyingOrderBookManager {
             symbol_index: Arc::new(SymbolIndex::new()),
             stp_mode: SharedSTPMode::new(),
             fee_schedule: SharedFeeSchedule::new(),
+            #[cfg(feature = "nats")]
+            nats_factory: SharedNatsFactory::new(),
         }
     }
 
@@ -959,7 +981,30 @@ impl UnderlyingOrderBookManager {
             symbol_index: Arc::new(SymbolIndex::new()),
             stp_mode: SharedSTPMode::new(),
             fee_schedule: SharedFeeSchedule::new(),
+            #[cfg(feature = "nats")]
+            nats_factory: SharedNatsFactory::new(),
         }
+    }
+
+    /// Creates a new underlying order book manager wired with a per-contract
+    /// NATS listener factory.
+    ///
+    /// Every contract book the hierarchy lazily creates beneath this manager
+    /// installs its own NATS publishers (built by `factory` from the contract
+    /// symbol) *before* the inner book is wrapped in `Arc`. This is the
+    /// hierarchy-side entry point used by the `nats` module's
+    /// `build_underlying_manager_with_nats` builder; the factory is an
+    /// `orderbook_rs`-native [`ContractNatsListenerFactory`] so the core
+    /// hierarchy never imports the eventing `nats` module.
+    ///
+    /// Additive: [`new`](Self::new) / [`new_with_seed`](Self::new_with_seed)
+    /// behave exactly as before (no factory configured).
+    #[cfg(feature = "nats")]
+    #[must_use]
+    pub(crate) fn with_nats_factory(factory: ContractNatsListenerFactory) -> Self {
+        let manager = Self::new();
+        manager.nats_factory.set(Some(factory));
+        manager
     }
 
     /// Returns the number of underlyings.
@@ -1010,6 +1055,13 @@ impl UnderlyingOrderBookManager {
         }
         if let Some(schedule) = self.fee_schedule.get() {
             fresh.set_fee_schedule(schedule);
+        }
+        // Propagate the per-contract NATS factory down the fresh subtree BEFORE
+        // publishing so it is configured-before-visible. Only when a factory is
+        // configured, keeping the no-factory path identical.
+        #[cfg(feature = "nats")]
+        if let Some(factory) = self.nats_factory.get() {
+            fresh.set_nats_factory(Some(factory));
         }
         // Atomic, idempotent publish: first inserter wins and is never evicted.
         let entry = self.underlyings.get_or_insert(underlying, fresh);

--- a/tests/unit/layering_tests.rs
+++ b/tests/unit/layering_tests.rs
@@ -83,6 +83,11 @@ const PRICING_TYPES: &[&str] = &[
 /// types and the factory alias but does not import the `nats` module — is not
 /// tripped, while a stray `use super::nats::…` in `strike.rs` / `chain.rs` /
 /// `expiration.rs` / `underlying.rs` is.
+///
+/// The needles match as **substrings**, so `orderbook::nats` also rejects every
+/// fully-qualified form (`crate::orderbook::nats::…`, `self::orderbook::nats::…`,
+/// `use crate :: orderbook::nats`), and `super::nats` covers the relative form —
+/// there is no qualified import style that bypasses the guard.
 const FORBIDDEN_MODULE_IMPORTS: &[&str] = &["super::nats", "orderbook::nats"];
 
 /// Strips full-line comments (doc comments and `//` comments) from source so the

--- a/tests/unit/layering_tests.rs
+++ b/tests/unit/layering_tests.rs
@@ -75,6 +75,16 @@ const PRICING_TYPES: &[&str] = &[
     "MarkPriceConfig",
 ];
 
+/// Eventing-layer module-import paths a guarded core / shared file must never
+/// use. The hierarchy receives any NATS wiring as an `orderbook_rs`-native
+/// listener factory threaded through the leaf (`book.rs`), never by importing
+/// the crate's `nats` module (issue #102). These needles are *path-scoped*
+/// (`module::`), so `book.rs` — which legitimately defines the `Nats*` listener
+/// types and the factory alias but does not import the `nats` module — is not
+/// tripped, while a stray `use super::nats::…` in `strike.rs` / `chain.rs` /
+/// `expiration.rs` / `underlying.rs` is.
+const FORBIDDEN_MODULE_IMPORTS: &[&str] = &["super::nats", "orderbook::nats"];
+
 /// Strips full-line comments (doc comments and `//` comments) from source so the
 /// structural check only inspects actual code. Documentation legitimately
 /// references the pricing modules by name (e.g. to explain the layering), so it
@@ -165,6 +175,17 @@ fn core_hierarchy_does_not_import_pricing_subsystem() {
                 "layering inversion: core-hierarchy / shared-service file `{rel}` \
                  references pricing symbol `{needle}`. The pricing subsystem reads \
                  the hierarchy, not the reverse (see issue #89).",
+            );
+        }
+
+        for needle in FORBIDDEN_MODULE_IMPORTS {
+            assert!(
+                !code.contains(needle),
+                "layering inversion: core-hierarchy / shared-service file `{rel}` \
+                 imports the eventing `nats` module via `{needle}`. NATS wiring must \
+                 reach the hierarchy as an orderbook_rs-native listener factory \
+                 threaded through `book.rs`, never by importing the `nats` module \
+                 (see issue #102).",
             );
         }
     }


### PR DESCRIPTION
## Summary

After #58, NATS publishers attached only to a standalone `OptionOrderBook` built
via `build_option_order_book_with_nats`, because `orderbook_rs` listeners must be
installed before the `Arc` wrap. Contract books created lazily by the hierarchy
(`get_or_create_strike` → `OptionOrderBook::new`) got no NATS wiring, so a
market-making deployment couldn't publish from the books the hierarchy actually
creates on demand. This wires every lazily-created contract book to its own
per-contract publisher.

## Changes

- Thread an `orderbook_rs`-native listener factory
  `ContractNatsListenerFactory = Arc<dyn Fn(&str) -> Option<PreparedNatsListeners>>`
  (defined in `book.rs`) down through the managers via the existing
  setter-propagation pattern (`set_nats_factory`, mirroring `fee_schedule` /
  `stp_mode`) — **no existing constructor signature changes**. The factory is
  keyed by per-contract symbol and returns the same native `TradeListener` +
  `PriceLevelChangedListener` that #58 installs pre-`Arc`.
- `nats.rs` supplies the factory via the new
  `build_underlying_manager_with_nats(config)` builder — the only public-surface
  addition. The core hierarchy never imports the `nats` module (only
  `super::book::ContractNatsListenerFactory`).
- Listeners are installed pre-`Arc` inside `StrikeOrderBookManager`'s
  `get_or_insert_with` closure; the one-time global side effects (instrument-ID
  allocation, symbol-index registration) stay gated to the `Arc::ptr_eq`
  insertion winner (the #49 winner path).
- The layering guard test (`tests/unit/layering_tests.rs`) now also rejects any
  `super::nats` / `orderbook::nats` import in a core/shared file.

## Technical decisions

A race-losing candidate under same-strike contention can transiently build a
publisher-wired call/put pair (crossbeam's `get_or_insert_with` may run the build
closure on a loser). This is safe and was verified by an adversarial determinism
audit: the loser allocates no instrument ID and registers no symbol (gated by
`Arc::ptr_eq` after the insert), and its publisher tasks block on an empty
channel and exit on channel-close when the loser drops — **no phantom NATS
message is ever emitted**, and the build cost is bounded to one extra pair per
racing thread (no retry loop). Per-hierarchy publisher teardown is intentionally
drop-driven (in-flight events drain before the task exits); the standalone
`build_option_order_book_with_nats` path still returns `NatsPublisherHandles` for
explicit async shutdown. All NATS code stays behind `#[cfg(feature = "nats")]`;
the default build is byte-for-byte unchanged (verified by hot-path review).

## Public API impact

Adds one `pub` item, `build_underlying_manager_with_nats` (feature `nats`),
re-exported from `src/orderbook/mod.rs` and `src/lib.rs`. All other new items
(`with_nats_factory`, `set_nats_factory`, the factory/holder types) are
`pub(crate)`. No existing public item changed. README unchanged (no module-doc
delta). Version stays `0.5.0`.

## Testing

- [x] Unit tests added or updated
- [x] Integration tests under `tests/unit/` added or updated (layering guard extended)
- [x] `make pre-push` run locally and clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No `unsafe` introduced
- [x] Layering respected (one-way leaf-up; core hierarchy never imports the `nats` module — enforced by the guard test)
- [x] Matching delegated to `orderbook-rs`; Greeks delegated to `optionstratlib`
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `src/lib.rs` re-exports updated for the new public item

Closes #102
