### PR TITLE
Adopt pricelevel newtypes in Quote and fix u128 docs (#67)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,13 @@ Every public item is available at the crate root **and** under
 type. Prefer the shorter crate-root path; the `orderbook::` path remains
 valid.
 
-The boundary newtypes — `OrderId`, `OrderType`, `Side`, `TimeInForce`, and
-`Hash32` — are re-exported here from `orderbook_rs` / `pricelevel`, so
-consumers need **no direct `orderbook_rs` dependency** to use the hierarchy.
-(Price and quantity cross the leaf boundary as plain `u128` / `u64`.)
+The boundary newtypes — `OrderId`, `OrderType`, `Side`, `TimeInForce`,
+`Hash32`, `Price`, `Quantity`, and `TimestampMs` — are re-exported here from
+`orderbook_rs` / `pricelevel`, so consumers need **no direct `orderbook_rs`
+/ `pricelevel` dependency** to use the hierarchy. `Quote` exposes prices,
+sizes, and timestamps through `Price` / `Quantity` / `TimestampMs`; the leaf
+`add_limit_order*` submission path still takes plain `u128` / `u64` (that is
+what `orderbook_rs` accepts there).
 
 ### Core Components
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,13 @@
 //! type. Prefer the shorter crate-root path; the `orderbook::` path remains
 //! valid.
 //!
-//! The boundary newtypes — `OrderId`, `OrderType`, `Side`, `TimeInForce`, and
-//! `Hash32` — are re-exported here from `orderbook_rs` / `pricelevel`, so
-//! consumers need **no direct `orderbook_rs` dependency** to use the hierarchy.
-//! (Price and quantity cross the leaf boundary as plain `u128` / `u64`.)
+//! The boundary newtypes — `OrderId`, `OrderType`, `Side`, `TimeInForce`,
+//! `Hash32`, `Price`, `Quantity`, and `TimestampMs` — are re-exported here from
+//! `orderbook_rs` / `pricelevel`, so consumers need **no direct `orderbook_rs`
+//! / `pricelevel` dependency** to use the hierarchy. `Quote` exposes prices,
+//! sizes, and timestamps through `Price` / `Quantity` / `TimestampMs`; the leaf
+//! `add_limit_order*` submission path still takes plain `u128` / `u64` (that is
+//! what `orderbook_rs` accepts there).
 //!
 //! ## Core Components
 //!
@@ -238,7 +241,8 @@ pub use error::{Error, Result};
 // root, so each type is reachable both as `option_chain_orderbook::X` and as
 // `option_chain_orderbook::orderbook::X`. This includes the primary hierarchy
 // types, the side subsystems, and the boundary newtypes (`OrderId`, `OrderType`,
-// `Side`, `TimeInForce`, `Hash32`) re-exported from `orderbook_rs` / `pricelevel`.
+// `Side`, `TimeInForce`, `Hash32`, `Price`, `Quantity`, `TimestampMs`) re-exported
+// from `orderbook_rs` / `pricelevel`.
 pub use orderbook::{
     AggregatedGreeks, CancelReason, ChainMassCancelResult, CleanupResult, ContractSpecs,
     ContractSpecsBuilder, CycleRule, ExerciseStyle, ExpirationCallback, ExpirationManagerStats,
@@ -249,13 +253,13 @@ pub use orderbook::{
     InstrumentStatus, LifecycleConfig, LifecycleEvent, LifecycleListener, LifecycleResult,
     MarkPriceCalculator, MarkPriceConfig, MarkPriceConfigBuilder, MassCancelResult, MockPriceFeed,
     OptionChainOrderBook, OptionChainOrderBookManager, OptionChainStats, OptionOrderBook, OrderId,
-    OrderStateTracker, OrderStatus, OrderType, Position, PriceUpdate, PriceUpdateListener, Quote,
-    QuoteUpdate, RefreshResult, STPMode, SettlementType, Side, StaticPriceFeed, StrikeGenerator,
-    StrikeMassCancelResult, StrikeOrderBook, StrikeOrderBookManager, StrikeRangeConfig,
-    StrikeRangeConfigBuilder, SubscriptionId, SymbolIndex, SymbolRef, TerminalOrderSummary,
-    TimeInForce, TradeResult, UnderlyingMassCancelResult, UnderlyingOrderBook,
-    UnderlyingOrderBookManager, UnderlyingStats, ValidationConfig, VolSurface, calculate_tte_years,
-    wire_feed_to_calculator,
+    OrderStateTracker, OrderStatus, OrderType, Position, Price, PriceUpdate, PriceUpdateListener,
+    Quantity, Quote, QuoteUpdate, RefreshResult, STPMode, SettlementType, Side, StaticPriceFeed,
+    StrikeGenerator, StrikeMassCancelResult, StrikeOrderBook, StrikeOrderBookManager,
+    StrikeRangeConfig, StrikeRangeConfigBuilder, SubscriptionId, SymbolIndex, SymbolRef,
+    TerminalOrderSummary, TimeInForce, TimestampMs, TradeResult, UnderlyingMassCancelResult,
+    UnderlyingOrderBook, UnderlyingOrderBookManager, UnderlyingStats, ValidationConfig, VolSurface,
+    calculate_tte_years, wire_feed_to_calculator,
 };
 
 #[cfg(feature = "nats")]

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -15,7 +15,7 @@ use orderbook_rs::{
     DefaultOrderBook, FeeSchedule, MassCancelResult, OrderBookSnapshot, OrderId, OrderStateTracker,
     OrderStatus, STPMode, Side, TimeInForce, TradeListener, TradeResult,
 };
-use pricelevel::{Hash32, MatchResult, Quantity};
+use pricelevel::{Hash32, MatchResult, Price, Quantity, TimestampMs};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicUsize, Ordering};
@@ -1621,6 +1621,13 @@ impl OptionOrderBook {
     /// with `levels = 1`. It performs **no** full-book scan and **no** heap
     /// allocation. A one-sided book yields a one-sided [`Quote`] (the empty side
     /// has `None` price and zero size).
+    ///
+    /// This is the single boundary where the engine's raw `u128` prices and
+    /// `u64` sizes are wrapped into the pricelevel newtypes ([`Price`],
+    /// [`Quantity`], [`TimestampMs`]) that [`Quote`] exposes. Prices are 128-bit
+    /// (`u128`): a value above `2^53` is not exactly representable as an
+    /// IEEE-754 double, so any consumer deserializing the resulting [`Quote`]
+    /// JSON must parse prices with a 128-bit-aware parser, not as `f64`.
     #[must_use]
     #[inline]
     pub fn best_quote(&self) -> Quote {
@@ -1629,18 +1636,26 @@ impl OptionOrderBook {
         // serialized into a journal record or NATS payload. Do NOT let a `Quote`
         // (and hence this timestamp) feed a journaled/replayed path — thread an
         // injected clock instead if that ever changes.
-        let timestamp_ms = orderbook_rs::current_time_millis();
+        let timestamp_ms = TimestampMs::new(orderbook_rs::current_time_millis());
 
         // One ordered top-of-book read per populated side; `total_depth_at_levels`
-        // with `levels = 1` sums only the best level and never allocates.
+        // with `levels = 1` sums only the best level and never allocates. The
+        // raw `u128` / `u64` engine values are wrapped into the pricelevel
+        // newtypes exactly once, here at the leaf boundary.
         let (bid_price, bid_size) = match self.book.best_bid() {
-            Some(p) => (Some(p), self.book.total_depth_at_levels(1, Side::Buy)),
-            None => (None, 0),
+            Some(p) => (
+                Some(Price::new(p)),
+                Quantity::new(self.book.total_depth_at_levels(1, Side::Buy)),
+            ),
+            None => (None, Quantity::ZERO),
         };
 
         let (ask_price, ask_size) = match self.book.best_ask() {
-            Some(p) => (Some(p), self.book.total_depth_at_levels(1, Side::Sell)),
-            None => (None, 0),
+            Some(p) => (
+                Some(Price::new(p)),
+                Quantity::new(self.book.total_depth_at_levels(1, Side::Sell)),
+            ),
+            None => (None, Quantity::ZERO),
         };
 
         Quote::new(bid_price, bid_size, ask_price, ask_size, timestamp_ms)
@@ -1887,10 +1902,10 @@ mod tests {
 
         let quote = book.best_quote();
 
-        assert_eq!(quote.bid_price(), Some(100));
-        assert_eq!(quote.bid_size(), 10);
-        assert_eq!(quote.ask_price(), Some(101));
-        assert_eq!(quote.ask_size(), 5);
+        assert_eq!(quote.bid_price(), Some(Price::new(100)));
+        assert_eq!(quote.bid_size(), Quantity::new(10));
+        assert_eq!(quote.ask_price(), Some(Price::new(101)));
+        assert_eq!(quote.ask_size(), Quantity::new(5));
         assert!(quote.is_two_sided());
         assert!(book.has_both_sides());
     }
@@ -1917,10 +1932,10 @@ mod tests {
             .expect("add deep ask");
 
         let quote = book.best_quote();
-        assert_eq!(quote.bid_price(), Some(100));
-        assert_eq!(quote.bid_size(), 17); // 10 + 7, deeper 99 excluded
-        assert_eq!(quote.ask_price(), Some(101));
-        assert_eq!(quote.ask_size(), 8); // 5 + 3, deeper 102 excluded
+        assert_eq!(quote.bid_price(), Some(Price::new(100)));
+        assert_eq!(quote.bid_size(), Quantity::new(17)); // 10 + 7, deeper 99 excluded
+        assert_eq!(quote.ask_price(), Some(Price::new(101)));
+        assert_eq!(quote.ask_size(), Quantity::new(8)); // 5 + 3, deeper 102 excluded
         assert!(quote.is_two_sided());
         assert!(book.has_both_sides());
     }
@@ -1933,10 +1948,10 @@ mod tests {
             .add_limit_order(OrderId::new(), Side::Buy, 100, 10)
             .expect("add bid");
         let q = bid_only.best_quote();
-        assert_eq!(q.bid_price(), Some(100));
-        assert_eq!(q.bid_size(), 10);
+        assert_eq!(q.bid_price(), Some(Price::new(100)));
+        assert_eq!(q.bid_size(), Quantity::new(10));
         assert_eq!(q.ask_price(), None);
-        assert_eq!(q.ask_size(), 0);
+        assert_eq!(q.ask_size(), Quantity::ZERO);
         assert!(!q.is_two_sided());
         assert!(!bid_only.has_both_sides());
 
@@ -1947,9 +1962,9 @@ mod tests {
             .expect("add ask");
         let q = ask_only.best_quote();
         assert_eq!(q.bid_price(), None);
-        assert_eq!(q.bid_size(), 0);
-        assert_eq!(q.ask_price(), Some(105));
-        assert_eq!(q.ask_size(), 5);
+        assert_eq!(q.bid_size(), Quantity::ZERO);
+        assert_eq!(q.ask_price(), Some(Price::new(105)));
+        assert_eq!(q.ask_size(), Quantity::new(5));
         assert!(!q.is_two_sided());
         assert!(!ask_only.has_both_sides());
 

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -142,4 +142,4 @@ pub use orderbook_rs::{
     CancelReason, FeeSchedule, MassCancelResult, OrderId, OrderStateTracker, OrderStatus,
     OrderType, STPMode, Side, TimeInForce, TradeResult,
 };
-pub use pricelevel::Hash32;
+pub use pricelevel::{Hash32, Price, Quantity, TimestampMs};

--- a/src/orderbook/quote.rs
+++ b/src/orderbook/quote.rs
@@ -3,13 +3,24 @@
 //! This module provides the [`Quote`] and [`QuoteUpdate`] types for representing
 //! two-sided markets (bid and ask).
 
+use pricelevel::{Price, Quantity, TimestampMs};
 use serde::{Deserialize, Serialize};
 
 /// Represents a two-sided quote (bid and ask).
 ///
 /// A quote captures the best bid and ask prices and sizes at a point in time.
-/// Prices are in smallest units (e.g., cents, satoshis) as `u128`
-/// (`Option<u128>`, `None` when that side is empty); sizes are `u64`.
+/// Prices are in smallest units (e.g., cents, satoshis) carried as
+/// [`Price`] (a `u128` newtype; `Option<Price>`, `None` when that side is
+/// empty); sizes are [`Quantity`] (a `u64` newtype); the timestamp is a
+/// [`TimestampMs`] (a `u64` newtype). The pricelevel newtypes are all
+/// `#[serde(transparent)]`, so the JSON wire format is bare numbers — an
+/// `Option<Price>` serializes identically to an `Option<u128>` and a
+/// [`Quantity`] identically to a `u64`.
+///
+/// JSON precision note: prices are 128-bit. A price above `2^53` cannot be
+/// represented exactly by an IEEE-754 double, so a consumer that deserializes
+/// `Quote` JSON MUST use a 128-bit-aware number parser for the price fields —
+/// parsing the JSON number as an `f64` silently loses precision above `2^53`.
 ///
 /// Note: Equality comparison excludes `timestamp_ms`, comparing only market
 /// data (prices and sizes). The struct carries no synthetic identifier, so its
@@ -18,35 +29,39 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct Quote {
     /// Best bid price (None if no bids).
-    bid_price: Option<u128>,
+    bid_price: Option<Price>,
     /// Size available at best bid.
-    bid_size: u64,
+    bid_size: Quantity,
     /// Best ask price (None if no asks).
-    ask_price: Option<u128>,
+    ask_price: Option<Price>,
     /// Size available at best ask.
-    ask_size: u64,
+    ask_size: Quantity,
     /// Timestamp in milliseconds.
-    timestamp_ms: u64,
+    timestamp_ms: TimestampMs,
 }
 
 impl Quote {
     /// Creates a new quote with the given values.
     ///
+    /// Taking the pricelevel newtypes (rather than bare integers) makes the
+    /// constructor self-documenting and removes the arg-swap footgun of a
+    /// positional all-integer signature on a financial type.
+    ///
     /// # Arguments
     ///
-    /// * `bid_price` - Best bid price (None if no bids)
-    /// * `bid_size` - Size at best bid
-    /// * `ask_price` - Best ask price (None if no asks)
-    /// * `ask_size` - Size at best ask
-    /// * `timestamp_ms` - Timestamp in milliseconds
+    /// * `bid_price` - Best bid [`Price`] (None if no bids)
+    /// * `bid_size` - [`Quantity`] at best bid
+    /// * `ask_price` - Best ask [`Price`] (None if no asks)
+    /// * `ask_size` - [`Quantity`] at best ask
+    /// * `timestamp_ms` - [`TimestampMs`] (milliseconds)
     #[must_use]
     #[inline]
-    pub fn new(
-        bid_price: Option<u128>,
-        bid_size: u64,
-        ask_price: Option<u128>,
-        ask_size: u64,
-        timestamp_ms: u64,
+    pub const fn new(
+        bid_price: Option<Price>,
+        bid_size: Quantity,
+        ask_price: Option<Price>,
+        ask_size: Quantity,
+        timestamp_ms: TimestampMs,
     ) -> Self {
         Self {
             bid_price,
@@ -60,48 +75,48 @@ impl Quote {
     /// Creates an empty quote with no prices.
     #[must_use]
     #[inline]
-    pub fn empty(timestamp_ms: u64) -> Self {
+    pub const fn empty(timestamp_ms: TimestampMs) -> Self {
         Self {
             bid_price: None,
-            bid_size: 0,
+            bid_size: Quantity::ZERO,
             ask_price: None,
-            ask_size: 0,
+            ask_size: Quantity::ZERO,
             timestamp_ms,
         }
     }
 
-    /// Returns the best bid price.
+    /// Returns the best bid [`Price`] (None if no bids).
     #[must_use]
     #[inline]
-    pub const fn bid_price(&self) -> Option<u128> {
+    pub const fn bid_price(&self) -> Option<Price> {
         self.bid_price
     }
 
-    /// Returns the size at best bid.
+    /// Returns the [`Quantity`] at best bid.
     #[must_use]
     #[inline]
-    pub const fn bid_size(&self) -> u64 {
+    pub const fn bid_size(&self) -> Quantity {
         self.bid_size
     }
 
-    /// Returns the best ask price.
+    /// Returns the best ask [`Price`] (None if no asks).
     #[must_use]
     #[inline]
-    pub const fn ask_price(&self) -> Option<u128> {
+    pub const fn ask_price(&self) -> Option<Price> {
         self.ask_price
     }
 
-    /// Returns the size at best ask.
+    /// Returns the [`Quantity`] at best ask.
     #[must_use]
     #[inline]
-    pub const fn ask_size(&self) -> u64 {
+    pub const fn ask_size(&self) -> Quantity {
         self.ask_size
     }
 
-    /// Returns the timestamp in milliseconds.
+    /// Returns the [`TimestampMs`] (milliseconds).
     #[must_use]
     #[inline]
-    pub const fn timestamp_ms(&self) -> u64 {
+    pub const fn timestamp_ms(&self) -> TimestampMs {
         self.timestamp_ms
     }
 
@@ -119,32 +134,53 @@ impl Quote {
         self.bid_price.is_none() && self.ask_price.is_none()
     }
 
-    /// Returns the spread if both sides exist.
+    /// Returns the spread (ask − bid) in raw price units if both sides exist
+    /// and the book is not crossed.
+    ///
+    /// A locked book (`ask == bid`) returns `Some(0)`; a crossed book
+    /// (`ask < bid`) or a one-sided book returns `None`.
+    ///
+    /// Returned as a raw `u128` (a price *difference*, not an absolute
+    /// [`Price`]), matching the leaf engine's
+    /// [`OptionOrderBook::spread`](crate::orderbook::OptionOrderBook::spread).
     #[must_use]
     #[inline]
     pub fn spread(&self) -> Option<u128> {
         match (self.bid_price, self.ask_price) {
-            (Some(bid), Some(ask)) if ask >= bid => Some(ask - bid),
+            (Some(bid), Some(ask)) if ask >= bid => Some(ask.as_u128() - bid.as_u128()),
             _ => None,
         }
     }
 
     /// Returns the mid price if both sides exist.
+    ///
+    /// Computed as `(bid + ask) / 2` over the `f64`-widened price values. The
+    /// result is guarded against a non-finite `f64` (NaN/inf) and yields `None`
+    /// in that case rather than leaking a NaN across the boundary.
     #[must_use]
     #[inline]
     pub fn mid_price(&self) -> Option<f64> {
         match (self.bid_price, self.ask_price) {
-            (Some(bid), Some(ask)) => Some((bid as f64 + ask as f64) / 2.0),
+            (Some(bid), Some(ask)) => {
+                let mid = (bid.to_f64_lossy() + ask.to_f64_lossy()) / 2.0;
+                mid.is_finite().then_some(mid)
+            }
             _ => None,
         }
     }
 
     /// Returns the spread in basis points relative to mid price.
+    ///
+    /// Guards the `f64` boundary: requires a positive, finite mid price and a
+    /// finite result, otherwise yields `None`.
     #[must_use]
     #[inline]
     pub fn spread_bps(&self) -> Option<f64> {
         match (self.spread(), self.mid_price()) {
-            (Some(spread), Some(mid)) if mid > 0.0 => Some(spread as f64 / mid * 10000.0),
+            (Some(spread), Some(mid)) if mid > 0.0 => {
+                let bps = spread as f64 / mid * 10000.0;
+                bps.is_finite().then_some(bps)
+            }
             _ => None,
         }
     }
@@ -218,18 +254,24 @@ mod tests {
 
     #[test]
     fn test_quote_creation() {
-        let quote = Quote::new(Some(100), 10, Some(105), 5, 1234567890);
+        let quote = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(1234567890),
+        );
 
-        assert_eq!(quote.bid_price(), Some(100));
-        assert_eq!(quote.bid_size(), 10);
-        assert_eq!(quote.ask_price(), Some(105));
-        assert_eq!(quote.ask_size(), 5);
+        assert_eq!(quote.bid_price(), Some(Price::new(100)));
+        assert_eq!(quote.bid_size(), Quantity::new(10));
+        assert_eq!(quote.ask_price(), Some(Price::new(105)));
+        assert_eq!(quote.ask_size(), Quantity::new(5));
         assert!(quote.is_two_sided());
     }
 
     #[test]
     fn test_quote_empty() {
-        let quote = Quote::empty(0);
+        let quote = Quote::empty(TimestampMs::new(0));
 
         assert!(quote.is_empty());
         assert!(!quote.is_two_sided());
@@ -239,7 +281,13 @@ mod tests {
 
     #[test]
     fn test_quote_spread() {
-        let quote = Quote::new(Some(100), 10, Some(105), 5, 0);
+        let quote = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(0),
+        );
 
         assert_eq!(quote.spread(), Some(5));
         let mid = match quote.mid_price() {
@@ -251,23 +299,53 @@ mod tests {
 
     #[test]
     fn test_quote_display() {
-        let quote = Quote::new(Some(100), 10, Some(105), 5, 0);
+        let quote = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(0),
+        );
         assert_eq!(format!("{}", quote), "10@100 / 5@105");
 
-        let bid_only = Quote::new(Some(100), 10, None, 0, 0);
+        let bid_only = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            None,
+            Quantity::ZERO,
+            TimestampMs::new(0),
+        );
         assert_eq!(format!("{}", bid_only), "10@100 / -");
 
-        let ask_only = Quote::new(None, 0, Some(105), 5, 0);
+        let ask_only = Quote::new(
+            None,
+            Quantity::ZERO,
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(0),
+        );
         assert_eq!(format!("{}", ask_only), "- / 5@105");
 
-        let empty = Quote::empty(0);
+        let empty = Quote::empty(TimestampMs::new(0));
         assert_eq!(format!("{}", empty), "- / -");
     }
 
     #[test]
     fn test_quote_update() {
-        let prev = Quote::new(Some(100), 10, Some(105), 5, 0);
-        let curr = Quote::new(Some(101), 10, Some(105), 5, 1);
+        let prev = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(0),
+        );
+        let curr = Quote::new(
+            Some(Price::new(101)),
+            Quantity::new(10),
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(1),
+        );
         let update = QuoteUpdate::new(prev, curr);
 
         assert!(update.bid_price_changed());
@@ -277,13 +355,25 @@ mod tests {
 
     #[test]
     fn test_quote_timestamp() {
-        let quote = Quote::new(Some(100), 10, Some(105), 5, 1234567890);
-        assert_eq!(quote.timestamp_ms(), 1234567890);
+        let quote = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(1234567890),
+        );
+        assert_eq!(quote.timestamp_ms(), TimestampMs::new(1234567890));
     }
 
     #[test]
     fn test_quote_spread_bps() {
-        let quote = Quote::new(Some(100), 10, Some(105), 5, 0);
+        let quote = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(0),
+        );
         let spread_bps = quote.spread_bps();
         assert!(spread_bps.is_some());
         // Spread = 5, mid = 102.5, bps = 5/102.5 * 10000 ≈ 487.8
@@ -296,10 +386,97 @@ mod tests {
 
     #[test]
     fn test_quote_spread_bps_none() {
-        let quote = Quote::new(Some(100), 10, None, 0, 0);
+        let quote = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            None,
+            Quantity::ZERO,
+            TimestampMs::new(0),
+        );
         assert!(quote.spread_bps().is_none());
 
-        let quote2 = Quote::empty(0);
+        let quote2 = Quote::empty(TimestampMs::new(0));
         assert!(quote2.spread_bps().is_none());
+    }
+
+    #[test]
+    fn test_quote_partial_eq_excludes_timestamp() {
+        // Equality compares market data only; the timestamp must not affect it.
+        let a = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(1),
+        );
+        let b = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(999_999),
+        );
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_quote_serde_roundtrip_transparent_shape() {
+        // The pricelevel newtypes are all `#[serde(transparent)]`, so the JSON
+        // shape is bare numbers — identical to the pre-migration
+        // `Option<u128>` / `u64` raw-integer wire format (no wrapper object).
+        let quote = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            Some(Price::new(105)),
+            Quantity::new(5),
+            TimestampMs::new(1_234_567_890),
+        );
+
+        let json = match serde_json::to_string(&quote) {
+            Ok(s) => s,
+            Err(e) => panic!("serialize failed: {e}"),
+        };
+        assert_eq!(
+            json,
+            r#"{"bid_price":100,"bid_size":10,"ask_price":105,"ask_size":5,"timestamp_ms":1234567890}"#,
+            "transparent newtypes must serialize as bare numbers, not wrapper objects"
+        );
+
+        let back: Quote = match serde_json::from_str(&json) {
+            Ok(q) => q,
+            Err(e) => panic!("deserialize failed: {e}"),
+        };
+        assert_eq!(back, quote);
+        // Round-trip also preserves the timestamp (excluded from PartialEq).
+        assert_eq!(back.timestamp_ms(), TimestampMs::new(1_234_567_890));
+
+        // A raw-integer JSON literal (the legacy wire form) still deserializes
+        // into the newtype `Quote`, proving the shape is unchanged.
+        let legacy = r#"{"bid_price":100,"bid_size":10,"ask_price":105,"ask_size":5,"timestamp_ms":1234567890}"#;
+        let from_legacy: Quote = match serde_json::from_str(legacy) {
+            Ok(q) => q,
+            Err(e) => panic!("legacy deserialize failed: {e}"),
+        };
+        assert_eq!(from_legacy, quote);
+    }
+
+    #[test]
+    fn test_quote_serde_one_sided_null_price() {
+        // `None` price serializes as JSON `null`, unchanged from `Option<u128>`.
+        let bid_only = Quote::new(
+            Some(Price::new(100)),
+            Quantity::new(10),
+            None,
+            Quantity::ZERO,
+            TimestampMs::new(7),
+        );
+        let json = match serde_json::to_string(&bid_only) {
+            Ok(s) => s,
+            Err(e) => panic!("serialize failed: {e}"),
+        };
+        assert_eq!(
+            json,
+            r#"{"bid_price":100,"bid_size":10,"ask_price":null,"ask_size":0,"timestamp_ms":7}"#
+        );
     }
 }

--- a/src/orderbook/quote.rs
+++ b/src/orderbook/quote.rs
@@ -436,10 +436,27 @@ mod tests {
             Ok(s) => s,
             Err(e) => panic!("serialize failed: {e}"),
         };
-        assert_eq!(
-            json,
-            r#"{"bid_price":100,"bid_size":10,"ask_price":105,"ask_size":5,"timestamp_ms":1234567890}"#,
-            "transparent newtypes must serialize as bare numbers, not wrapper objects"
+        // Assert the transparent shape via `serde_json::Value` (robust to field
+        // order / whitespace): every field must be a bare JSON number with the
+        // expected value — not a wrapper object/array — proving the newtypes
+        // serialize identically to the legacy raw-integer wire form.
+        let value: serde_json::Value = match serde_json::from_str(&json) {
+            Ok(v) => v,
+            Err(e) => panic!("parse to Value failed: {e}"),
+        };
+        assert_eq!(value["bid_price"], serde_json::json!(100));
+        assert_eq!(value["bid_size"], serde_json::json!(10));
+        assert_eq!(value["ask_price"], serde_json::json!(105));
+        assert_eq!(value["ask_size"], serde_json::json!(5));
+        assert_eq!(value["timestamp_ms"], serde_json::json!(1_234_567_890));
+        // Each price/size field is a bare number, not a `{ "0": .. }` wrapper.
+        assert!(
+            value["bid_price"].is_number() && value["ask_price"].is_number(),
+            "transparent prices must be bare numbers, not wrapper objects"
+        );
+        assert!(
+            value["bid_size"].is_number() && value["timestamp_ms"].is_number(),
+            "transparent sizes/timestamp must be bare numbers"
         );
 
         let back: Quote = match serde_json::from_str(&json) {


### PR DESCRIPTION
## Summary

`Quote` is a crate-owned, serialized, publicly re-exported domain DTO but modeled
prices as bare `Option<u128>`, sizes as bare `u64`, and the timestamp as bare
`u64`, with an all-integer positional constructor that is an arg-swap footgun in a
financial type. Two doc comments also wrongly claimed prices are `u64` when the
fields are `u128`. This adopts the pricelevel newtypes at the `Quote` boundary,
per the project rule "pricelevel newtypes at every domain boundary".

## Changes

- **`Quote` → newtypes.** Fields/accessors are now `Option<Price>` (prices),
  `Quantity` (sizes), `TimestampMs` (timestamp). `Quote::new`/`empty` take
  newtypes, killing the all-integer arg-swap footgun. Conversion happens **once**
  at the `best_quote` boundary in `book.rs` (`Price::new`/`Quantity::new`/
  `TimestampMs::new`); the leaf `add_limit_order*` signatures stay on raw
  `u128`/`u64` (orderbook_rs takes raw there).
- **Wire format unchanged.** The pricelevel newtypes are `#[serde(transparent)]`,
  so the JSON is identical to the prior raw-integer form. A new round-trip test
  asserts bare-number JSON and that a legacy raw-integer `Quote` JSON still
  deserializes. `Quote` is not journaled or published — no replay impact.
- **Re-export the newtypes.** `Price`/`Quantity`/`TimestampMs` now cross the public
  `Quote` boundary, so they are re-exported from the crate root and
  `orderbook/mod.rs` — consumers need no direct `pricelevel` dependency, per the
  crate's re-export convention. Crate-level docs updated; `README.md` regenerated.
- **Docs.** Price-type docs now say `u128` with the JSON-precision note (values
  above 2^53 lose precision parsed as an IEEE-754 double). `mid_price`/`spread_bps`
  gained `is_finite()` guards; the locked-book (`Some(0)`) vs crossed (`None`)
  spread behavior is documented.

## Technical decisions

`spread()` stays `Option<u128>` (a price *difference*, not an absolute `Price`),
matching the sibling `OptionOrderBook::spread()`. The quote math is bit-for-bit
preserved vs the 0.4.4 baseline (verified by an adversarial review): `mid_price`
is a true f64 average (no half-tick loss), `spread` has the correct non-crossed
guard with no `u128` underflow, equality still excludes `timestamp_ms`. The only
lossy step is `to_f64_lossy()` for mid/bps, which was already an `as f64` cast.

## Public API impact (breaking Rust API, wire-compatible, within 0.4.4 → 0.5.0)

`Quote` accessor return types change (`u128` → `Option<Price>`, `u64` →
`Quantity`/`TimestampMs`) and the constructors take newtypes — a breaking **Rust**
API change, but the **serialized form is unchanged** (`#[serde(transparent)]`).
Newly re-exported at the crate root: `Price`, `Quantity`, `TimestampMs`. Version
stays `0.5.0`.

## Testing

- [x] Serde round-trip + transparent-shape test (bare-number JSON; legacy JSON still deserializes; one-sided `null` price)
- [x] `PartialEq`-excludes-timestamp test; existing `Quote` tests updated to newtype constructors
- [x] `make pre-push` clean; `cargo build --features nats,sequencer` clean; README regenerated

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] `pricelevel` newtypes at the domain boundary; re-exported so no direct dep needed
- [x] No `.unwrap()`/`.expect()` in production code; `f64` boundaries guarded against NaN
- [x] No `unsafe`; `tracing` only
- [x] Layering respected (leaf only; conversion once at `best_quote`)
- [x] No new dependencies / feature flags
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) updated

Closes #67
