### PR TITLE
Eliminate per-quote/per-trade allocations on the leaf hot path (#80)

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,9 @@ cargo bench -- hierarchy_benches
 Built on OrderBook-rs's lock-free architecture:
 
 - **Order Operations**: O(log N) for add/cancel operations
-- **Best Quote Lookup**: O(1) with caching
+- **Best Quote Lookup**: small bounded top-of-book read (best price per side
+  plus the aggregate size at that single best level); no caching and no
+  full-book scan or heap allocation
 - **Thread Safety**: Lock-free operations for concurrent access
 - **Hierarchy Traversal**: O(log N) access via `SkipMap`
 

--- a/benches/orderbook_bench.rs
+++ b/benches/orderbook_bench.rs
@@ -50,14 +50,14 @@ pub fn orderbook_operations(c: &mut Criterion) {
         );
     });
 
-    // Benchmark update_last_quote
-    group.bench_function("update_last_quote", |b| {
-        let mut book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-        book.add_limit_order(OrderId::new(), Side::Buy, 100, 10)
-            .unwrap();
-        book.add_limit_order(OrderId::new(), Side::Sell, 101, 5)
-            .unwrap();
-        b.iter(|| book.update_last_quote());
+    // Benchmark getting best quote from a one-sided (bid-only) book
+    group.bench_function("best_quote_one_sided", |b| {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        for i in 0..100 {
+            book.add_limit_order(OrderId::new(), Side::Buy, 100 - i, 10)
+                .unwrap();
+        }
+        b.iter(|| book.best_quote());
     });
 
     // Benchmark snapshot creation

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,9 @@
 //! Built on OrderBook-rs's lock-free architecture:
 //!
 //! - **Order Operations**: O(log N) for add/cancel operations
-//! - **Best Quote Lookup**: O(1) with caching
+//! - **Best Quote Lookup**: small bounded top-of-book read (best price per side
+//!   plus the aggregate size at that single best level); no caching and no
+//!   full-book scan or heap allocation
 //! - **Thread Safety**: Lock-free operations for concurrent access
 //! - **Hierarchy Traversal**: O(log N) access via `SkipMap`
 //!

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -223,22 +223,24 @@ impl std::iter::Sum for TerminalOrderSummary {
     }
 }
 
-/// RAII guard that arms trade capture for a scope and restores the previous
-/// armed state on drop.
+/// RAII guard that holds a scoped trade-capture arm for its lifetime.
 ///
 /// Constructed by [`OptionOrderBook::arm_capture_scope`] so the `_full` order
 /// methods capture their own trade without leaving the book permanently armed.
+/// It increments a scope refcount on entry and decrements it on drop; capture is
+/// active while the refcount is non-zero (or the book is manually armed). Using a
+/// refcount rather than a save/restore boolean makes overlapping `_full` scopes
+/// on the same book compose correctly — no scope can clobber another's state or
+/// leave the book stuck armed.
 struct CaptureArmGuard<'a> {
-    /// The book's armed flag.
-    flag: &'a AtomicBool,
-    /// Armed state observed at scope entry, restored on drop.
-    previous: bool,
+    /// The book's scoped-arm refcount, decremented on drop.
+    scopes: &'a AtomicUsize,
 }
 
 impl Drop for CaptureArmGuard<'_> {
     #[inline]
     fn drop(&mut self) {
-        self.flag.store(self.previous, Ordering::Relaxed);
+        self.scopes.fetch_sub(1, Ordering::Relaxed);
     }
 }
 
