### PR TITLE
Align chain symbol-index wiring and books_affected unit (#79)

### DIFF
--- a/examples/07_mass_cancel.rs
+++ b/examples/07_mass_cancel.rs
@@ -70,7 +70,7 @@ fn main() {
         // Cancel all sell orders across the chain
         if let Ok(result) = chain.cancel_by_side(Side::Sell) {
             info!(
-                "Cancelled {} sell orders across {} strikes",
+                "Cancelled {} sell orders across {} contract books",
                 result.total_cancelled(),
                 result.books_affected()
             );
@@ -144,7 +144,7 @@ fn main() {
 
         if let Ok(result) = btc.cancel_all() {
             info!(
-                "Cancelled {} orders across {} expirations",
+                "Cancelled {} orders across {} contract books",
                 result.total_cancelled(),
                 result.books_affected()
             );
@@ -165,7 +165,7 @@ fn main() {
 
     if let Ok(result) = manager.cancel_all_across_underlyings() {
         info!(
-            "\nGlobal cancel: {} orders cancelled across {} underlyings",
+            "\nGlobal cancel: {} orders cancelled across {} contract books",
             result.total_cancelled(),
             result.books_affected()
         );

--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -639,11 +639,16 @@ pub struct ChainMassCancelResult {
 }
 
 impl ChainMassCancelResult {
-    /// Returns the number of strike books with cancelled orders.
+    /// Returns the number of leaf option books with cancelled orders.
     ///
     /// # Description
     ///
-    /// Counts how many strike books recorded at least one cancelled order.
+    /// Drills into each per-strike result and sums its affected leaf
+    /// [`OptionOrderBook`](super::book::OptionOrderBook)s (call/put contract
+    /// books). The unit is a leaf contract book — identical to the unit reported
+    /// at every other level — so results aggregate cleanly up the tree (a chain
+    /// spanning `N` strikes with both legs touched reports `2N`). This is NOT a
+    /// count of affected strikes.
     ///
     /// # Arguments
     ///
@@ -651,7 +656,7 @@ impl ChainMassCancelResult {
     ///
     /// # Returns
     ///
-    /// Number of strike books affected (books).
+    /// Number of leaf option books affected (call/put contract books).
     ///
     /// # Errors
     ///
@@ -669,8 +674,8 @@ impl ChainMassCancelResult {
     pub fn books_affected(&self) -> usize {
         self.per_child
             .iter()
-            .filter(|(_, result)| result.total_cancelled() > 0)
-            .count()
+            .map(|(_, result)| result.books_affected())
+            .sum()
     }
 
     /// Returns the total number of cancelled orders across the chain.
@@ -728,6 +733,9 @@ pub struct OptionChainOrderBookManager {
     contract_specs: SharedContractSpecs,
     /// Instrument registry propagated to newly created chains.
     registry: Option<Arc<InstrumentRegistry>>,
+    /// Symbol index propagated to newly created chains so that strikes created
+    /// through this manager register their call/put symbols for O(1) lookup.
+    symbol_index: Option<Arc<SymbolIndex>>,
     /// STP mode propagated to newly created chains.
     stp_mode: SharedSTPMode,
     /// Fee schedule propagated to newly created chains.
@@ -748,6 +756,7 @@ impl OptionChainOrderBookManager {
             validation_config: SharedValidationConfig::new(),
             contract_specs: SharedContractSpecs::new(),
             registry: None,
+            symbol_index: None,
             stp_mode: SharedSTPMode::new(),
             fee_schedule: SharedFeeSchedule::new(),
         }
@@ -774,6 +783,43 @@ impl OptionChainOrderBookManager {
             validation_config: SharedValidationConfig::new(),
             contract_specs: SharedContractSpecs::new(),
             registry: Some(registry),
+            symbol_index: None,
+            stp_mode: SharedSTPMode::new(),
+            fee_schedule: SharedFeeSchedule::new(),
+        }
+    }
+
+    /// Creates a new option chain manager with both an instrument registry and a
+    /// symbol index.
+    ///
+    /// Mirrors [`ExpirationOrderBookManager::new_with_registry_and_index`]: the
+    /// registry is propagated to newly created chains for unique instrument-ID
+    /// allocation, and the symbol index is propagated so that every strike
+    /// created beneath this manager registers its call/put symbols for O(1)
+    /// lookup. Both are forwarded together through
+    /// [`get_or_create`](Self::get_or_create) to the chain's strike manager.
+    ///
+    /// [`ExpirationOrderBookManager::new_with_registry_and_index`]: super::expiration::ExpirationOrderBookManager::new_with_registry_and_index
+    ///
+    /// # Arguments
+    ///
+    /// * `underlying` - The underlying asset symbol
+    /// * `registry` - The instrument registry for ID allocation
+    /// * `symbol_index` - The symbol index for O(1) lookups
+    #[must_use]
+    #[allow(dead_code)]
+    pub(crate) fn new_with_registry_and_index(
+        underlying: impl Into<String>,
+        registry: Arc<InstrumentRegistry>,
+        symbol_index: Arc<SymbolIndex>,
+    ) -> Self {
+        Self {
+            chains: SkipMap::new(),
+            underlying: underlying.into(),
+            validation_config: SharedValidationConfig::new(),
+            contract_specs: SharedContractSpecs::new(),
+            registry: Some(registry),
+            symbol_index: Some(symbol_index),
             stp_mode: SharedSTPMode::new(),
             fee_schedule: SharedFeeSchedule::new(),
         }
@@ -890,14 +936,19 @@ impl OptionChainOrderBookManager {
         // winning chain is configured-before-visible. Configuration only mutates
         // the fresh object (no global side effects), so a race loser's chain is
         // dropped harmlessly.
-        let fresh = if let Some(ref reg) = self.registry {
-            Arc::new(OptionChainOrderBook::new_with_registry(
+        let fresh = match (&self.registry, &self.symbol_index) {
+            (Some(reg), Some(idx)) => Arc::new(OptionChainOrderBook::new_with_registry_and_index(
                 &self.underlying,
                 expiration,
                 Arc::clone(reg),
-            ))
-        } else {
-            Arc::new(OptionChainOrderBook::new(&self.underlying, expiration))
+                Arc::clone(idx),
+            )),
+            (Some(reg), None) => Arc::new(OptionChainOrderBook::new_with_registry(
+                &self.underlying,
+                expiration,
+                Arc::clone(reg),
+            )),
+            _ => Arc::new(OptionChainOrderBook::new(&self.underlying, expiration)),
         };
         if let Some(ref config) = self.validation_config.get() {
             fresh.set_validation(config.clone());
@@ -1379,7 +1430,10 @@ mod tests {
         };
 
         assert_eq!(result.total_cancelled(), 3);
-        assert_eq!(result.books_affected(), 2);
+        // `books_affected` is the leaf option-book unit: strike 50000 touched
+        // both legs (call + put = 2 books) and strike 52000 touched only the
+        // call (1 book), so 3 leaf books are affected (NOT 2 strikes).
+        assert_eq!(result.books_affected(), 3);
         assert_eq!(chain.total_order_count(), 0);
     }
 
@@ -1737,5 +1791,66 @@ mod tests {
 
         let count = manager.iter().count();
         assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_chain_manager_get_or_create_registers_strikes_in_symbol_index() {
+        use optionstratlib::OptionStyle;
+
+        // A strike created through the PUBLIC chain manager — wired with a
+        // registry + symbol index via `new_with_registry_and_index`, mirroring
+        // the expiration manager — must register its call/put symbols in the
+        // supplied `SymbolIndex`. Before this wiring the chain manager had no
+        // index and strikes created through it were invisible to symbol lookup.
+        let registry = Arc::new(InstrumentRegistry::new());
+        let symbol_index = Arc::new(SymbolIndex::new());
+        let manager = OptionChainOrderBookManager::new_with_registry_and_index(
+            "BTC",
+            Arc::clone(&registry),
+            Arc::clone(&symbol_index),
+        );
+
+        assert!(symbol_index.is_empty());
+
+        let chain = manager.get_or_create(test_expiration());
+        let _strike = chain.get_or_create_strike(50000);
+
+        // Exactly the call + put pair for the one strike is registered.
+        assert_eq!(symbol_index.len(), 2);
+
+        let entries = symbol_index.entries();
+        let call = entries
+            .iter()
+            .find(|(_, r)| r.option_style() == OptionStyle::Call)
+            .expect("call symbol registered");
+        let put = entries
+            .iter()
+            .find(|(_, r)| r.option_style() == OptionStyle::Put)
+            .expect("put symbol registered");
+        assert_eq!(call.1.underlying(), "BTC");
+        assert_eq!(call.1.strike(), 50000);
+        assert_eq!(put.1.underlying(), "BTC");
+        assert_eq!(put.1.strike(), 50000);
+
+        // Repeat creation of the same strike is idempotent and does not
+        // double-register in the index.
+        let again = chain.get_or_create_strike(50000);
+        assert!(Arc::ptr_eq(&again, &chain.get_or_create_strike(50000)));
+        assert_eq!(symbol_index.len(), 2);
+    }
+
+    #[test]
+    fn test_chain_manager_no_symbol_index_by_default() {
+        // The plain `new` constructor wires no symbol index, so strikes created
+        // through it allocate no index entries (the additive `new_with_registry`
+        // / `new_with_registry_and_index` opt-in path leaves `new` unchanged).
+        let symbol_index = Arc::new(SymbolIndex::new());
+        let manager = OptionChainOrderBookManager::new("BTC");
+
+        let chain = manager.get_or_create(test_expiration());
+        let _strike = chain.get_or_create_strike(50000);
+
+        // The externally held index is never touched by a manager built via `new`.
+        assert!(symbol_index.is_empty());
     }
 }

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -978,11 +978,16 @@ pub struct ExpirationMassCancelResult {
 }
 
 impl ExpirationMassCancelResult {
-    /// Returns the number of chain books with cancelled orders.
+    /// Returns the number of leaf option books with cancelled orders.
     ///
     /// # Description
     ///
-    /// Counts how many chain books recorded at least one cancelled order.
+    /// Drills into each per-chain result and sums its affected leaf
+    /// [`OptionOrderBook`](super::book::OptionOrderBook)s (call/put contract
+    /// books). The unit is a leaf contract book — identical to the unit reported
+    /// at every other level — so results aggregate cleanly up the tree and match
+    /// the same count read at the chain / underlying / global levels. This is NOT
+    /// a count of affected chains.
     ///
     /// # Arguments
     ///
@@ -990,7 +995,7 @@ impl ExpirationMassCancelResult {
     ///
     /// # Returns
     ///
-    /// Number of chain books affected (books).
+    /// Number of leaf option books affected (call/put contract books).
     ///
     /// # Errors
     ///
@@ -1008,8 +1013,8 @@ impl ExpirationMassCancelResult {
     pub fn books_affected(&self) -> usize {
         self.per_child
             .iter()
-            .filter(|(_, result)| result.total_cancelled() > 0)
-            .count()
+            .map(|(_, result)| result.books_affected())
+            .sum()
     }
 
     /// Returns the total number of cancelled orders across the expiration.

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -645,11 +645,16 @@ pub struct StrikeMassCancelResult {
 }
 
 impl StrikeMassCancelResult {
-    /// Returns the number of option books with cancelled orders.
+    /// Returns the number of leaf option books with cancelled orders.
     ///
     /// # Description
     ///
-    /// Counts how many option books recorded at least one cancelled order.
+    /// Counts how many leaf [`OptionOrderBook`](super::book::OptionOrderBook)s
+    /// (call/put contract books) recorded at least one cancelled order. This is
+    /// the leaf base case of `books_affected`: every higher level
+    /// (chain / expiration / underlying / global) drills down and sums these, so
+    /// the unit is a leaf contract book at every level and the counts aggregate
+    /// cleanly up the tree.
     ///
     /// # Arguments
     ///
@@ -657,7 +662,7 @@ impl StrikeMassCancelResult {
     ///
     /// # Returns
     ///
-    /// Number of books affected (books).
+    /// Number of leaf option books affected (call/put contract books).
     ///
     /// # Errors
     ///

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -99,11 +99,16 @@ pub struct UnderlyingMassCancelResult {
 }
 
 impl UnderlyingMassCancelResult {
-    /// Returns the number of expiration books with cancelled orders.
+    /// Returns the number of leaf option books with cancelled orders.
     ///
     /// # Description
     ///
-    /// Counts how many expiration books recorded at least one cancelled order.
+    /// Drills into each per-expiration result and sums its affected leaf
+    /// [`OptionOrderBook`](super::book::OptionOrderBook)s (call/put contract
+    /// books). The unit is a leaf contract book — identical to the unit reported
+    /// at every other level — so results aggregate cleanly up the tree and match
+    /// the same count read at the expiration / global levels. This is NOT a count
+    /// of affected expirations.
     ///
     /// # Arguments
     ///
@@ -111,7 +116,7 @@ impl UnderlyingMassCancelResult {
     ///
     /// # Returns
     ///
-    /// Number of expiration books affected (books).
+    /// Number of leaf option books affected (call/put contract books).
     ///
     /// # Errors
     ///
@@ -129,8 +134,8 @@ impl UnderlyingMassCancelResult {
     pub fn books_affected(&self) -> usize {
         self.per_child
             .iter()
-            .filter(|(_, result)| result.total_cancelled() > 0)
-            .count()
+            .map(|(_, result)| result.books_affected())
+            .sum()
     }
 
     /// Returns the total number of cancelled orders across the underlying.
@@ -1604,11 +1609,16 @@ pub struct GlobalMassCancelResult {
 }
 
 impl GlobalMassCancelResult {
-    /// Returns the number of underlying books with cancelled orders.
+    /// Returns the number of leaf option books with cancelled orders.
     ///
     /// # Description
     ///
-    /// Counts how many underlying books recorded at least one cancelled order.
+    /// Drills into each per-underlying result and sums its affected leaf
+    /// [`OptionOrderBook`](super::book::OptionOrderBook)s (call/put contract
+    /// books). The unit is a leaf contract book — identical to the unit reported
+    /// at every other level — so the global total equals the sum of the
+    /// per-underlying / per-expiration / per-chain leaf counts. This is NOT a
+    /// count of affected underlyings.
     ///
     /// # Arguments
     ///
@@ -1616,7 +1626,7 @@ impl GlobalMassCancelResult {
     ///
     /// # Returns
     ///
-    /// Number of underlying books affected (books).
+    /// Number of leaf option books affected (call/put contract books).
     ///
     /// # Errors
     ///
@@ -1634,8 +1644,8 @@ impl GlobalMassCancelResult {
     pub fn books_affected(&self) -> usize {
         self.per_child
             .iter()
-            .filter(|(_, result)| result.total_cancelled() > 0)
-            .count()
+            .map(|(_, result)| result.books_affected())
+            .sum()
     }
 
     /// Returns the total number of cancelled orders across all underlyings.
@@ -1714,8 +1724,74 @@ mod tests {
         };
 
         assert_eq!(result.total_cancelled(), 2);
+        // Each of the two expirations touched exactly one leaf option book, so
+        // the leaf-book unit (2) coincides with the expiration count here.
         assert_eq!(result.books_affected(), 2);
         assert_eq!(book.total_order_count(), 0);
+    }
+
+    #[test]
+    fn test_books_affected_consistent_leaf_unit_across_levels() {
+        // A mass cancel spanning N strikes with BOTH legs populated must report
+        // the SAME leaf-option-book count (2N) regardless of the level at which
+        // `books_affected` is read — chain, expiration, underlying, or global.
+        // Each level drills down to leaf contract books, so the unit is stable
+        // and the counts aggregate cleanly up the tree.
+        const N: u64 = 3;
+        let exp = test_expiration();
+        let expected = 2 * (N as usize); // 2 legs × N strikes
+
+        // Populate a single expiration with N strikes, an order on each leg.
+        let populate = |book: &UnderlyingOrderBook| {
+            let exp_book = book.get_or_create_expiration(exp);
+            for i in 0..N {
+                let strike = 50000 + i * 1000;
+                let s = exp_book.get_or_create_strike(strike);
+                s.call()
+                    .add_limit_order(OrderId::new(), Side::Buy, 100, 10)
+                    .expect("add call");
+                s.put()
+                    .add_limit_order(OrderId::new(), Side::Sell, 50, 5)
+                    .expect("add put");
+            }
+        };
+
+        // Chain level (drilled to the chain under the single expiration).
+        let book_a = UnderlyingOrderBook::new("BTC");
+        populate(&book_a);
+        let chain_result = book_a
+            .get_expiration(&exp)
+            .expect("expiration exists")
+            .chain()
+            .cancel_all()
+            .expect("chain cancel");
+        assert_eq!(chain_result.total_cancelled(), expected);
+        assert_eq!(chain_result.books_affected(), expected);
+
+        // Expiration level (fresh tree — cancel is destructive).
+        let book_b = UnderlyingOrderBook::new("BTC");
+        populate(&book_b);
+        let exp_result = book_b
+            .get_expiration(&exp)
+            .expect("expiration exists")
+            .cancel_all()
+            .expect("expiration cancel");
+        assert_eq!(exp_result.books_affected(), expected);
+
+        // Underlying level (fresh tree).
+        let book_c = UnderlyingOrderBook::new("BTC");
+        populate(&book_c);
+        let underlying_result = book_c.cancel_all().expect("underlying cancel");
+        assert_eq!(underlying_result.books_affected(), expected);
+
+        // Global level (fresh tree, through the top-level manager).
+        let manager = UnderlyingOrderBookManager::new();
+        let book_d = manager.get_or_create("BTC");
+        populate(&book_d);
+        let global_result = manager
+            .cancel_all_across_underlyings()
+            .expect("global cancel");
+        assert_eq!(global_result.books_affected(), expected);
     }
 
     #[test]

--- a/tests/unit/orderbook_tests.rs
+++ b/tests/unit/orderbook_tests.rs
@@ -96,7 +96,10 @@ fn test_cancel_all_across_underlyings() {
     };
 
     assert_eq!(result.total_cancelled(), 3);
-    assert_eq!(result.books_affected(), 2);
+    // `books_affected` reports leaf option books (call/put contract books):
+    // BTC touched both legs (2 books) and ETH touched only the call (1 book),
+    // so 3 leaf books are affected (NOT 2 underlyings).
+    assert_eq!(result.books_affected(), 3);
     assert_eq!(manager.total_order_count(), 0);
 }
 


### PR DESCRIPTION
## Summary

Two manager-level API inconsistencies. (A) `OptionChainOrderBookManager` had no
`symbol_index` field or constructor (unlike `StrikeOrderBookManager` /
`ExpirationOrderBookManager`), so strikes created through this public manager were
never registered in a `SymbolIndex` with no way to opt in. (B) `books_affected()`
silently changed unit per level (chains vs strikes vs option-books), so a consumer
aggregating mass-cancel results up the tree got a method whose meaning shifted.

## Changes

- **Part A — chain symbol-index wiring.** Add a private `symbol_index` field
  (`None` in the existing `new` / `new_with_registry` constructors) and a
  `pub(crate) new_with_registry_and_index(...)` mirroring
  `ExpirationOrderBookManager`; `get_or_create` selects it so both call/put legs
  register via the single #51-hardened `StrikeOrderBookManager::assign_instrument_ids`
  path (same key format — no divergent reimplementation).
- **Part B — `books_affected` consistent unit.** Make it report leaf
  `OptionOrderBook`s affected at every level (strike/chain/expiration/underlying/
  global), computed as the sum of each child's `books_affected()` over the ordered
  `per_child`/`per_book` Vecs. The strike base case already counted call/put legs
  with `cancelled_count() > 0`; higher levels now drill down to leaves instead of
  counting immediate children, so the count is additive up the tree.

## Technical decisions

`books_affected()`'s signature is unchanged but its **return value's meaning
changes** at chain/expiration/underlying/global (immediate-children → leaf books).
This is the intended fix and is source-compatible; it falls within the 0.4.4 →
0.5.0 window this batch ships under. The previous "children touched" signal is not
lost — it is recoverable from the `pub per_child` vectors
(`per_child.iter().filter(|(_, r)| r.total_cancelled() > 0).count()`). Method docs
now state the leaf-book unit at every level and explicitly negate the old reading.
`books_affected()` is never journaled or published (only `total_cancelled()` is),
so no sequencer/NATS event or replay payload changes — verified by a determinism
audit. The `examples/07_mass_cancel.rs` log lines that captioned `books_affected()`
as "strikes"/"expirations"/"underlyings" are corrected to "contract books".

## Public API impact

No public surface change: the new constructor is `pub(crate)`, the new field is
private, and `books_affected()`'s signature is unchanged. `make readme` is a no-op
(no `pub` item or crate-doc delta). Version stays `0.5.0`.

## Testing

- [x] Unit tests added (chain-manager registers strikes in the supplied index;
  `books_affected` reports the consistent leaf unit — N strikes × 2 legs = 2N read
  at chain, expiration, underlying and global levels)
- [x] Updated two existing assertions whose value changed under the new unit
- [x] `make pre-push` run locally and clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No `unsafe` introduced
- [x] Layering respected (mass-cancel rollup stays leaf-up; no higher-level import)
- [x] Counts are deterministic pure sums over ordered containers (audited)
- [x] No new dependencies / feature flags
- [x] `tracing` only for logging

Closes #79