@@ -339,6 +341,12 @@ pub struct OptionOrderBook {
     /// trade; [`arm_trade_capture`](Self::arm_trade_capture) opts a book into
     /// continuous capture for [`last_trade_result`](Self::last_trade_result).
     trade_capture_armed: Arc<AtomicBool>,
+    /// Refcount of active `_full` capture scopes. Capture is also active while
+    /// this is non-zero, so overlapping `_full` calls on the same book compose
+    /// correctly (each scope increments on entry and decrements on drop) without
+    /// clobbering each other's armed state or the manual `trade_capture_armed`
+    /// flag.
+    trade_capture_scopes: Arc<AtomicUsize>,
     /// Cumulative terminal order counters maintained by the state listener.
     ///
     /// `None` when state tracking is disabled via `BookConfig`.
@@ -377,15 +385,19 @@ impl OptionOrderBook {
         }
 
         // Install trade-capture listener so `_full` methods can return TradeResult.
-        // The clone+lock is gated behind a cheap relaxed atomic so the common
-        // (non-`_full`, unarmed) match path pays only one atomic load and never
+        // The clone+lock is gated behind two cheap relaxed atomics — the manual
+        // `armed` flag and the `_full` scope refcount — so the common
+        // (non-`_full`, unarmed) match path pays only the atomic loads and never
         // clones the TradeResult or takes the lock.
         let capture: Arc<Mutex<Option<TradeResult>>> = Arc::new(Mutex::new(None));
         let armed: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        let scopes: Arc<AtomicUsize> = Arc::new(AtomicUsize::new(0));
         let capture_clone = Arc::clone(&capture);
         let armed_clone = Arc::clone(&armed);
+        let scopes_clone = Arc::clone(&scopes);
         let capture_listener: TradeListener = Arc::new(move |tr: &TradeResult| {
-            if !armed_clone.load(Ordering::Relaxed) {
+            // Capture when manually armed OR inside at least one `_full` scope.
+            if !armed_clone.load(Ordering::Relaxed) && scopes_clone.load(Ordering::Relaxed) == 0 {
                 return;
             }
             let mut guard = capture_clone
@@ -445,6 +457,7 @@ impl OptionOrderBook {
             instrument_id: AtomicU32::new(config.instrument_id),
             last_trade_result: capture,
             trade_capture_armed: armed,
+            trade_capture_scopes: scopes,
             terminal_counters,
         }
     }
@@ -1075,17 +1088,18 @@ impl OptionOrderBook {
     // ── Full order methods (return TradeResult) ─────────────────────────
 
     /// Arms trade capture for the lifetime of the returned guard, restoring the
-    /// previous armed state on drop.
+    /// scope refcount on drop.
     ///
     /// Used by the `_full` order methods so a trade is captured even when the
-    /// book is not under continuous capture. The guard restores (rather than
-    /// unconditionally disarming) so a `_full` call nested inside an armed scope
-    /// leaves capture armed afterwards.
+    /// book is not under continuous capture. Incrementing a refcount (rather than
+    /// saving/restoring a boolean) means overlapping `_full` scopes on the same
+    /// book compose correctly: capture stays active until the last scope exits,
+    /// and the manual [`arm_trade_capture`](Self::arm_trade_capture) flag is left
+    /// untouched.
     fn arm_capture_scope(&self) -> CaptureArmGuard<'_> {
-        let previous = self.trade_capture_armed.swap(true, Ordering::Relaxed);
+        self.trade_capture_scopes.fetch_add(1, Ordering::Relaxed);
         CaptureArmGuard {
-            flag: &self.trade_capture_armed,
-            previous,
+            scopes: &self.trade_capture_scopes,
         }
     }
 
@@ -1994,6 +2008,55 @@ mod tests {
         assert_eq!(book.order_count(), 0);
         // Arm state restored to disarmed after the _full call.
         assert!(!book.is_trade_capture_armed());
+    }
+
+    #[test]
+    fn test_capture_scopes_refcount_composes() {
+        // Overlapping `_full` scopes must compose via the refcount: capture stays
+        // active until the LAST scope exits, the manual flag is never touched, and
+        // the book is not left stuck-armed once all scopes drop.
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        assert!(!book.is_trade_capture_armed());
+
+        let outer = book.arm_capture_scope();
+        let inner = book.arm_capture_scope();
+        // Two scopes active: a plain matching order is captured.
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 5)
+            .expect("add ask");
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 5)
+            .expect("add crossing buy");
+        assert!(
+            book.last_trade_result().is_some(),
+            "capture active while a scope is held"
+        );
+
+        // Dropping one scope leaves capture active (refcount still 1); the manual
+        // flag was never set, so this is not a stuck-armed state.
+        drop(inner);
+        assert!(!book.is_trade_capture_armed());
+        book.clear_trade_capture();
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 3)
+            .expect("add ask");
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 3)
+            .expect("add crossing buy");
+        assert!(
+            book.last_trade_result().is_some(),
+            "capture still active with one scope remaining"
+        );
+
+        // Dropping the last scope returns to disarmed: a later plain match is not
+        // captured, and the manual flag remains false (no stuck-armed leak).
+        drop(outer);
+        assert!(!book.is_trade_capture_armed());
+        book.clear_trade_capture();
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 2)
+            .expect("add ask");
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 2)
+            .expect("add crossing buy");
+        assert!(
+            book.last_trade_result().is_none(),
+            "capture disarmed once all scopes drop"
+        );
     }
 
     #[test]

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -18,7 +18,7 @@ use orderbook_rs::{
 use pricelevel::{Hash32, MatchResult, Quantity};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
-use std::sync::atomic::{AtomicU8, AtomicU32, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -223,6 +223,25 @@ impl std::iter::Sum for TerminalOrderSummary {
     }
 }
 
+/// RAII guard that arms trade capture for a scope and restores the previous
+/// armed state on drop.
+///
+/// Constructed by [`OptionOrderBook::arm_capture_scope`] so the `_full` order
+/// methods capture their own trade without leaving the book permanently armed.
+struct CaptureArmGuard<'a> {
+    /// The book's armed flag.
+    flag: &'a AtomicBool,
+    /// Armed state observed at scope entry, restored on drop.
+    previous: bool,
+}
+
+impl Drop for CaptureArmGuard<'_> {
+    #[inline]
+    fn drop(&mut self) {
+        self.flag.store(self.previous, Ordering::Relaxed);
+    }
+}
+
 /// Internal atomic counters for terminal state tracking via listener.
 pub(crate) struct TerminalCounters {
     filled: AtomicUsize,
@@ -294,8 +313,6 @@ pub struct OptionOrderBook {
     symbol_hash: u64,
     /// The underlying order book from OrderBook-rs.
     book: Arc<DefaultOrderBook>,
-    /// Last known quote for change detection.
-    last_quote: Arc<Quote>,
     /// The option style (Call or Put).
     option_style: OptionStyle,
     /// Unique identifier for this order book.
@@ -308,9 +325,20 @@ pub struct OptionOrderBook {
     instrument_id: AtomicU32,
     /// Captured trade result from the last order submission.
     ///
-    /// Populated by the internal trade listener when a matching occurs.
-    /// Used by the `_full` order methods to return [`TradeResult`].
+    /// Populated by the internal trade listener when a matching occurs *and*
+    /// trade capture is armed. Used by the `_full` order methods to return
+    /// [`TradeResult`].
     last_trade_result: Arc<Mutex<Option<TradeResult>>>,
+    /// Cheap armed flag gating the trade-capture clone+lock on the match hot
+    /// path.
+    ///
+    /// Disarmed by default: the always-installed trade listener performs a
+    /// single relaxed atomic load and returns without cloning the
+    /// [`TradeResult`] or taking the capture lock. The `_full` order methods arm
+    /// it for the duration of their own submission so they still observe the
+    /// trade; [`arm_trade_capture`](Self::arm_trade_capture) opts a book into
+    /// continuous capture for [`last_trade_result`](Self::last_trade_result).
+    trade_capture_armed: Arc<AtomicBool>,
     /// Cumulative terminal order counters maintained by the state listener.
     ///
     /// `None` when state tracking is disabled via `BookConfig`.
@@ -348,10 +376,18 @@ impl OptionOrderBook {
             book.set_fee_schedule(Some(schedule));
         }
 
-        // Install trade-capture listener so `_full` methods can return TradeResult
+        // Install trade-capture listener so `_full` methods can return TradeResult.
+        // The clone+lock is gated behind a cheap relaxed atomic so the common
+        // (non-`_full`, unarmed) match path pays only one atomic load and never
+        // clones the TradeResult or takes the lock.
         let capture: Arc<Mutex<Option<TradeResult>>> = Arc::new(Mutex::new(None));
+        let armed: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let capture_clone = Arc::clone(&capture);
+        let armed_clone = Arc::clone(&armed);
         let capture_listener: TradeListener = Arc::new(move |tr: &TradeResult| {
+            if !armed_clone.load(Ordering::Relaxed) {
+                return;
+            }
             let mut guard = capture_clone
                 .lock()
                 .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -403,12 +439,12 @@ impl OptionOrderBook {
             symbol,
             symbol_hash,
             book: Arc::new(book),
-            last_quote: Arc::new(Quote::empty(0)),
             option_style,
             id: OrderId::new(),
             status: AtomicU8::new(InstrumentStatus::Active as u8),
             instrument_id: AtomicU32::new(config.instrument_id),
             last_trade_result: capture,
+            trade_capture_armed: armed,
             terminal_counters,
         }
     }
@@ -627,19 +663,64 @@ impl OptionOrderBook {
     }
 
     /// Returns the trade result captured from the last order submission,
-    /// or `None` if no match occurred.
+    /// or `None` if no match occurred *while trade capture was armed*.
     ///
-    /// This is populated by the internal trade listener whenever a matching
-    /// event occurs. Prefer the `_full` order methods for reliable access.
+    /// Trade capture is **disarmed by default** to keep the per-match hot path
+    /// allocation-free: the internal listener only records a [`TradeResult`]
+    /// when the book is armed. The `_full` order methods arm capture for the
+    /// duration of their own submission, so they always observe their trade
+    /// regardless of this setting. To populate this accessor from the plain
+    /// (non-`_full`) order path, call
+    /// [`arm_trade_capture(true)`](Self::arm_trade_capture) first; with capture
+    /// disarmed this returns `None` (or the last value captured while armed).
     ///
     /// **Note:** concurrent calls to order methods on the same book may
-    /// overwrite this value before it is read.
+    /// overwrite this value before it is read — it is a single-slot,
+    /// last-write-wins poll, never a per-fill feed. For a reliable real-time
+    /// trade/fill stream use the NATS trade publisher (feature `nats`) or the
+    /// `_full` order methods' return values; for risk/PnL counters use the
+    /// order-state tracker. All three are independent of this arm flag.
+    ///
+    /// **Changed in 0.5.0:** trade capture is now disarmed by default, so the
+    /// plain order path no longer auto-populates this accessor. Pre-0.5.0 code
+    /// that polled `last_trade_result()` after a plain `add_*`/`cancel` must now
+    /// call [`arm_trade_capture(true)`](Self::arm_trade_capture) first, or switch
+    /// to one of the feeds above.
     #[must_use]
     pub fn last_trade_result(&self) -> Option<TradeResult> {
         self.last_trade_result
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .clone()
+    }
+
+    /// Arms or disarms continuous trade capture for this book.
+    ///
+    /// When armed, the internal trade listener clones each matching
+    /// [`TradeResult`] under a lock so it can be read back via
+    /// [`last_trade_result`](Self::last_trade_result). When disarmed (the
+    /// default), the listener short-circuits on a single relaxed atomic load,
+    /// adding no clone or lock cost to the match path.
+    ///
+    /// The `_full` order methods arm capture internally for their own
+    /// submission, so this toggle is only needed to observe trades made through
+    /// the plain (non-`_full`) order methods.
+    ///
+    /// Intended for a single controller: the `_full` methods save and restore
+    /// the prior arm state around their own submission, so interleaving a manual
+    /// `arm_trade_capture(true)` with concurrent `_full` calls on the same book
+    /// can race (a `_full` that captured the pre-arm `false` will restore it on
+    /// drop). Arm from one owner, not concurrently with `_full` traffic.
+    #[inline]
+    pub fn arm_trade_capture(&self, armed: bool) {
+        self.trade_capture_armed.store(armed, Ordering::Relaxed);
+    }
+
+    /// Returns whether continuous trade capture is currently armed.
+    #[must_use]
+    #[inline]
+    pub fn is_trade_capture_armed(&self) -> bool {
+        self.trade_capture_armed.load(Ordering::Relaxed)
     }
 
     /// Returns the current lifecycle status of this instrument.
@@ -993,6 +1074,21 @@ impl OptionOrderBook {
 
     // ── Full order methods (return TradeResult) ─────────────────────────
 
+    /// Arms trade capture for the lifetime of the returned guard, restoring the
+    /// previous armed state on drop.
+    ///
+    /// Used by the `_full` order methods so a trade is captured even when the
+    /// book is not under continuous capture. The guard restores (rather than
+    /// unconditionally disarming) so a `_full` call nested inside an armed scope
+    /// leaves capture armed afterwards.
+    fn arm_capture_scope(&self) -> CaptureArmGuard<'_> {
+        let previous = self.trade_capture_armed.swap(true, Ordering::Relaxed);
+        CaptureArmGuard {
+            flag: &self.trade_capture_armed,
+            previous,
+        }
+    }
+
     /// Clears the captured trade result before submitting an order.
     fn clear_trade_capture(&self) {
         let mut guard = self
@@ -1040,6 +1136,7 @@ impl OptionOrderBook {
         quantity: u64,
     ) -> Result<TradeResult> {
         self.check_active()?;
+        let _capture = self.arm_capture_scope();
         self.clear_trade_capture();
         self.book
             .add_limit_order(order_id, price, quantity, side, TimeInForce::Gtc, None)?;
@@ -1062,6 +1159,7 @@ impl OptionOrderBook {
         tif: TimeInForce,
     ) -> Result<TradeResult> {
         self.check_active()?;
+        let _capture = self.arm_capture_scope();
         self.clear_trade_capture();
         self.book
             .add_limit_order(order_id, price, quantity, side, tif, None)?;
@@ -1084,6 +1182,7 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<TradeResult> {
         self.check_active()?;
+        let _capture = self.arm_capture_scope();
         self.clear_trade_capture();
         self.book.add_limit_order_with_user(
             order_id,
@@ -1115,6 +1214,7 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<TradeResult> {
         self.check_active()?;
+        let _capture = self.arm_capture_scope();
         self.clear_trade_capture();
         self.book
             .add_limit_order_with_user(order_id, price, quantity, side, tif, user_id, None)?;
@@ -1499,45 +1599,76 @@ impl OptionOrderBook {
     }
 
     /// Returns the current best quote.
+    ///
+    /// This is a small bounded top-of-book read, not an O(1) cached lookup: it
+    /// reads the best price on each side and the aggregate size resting at that
+    /// single best level via
+    /// [`total_depth_at_levels`](orderbook_rs::OrderBook::total_depth_at_levels)
+    /// with `levels = 1`. It performs **no** full-book scan and **no** heap
+    /// allocation. A one-sided book yields a one-sided [`Quote`] (the empty side
+    /// has `None` price and zero size).
     #[must_use]
+    #[inline]
     pub fn best_quote(&self) -> Quote {
+        // Wall-clock stamp (non-monotonic). Safe here: `Quote` is a transient
+        // market-data read, is excluded from `Quote`'s `PartialEq`, and is never
+        // serialized into a journal record or NATS payload. Do NOT let a `Quote`
+        // (and hence this timestamp) feed a journaled/replayed path — thread an
+        // injected clock instead if that ever changes.
         let timestamp_ms = orderbook_rs::current_time_millis();
 
-        let (bid_price, bid_size) = self
-            .book
-            .best_bid()
-            .map(|p| (Some(p), self.bid_depth_at_price(p)))
-            .unwrap_or((None, 0));
+        // One ordered top-of-book read per populated side; `total_depth_at_levels`
+        // with `levels = 1` sums only the best level and never allocates.
+        let (bid_price, bid_size) = match self.book.best_bid() {
+            Some(p) => (Some(p), self.book.total_depth_at_levels(1, Side::Buy)),
+            None => (None, 0),
+        };
 
-        let (ask_price, ask_size) = self
-            .book
-            .best_ask()
-            .map(|p| (Some(p), self.ask_depth_at_price(p)))
-            .unwrap_or((None, 0));
+        let (ask_price, ask_size) = match self.book.best_ask() {
+            Some(p) => (Some(p), self.book.total_depth_at_levels(1, Side::Sell)),
+            None => (None, 0),
+        };
 
         Quote::new(bid_price, bid_size, ask_price, ask_size, timestamp_ms)
     }
 
+    /// Returns `true` if the book currently has resting orders on **both**
+    /// sides (a two-sided market).
+    ///
+    /// Cheaper than [`best_quote`](Self::best_quote) when only two-sidedness is
+    /// needed: it reads just the best price on each side and never computes
+    /// sizes or builds a [`Quote`]. Used by the strike layer to test whether a
+    /// contract is fully quoted.
+    #[must_use]
+    #[inline]
+    pub fn has_both_sides(&self) -> bool {
+        self.book.best_bid().is_some() && self.book.best_ask().is_some()
+    }
+
     /// Returns the best bid price.
     #[must_use]
+    #[inline]
     pub fn best_bid(&self) -> Option<u128> {
         self.book.best_bid()
     }
 
     /// Returns the best ask price.
     #[must_use]
+    #[inline]
     pub fn best_ask(&self) -> Option<u128> {
         self.book.best_ask()
     }
 
     /// Returns the mid price if both sides exist.
     #[must_use]
+    #[inline]
     pub fn mid_price(&self) -> Option<f64> {
         self.book.mid_price()
     }
 
     /// Returns the spread if both sides exist.
     #[must_use]
+    #[inline]
     pub fn spread(&self) -> Option<u128> {
         self.book.spread()
     }
@@ -1621,26 +1752,6 @@ impl OptionOrderBook {
     #[must_use]
     pub fn imbalance(&self, levels: usize) -> f64 {
         self.book.order_book_imbalance(levels)
-    }
-
-    /// Updates the last known quote and returns true if it changed.
-    pub fn update_last_quote(&mut self) -> bool {
-        let current = self.best_quote();
-        let changed = current != *self.last_quote;
-        self.last_quote = Arc::new(current);
-        changed
-    }
-
-    /// Returns a reference to the last known quote.
-    #[must_use]
-    pub fn last_quote(&self) -> &Quote {
-        &self.last_quote
-    }
-
-    /// Returns an Arc reference to the last known quote.
-    #[must_use]
-    pub fn last_quote_arc(&self) -> Arc<Quote> {
-        Arc::clone(&self.last_quote)
     }
 
     /// Returns depth at a specific price level on the bid side.
@@ -1767,6 +1878,122 @@ mod tests {
         assert_eq!(quote.ask_price(), Some(101));
         assert_eq!(quote.ask_size(), 5);
         assert!(quote.is_two_sided());
+        assert!(book.has_both_sides());
+    }
+
+    #[test]
+    fn test_best_quote_sums_best_level_only() {
+        // best_quote's size must aggregate all orders resting at the single
+        // best level (and not deeper levels), using total_depth_at_levels(1).
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+
+        // Two orders at the best bid (100), one deeper bid (99).
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 10)
+            .expect("add bid");
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 7)
+            .expect("add bid");
+        book.add_limit_order(OrderId::new(), Side::Buy, 99, 100)
+            .expect("add deep bid");
+        // Two orders at the best ask (101), one deeper ask (102).
+        book.add_limit_order(OrderId::new(), Side::Sell, 101, 5)
+            .expect("add ask");
+        book.add_limit_order(OrderId::new(), Side::Sell, 101, 3)
+            .expect("add ask");
+        book.add_limit_order(OrderId::new(), Side::Sell, 102, 100)
+            .expect("add deep ask");
+
+        let quote = book.best_quote();
+        assert_eq!(quote.bid_price(), Some(100));
+        assert_eq!(quote.bid_size(), 17); // 10 + 7, deeper 99 excluded
+        assert_eq!(quote.ask_price(), Some(101));
+        assert_eq!(quote.ask_size(), 8); // 5 + 3, deeper 102 excluded
+        assert!(quote.is_two_sided());
+        assert!(book.has_both_sides());
+    }
+
+    #[test]
+    fn test_best_quote_one_sided() {
+        // Bid-only book: ask side must be None/zero, not two-sided.
+        let bid_only = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        bid_only
+            .add_limit_order(OrderId::new(), Side::Buy, 100, 10)
+            .expect("add bid");
+        let q = bid_only.best_quote();
+        assert_eq!(q.bid_price(), Some(100));
+        assert_eq!(q.bid_size(), 10);
+        assert_eq!(q.ask_price(), None);
+        assert_eq!(q.ask_size(), 0);
+        assert!(!q.is_two_sided());
+        assert!(!bid_only.has_both_sides());
+
+        // Ask-only book: bid side must be None/zero, not two-sided.
+        let ask_only = OptionOrderBook::new("BTC-20240329-50000-P", OptionStyle::Put);
+        ask_only
+            .add_limit_order(OrderId::new(), Side::Sell, 105, 5)
+            .expect("add ask");
+        let q = ask_only.best_quote();
+        assert_eq!(q.bid_price(), None);
+        assert_eq!(q.bid_size(), 0);
+        assert_eq!(q.ask_price(), Some(105));
+        assert_eq!(q.ask_size(), 5);
+        assert!(!q.is_two_sided());
+        assert!(!ask_only.has_both_sides());
+
+        // Empty book: neither side, not two-sided.
+        let empty = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let q = empty.best_quote();
+        assert!(q.is_empty());
+        assert!(!q.is_two_sided());
+        assert!(!empty.has_both_sides());
+    }
+
+    #[test]
+    fn test_trade_capture_disarmed_by_default() {
+        // Default: capture is disarmed, so plain order methods do not populate
+        // last_trade_result even when a match occurs.
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        assert!(!book.is_trade_capture_armed());
+
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 10)
+            .expect("add ask");
+        // Crossing buy matches the resting ask.
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 10)
+            .expect("add crossing buy");
+        assert!(
+            book.last_trade_result().is_none(),
+            "disarmed capture must not record a trade"
+        );
+
+        // Arming makes the plain path populate the capture.
+        book.arm_trade_capture(true);
+        assert!(book.is_trade_capture_armed());
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 4)
+            .expect("add ask");
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 4)
+            .expect("add crossing buy");
+        assert!(
+            book.last_trade_result().is_some(),
+            "armed capture must record a trade"
+        );
+    }
+
+    #[test]
+    fn test_full_order_captures_regardless_of_arm_state() {
+        // The _full methods arm capture internally and restore the prior state,
+        // so they return a TradeResult even when the book is disarmed.
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        assert!(!book.is_trade_capture_armed());
+
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 10)
+            .expect("add ask");
+        let result = book
+            .add_limit_order_full(OrderId::new(), Side::Buy, 100, 10)
+            .expect("full buy");
+        // The crossing buy fully consumed the resting ask.
+        assert_eq!(result.symbol, "BTC-20240329-50000-C");
+        assert_eq!(book.order_count(), 0);
+        // Arm state restored to disarmed after the _full call.
+        assert!(!book.is_trade_capture_armed());
     }
 
     #[test]
@@ -2062,23 +2289,6 @@ mod tests {
             Some(OrderStatus::Cancelled { .. })
         ));
         assert_eq!(book.terminal_order_summary().cancelled, 2);
-    }
-
-    #[test]
-    fn test_update_last_quote() {
-        let mut book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
-
-        if let Err(err) = book.add_limit_order(OrderId::new(), Side::Buy, 100, 10) {
-            panic!("add order failed: {}", err);
-        }
-
-        let changed = book.update_last_quote();
-        assert!(changed);
-
-        let changed_again = book.update_last_quote();
-        assert!(!changed_again);
-
-        let _last = book.last_quote();
     }
 
     #[test]
@@ -3216,6 +3426,9 @@ mod tests {
     #[test]
     fn test_last_trade_result_populated_after_match() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        // Capture is disarmed by default; arm it so the plain order path records
+        // the trade into last_trade_result.
+        book.arm_trade_capture(true);
         if let Err(err) = book.add_limit_order(OrderId::new(), Side::Sell, 100, 10) {
             panic!("add order failed: {}", err);
         }
@@ -3455,6 +3668,10 @@ mod tests {
                 ..BookConfig::default()
             },
         );
+
+        // Arm trade capture so the multiplexed internal capture listener (which
+        // is disarmed by default) records the trade alongside the NATS listener.
+        book.arm_trade_capture(true);
 
         // Rest a sell, then cross it with a marketable buy to force a trade.
         book.add_limit_order(OrderId::new(), Side::Sell, 100, 5)

--- a/src/orderbook/quote.rs
+++ b/src/orderbook/quote.rs
@@ -8,7 +8,8 @@ use serde::{Deserialize, Serialize};
 /// Represents a two-sided quote (bid and ask).
 ///
 /// A quote captures the best bid and ask prices and sizes at a point in time.
-/// Prices are in smallest units (e.g., cents, satoshis) as `u64`.
+/// Prices are in smallest units (e.g., cents, satoshis) as `u128`
+/// (`Option<u128>`, `None` when that side is empty); sizes are `u64`.
 ///
 /// Note: Equality comparison excludes `timestamp_ms`, comparing only market
 /// data (prices and sizes). The struct carries no synthetic identifier, so its

--- a/src/orderbook/quote.rs
+++ b/src/orderbook/quote.rs
@@ -3,7 +3,6 @@
 //! This module provides the [`Quote`] and [`QuoteUpdate`] types for representing
 //! two-sided markets (bid and ask).
 
-use orderbook_rs::OrderId;
 use serde::{Deserialize, Serialize};
 
 /// Represents a two-sided quote (bid and ask).
@@ -11,7 +10,10 @@ use serde::{Deserialize, Serialize};
 /// A quote captures the best bid and ask prices and sizes at a point in time.
 /// Prices are in smallest units (e.g., cents, satoshis) as `u64`.
 ///
-/// Note: Equality comparison excludes the `id` field, comparing only market data.
+/// Note: Equality comparison excludes `timestamp_ms`, comparing only market
+/// data (prices and sizes). The struct carries no synthetic identifier, so its
+/// serialized form is fully determined by its market data and timestamp — there
+/// is no per-construction clock/RNG cost and serialization is deterministic.
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct Quote {
     /// Best bid price (None if no bids).
@@ -24,8 +26,6 @@ pub struct Quote {
     ask_size: u64,
     /// Timestamp in milliseconds.
     timestamp_ms: u64,
-    /// Unique identifier for this quote.
-    id: OrderId,
 }
 
 impl Quote {
@@ -39,6 +39,7 @@ impl Quote {
     /// * `ask_size` - Size at best ask
     /// * `timestamp_ms` - Timestamp in milliseconds
     #[must_use]
+    #[inline]
     pub fn new(
         bid_price: Option<u128>,
         bid_size: u64,
@@ -52,12 +53,12 @@ impl Quote {
             ask_price,
             ask_size,
             timestamp_ms,
-            id: OrderId::new(),
         }
     }
 
     /// Creates an empty quote with no prices.
     #[must_use]
+    #[inline]
     pub fn empty(timestamp_ms: u64) -> Self {
         Self {
             bid_price: None,
@@ -65,60 +66,61 @@ impl Quote {
             ask_price: None,
             ask_size: 0,
             timestamp_ms,
-            id: OrderId::new(),
         }
-    }
-
-    /// Returns the unique identifier for this quote.
-    #[must_use]
-    pub const fn id(&self) -> OrderId {
-        self.id
     }
 
     /// Returns the best bid price.
     #[must_use]
+    #[inline]
     pub const fn bid_price(&self) -> Option<u128> {
         self.bid_price
     }
 
     /// Returns the size at best bid.
     #[must_use]
+    #[inline]
     pub const fn bid_size(&self) -> u64 {
         self.bid_size
     }
 
     /// Returns the best ask price.
     #[must_use]
+    #[inline]
     pub const fn ask_price(&self) -> Option<u128> {
         self.ask_price
     }
 
     /// Returns the size at best ask.
     #[must_use]
+    #[inline]
     pub const fn ask_size(&self) -> u64 {
         self.ask_size
     }
 
     /// Returns the timestamp in milliseconds.
     #[must_use]
+    #[inline]
     pub const fn timestamp_ms(&self) -> u64 {
         self.timestamp_ms
     }
 
     /// Returns true if the quote has both bid and ask.
     #[must_use]
+    #[inline]
     pub const fn is_two_sided(&self) -> bool {
         self.bid_price.is_some() && self.ask_price.is_some()
     }
 
     /// Returns true if the quote has no prices.
     #[must_use]
+    #[inline]
     pub const fn is_empty(&self) -> bool {
         self.bid_price.is_none() && self.ask_price.is_none()
     }
 
     /// Returns the spread if both sides exist.
     #[must_use]
+    #[inline]
     pub fn spread(&self) -> Option<u128> {
         match (self.bid_price, self.ask_price) {
             (Some(bid), Some(ask)) if ask >= bid => Some(ask - bid),
@@ -128,6 +130,7 @@ impl Quote {
 
     /// Returns the mid price if both sides exist.
     #[must_use]
+    #[inline]
     pub fn mid_price(&self) -> Option<f64> {
         match (self.bid_price, self.ask_price) {
             (Some(bid), Some(ask)) => Some((bid as f64 + ask as f64) / 2.0),
@@ -137,6 +140,7 @@ impl Quote {
 
     /// Returns the spread in basis points relative to mid price.
     #[must_use]
+    #[inline]
     pub fn spread_bps(&self) -> Option<f64> {
         match (self.spread(), self.mid_price()) {
             (Some(spread), Some(mid)) if mid > 0.0 => Some(spread as f64 / mid * 10000.0),
@@ -146,8 +150,9 @@ impl Quote {
 }
 
 impl PartialEq for Quote {
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
-        // Note: timestamp_ms and id are excluded from comparison
+        // Note: timestamp_ms is excluded from comparison
         // to detect only market data changes (prices and sizes)
         self.bid_price == other.bid_price
             && self.bid_size == other.bid_size

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -264,9 +264,13 @@ impl StrikeOrderBook {
     }
 
     /// Returns true if both call and put have two-sided quotes.
+    ///
+    /// Uses the leaf's [`has_both_sides`](OptionOrderBook::has_both_sides)
+    /// top-of-book check rather than constructing a full [`Quote`] per side, so
+    /// it never computes sizes or a timestamp just to test two-sidedness.
     #[must_use]
     pub fn is_fully_quoted(&self) -> bool {
-        self.call.best_quote().is_two_sided() && self.put.best_quote().is_two_sided()
+        self.call.has_both_sides() && self.put.has_both_sides()
     }
 
     /// Returns the total order count across call and put.


### PR DESCRIPTION
## Summary

`best_quote` read top-of-book size via `bid_depth_at_price`/`ask_depth_at_price`,
each calling `get_volume_by_price()` which iterates the whole bid **and** ask
SkipMaps and allocates two HashMaps — so a single quote read did two full book
scans and four HashMap allocations, plus `Quote::new` minted an unused ULID
(clock + RNG) per call, and the trade-capture listener cloned the full
`TradeResult` under a `Mutex` on every match. This removes all of that from the
leaf hot path.

## Changes

- **`best_quote` allocation-free.** Each populated side's best-level size now
  comes from `total_depth_at_levels(1, side)` (one ordered top-of-book read, no
  HashMap; verified stack-iterator / no heap alloc in orderbook-rs 0.9.0); the
  empty side short-circuits to `(None, 0)`.
- **`Quote` drops its unused `OrderId`.** Kills the per-call ULID clock+RNG and
  makes `Quote` serialization deterministic.
- **Trade capture gated behind `Arc<AtomicBool>` (default disarmed).** The
  listener does one `Relaxed` load and returns before any clone/lock when
  disarmed. New API `arm_trade_capture` / `is_trade_capture_armed`; the `_full`
  methods arm via an RAII scope guard that restores the prior state on drop.
- **`has_both_sides()`** added on the leaf; the strike layer's `is_fully_quoted()`
  switched to it (no longer builds two `Quote`s to test two-sidedness).
- `#[inline]` on the quote accessors; **dead `update_last_quote`/`last_quote`
  cache removed**; the false **"O(1) with caching"** doc claim fixed.

## Performance (Criterion, `orderbook_operations`)

| case | before | after | change |
|------|--------|-------|--------|
| `best_quote_populated` (100×2 levels) | 11.751 µs | 69.10 ns | **~170× faster** |
| `best_quote_empty` | 67.09 ns | 37.51 ns | ~44% faster |
| `best_quote_one_sided` (new) | — | 56.49 ns | — |
| `update_last_quote` | 246.63 ns | removed (dead API) | — |

`best_quote` now does no full-book scan and no heap allocation, with at most one
ordered top-of-book read per populated side.

## Public API impact (breaking, within the 0.4.4 → 0.5.0 window)

- **Removed:** `Quote::id()` + the `Quote.id` field; `OptionOrderBook::update_last_quote`/`last_quote`/`last_quote_arc` (all dead — zero callers outside the leaf/tests/bench).
- **Added:** `OptionOrderBook::has_both_sides`, `arm_trade_capture`, `is_trade_capture_armed`.
- **Behavior change:** trade capture is **disarmed by default**, so `last_trade_result()` no longer auto-populates on the plain order path. Pre-0.5.0 pollers must call `arm_trade_capture(true)` or use the NATS trade feed / `_full` return values / order-state tracker (all independent of the flag). Documented on `last_trade_result`/`arm_trade_capture`.
- `Quote`'s serde shape loses `id` (deterministic) — `Quote` is **not** journaled or published, so no replay/wire impact. `src/lib.rs` doc + `README.md` regenerated (O(1) claim fixed). Version stays `0.5.0`.

## Testing

- [x] One-sided-book `best_quote` test (bid-only, ask-only, empty) asserting the empty side is `None`/`0` and `is_two_sided()`/`has_both_sides()` are false
- [x] Best-level-sum test (multiple orders at best level summed; deeper level excluded)
- [x] Trade-capture disarmed-by-default + `_full`-captures-regardless tests
- [x] Criterion before/after attached
- [x] `make pre-push` clean; `cargo build --features nats,sequencer` clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No `.unwrap()`/`.expect()`/unchecked indexing in production code
- [x] No `unsafe`; `tracing` only
- [x] Layering respected (`has_both_sides` on the leaf; strike calls down; leaf knows nothing of strike/chain)
- [x] Matching delegated to `orderbook-rs`
- [x] No new dependencies / feature flags
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) updated

Closes #80
