### PR TITLE
Add structured tracing across hierarchy/greeks/lifecycle (#83)

### DIFF
--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -857,6 +857,17 @@ impl ExpirationOrderBookManager {
         // `inserted` is true iff the published value is the book we just built,
         // i.e. this call is the unique `get_or_insert` winner for this key.
         let inserted = Arc::ptr_eq(entry.value(), &candidate);
+        if inserted {
+            // Cold path: emitted once per truly-new expiration (the unique
+            // `get_or_insert` winner), for every creating caller — direct
+            // `get_or_create_expiration` and the expiry scheduler alike. Never on
+            // the order-submission path.
+            tracing::info!(
+                underlying = %self.underlying,
+                expiration = %expiration,
+                "expiration created",
+            );
+        }
         (Arc::clone(entry.value()), inserted)
     }
 

--- a/src/orderbook/expiry_lifecycle.rs
+++ b/src/orderbook/expiry_lifecycle.rs
@@ -288,7 +288,14 @@ impl ExpiryLifecycleManager {
             let settle_dt = to_datetime(exp_date, expiry_config.settlement_time_utc);
             let removal_dt = settle_dt
                 .checked_add_signed(lifecycle_config.retention_period)
-                .ok_or_else(|| Error::configuration("overflow computing removal datetime"))?;
+                .ok_or_else(|| {
+                    tracing::error!(
+                        underlying = %underlying_name,
+                        expiration = %expiration,
+                        "overflow computing removal datetime",
+                    );
+                    Error::configuration("overflow computing removal datetime")
+                })?;
 
             // Check transitions in reverse order (furthest-along state first).
             // Allow catching up: if the scheduler missed ticks, we can jump
@@ -311,7 +318,15 @@ impl ExpiryLifecycleManager {
                     let exp_book = underlying.expirations().get(expiration)?;
                     if *status < InstrumentStatus::Settling {
                         set_all_book_status(exp_book.chain(), InstrumentStatus::Settling);
-                        let cancel_result = exp_book.cancel_all()?;
+                        let cancel_result = exp_book.cancel_all().map_err(|e| {
+                            tracing::warn!(
+                                underlying = %underlying_name,
+                                expiration = %expiration,
+                                error = %e,
+                                "cancel-all failed during lifecycle transition",
+                            );
+                            e
+                        })?;
                         let cancelled = cancel_result.total_cancelled();
                         let settling_event = LifecycleEvent::InstrumentSettling {
                             underlying: underlying_name.clone(),
@@ -349,7 +364,15 @@ impl ExpiryLifecycleManager {
                     // could be accepted during cancellation.
                     if *status < InstrumentStatus::Settling {
                         set_all_book_status(exp_book.chain(), InstrumentStatus::Settling);
-                        let cancel_result = exp_book.cancel_all()?;
+                        let cancel_result = exp_book.cancel_all().map_err(|e| {
+                            tracing::warn!(
+                                underlying = %underlying_name,
+                                expiration = %expiration,
+                                error = %e,
+                                "cancel-all failed during lifecycle transition",
+                            );
+                            e
+                        })?;
                         let cancelled = cancel_result.total_cancelled();
                         let settling_event = LifecycleEvent::InstrumentSettling {
                             underlying: underlying_name.clone(),
@@ -374,7 +397,15 @@ impl ExpiryLifecycleManager {
                     // Active/Halted/Pending → Settling
                     let exp_book = underlying.expirations().get(expiration)?;
                     set_all_book_status(exp_book.chain(), InstrumentStatus::Settling);
-                    let cancel_result = exp_book.cancel_all()?;
+                    let cancel_result = exp_book.cancel_all().map_err(|e| {
+                        tracing::warn!(
+                            underlying = %underlying_name,
+                            expiration = %expiration,
+                            error = %e,
+                            "cancel-all failed during lifecycle transition",
+                        );
+                        e
+                    })?;
                     let cancelled = cancel_result.total_cancelled();
                     let event = LifecycleEvent::InstrumentSettling {
                         underlying: underlying_name.clone(),
@@ -408,11 +439,61 @@ impl ExpiryLifecycleManager {
             underlying.expirations().remove(exp);
         }
 
+        // Cold path: emit one structured INFO per lifecycle transition. Iterated
+        // in push order, which is driven by the ordered expiration traversal
+        // above; the log carries only fields already on each event, so it adds
+        // no clock/RNG read and cannot perturb replay determinism.
+        for event in &result.events {
+            log_lifecycle_event(event);
+        }
+
         Ok(result)
     }
 }
 
 // ─── Internal helpers ────────────────────────────────────────────────────────
+
+/// Emits a structured `tracing` record for a single lifecycle transition.
+///
+/// Cold path — invoked only when an actual state transition occurred, never on
+/// the order-submission or per-quote path. It logs only fields already present
+/// on `event`; it never reads a clock or RNG, so it cannot perturb replay
+/// determinism.
+#[cold]
+#[inline(never)]
+fn log_lifecycle_event(event: &LifecycleEvent) {
+    match event {
+        LifecycleEvent::InstrumentSettling {
+            underlying,
+            expiration,
+            cancelled_orders,
+        } => tracing::info!(
+            underlying = %underlying,
+            expiration = %expiration,
+            cancelled_orders = *cancelled_orders,
+            status = "settling",
+            "expiration settling",
+        ),
+        LifecycleEvent::InstrumentExpired {
+            underlying,
+            expiration,
+        } => tracing::info!(
+            underlying = %underlying,
+            expiration = %expiration,
+            status = "expired",
+            "expiration expired",
+        ),
+        LifecycleEvent::ExpirationRemoved {
+            underlying,
+            expiration,
+        } => tracing::info!(
+            underlying = %underlying,
+            expiration = %expiration,
+            status = "removed",
+            "expiration removed",
+        ),
+    }
+}
 
 /// Returns the **minimum** lifecycle status across every call **and** put book
 /// of every strike in the chain, or `None` if the chain has no strikes.

--- a/src/orderbook/expiry_scheduler.rs
+++ b/src/orderbook/expiry_scheduler.rs
@@ -211,9 +211,27 @@ impl ExpiryScheduler {
                 result.strikes_generated = result
                     .strikes_generated
                     .checked_add(strikes.len())
-                    .ok_or_else(|| Error::configuration("strikes_generated overflow"))?;
+                    .ok_or_else(|| {
+                        tracing::error!(
+                            underlying = %underlying.underlying(),
+                            "strikes_generated overflow",
+                        );
+                        Error::configuration("strikes_generated overflow")
+                    })?;
 
                 result.created.push(date);
+
+                // Cold path: the scheduler generated the strike ladder for a
+                // newly-created expiration. The fundamental "expiration created"
+                // INFO is emitted by the expiration-manager insertion-winner
+                // (covering every creator); this records the scheduler's own
+                // strike-generation step. Never on the order-submission path.
+                tracing::info!(
+                    underlying = %underlying.underlying(),
+                    expiration = %date,
+                    strikes = strikes.len(),
+                    "strikes generated for expiration",
+                );
 
                 // Invoke callback if provided
                 if let Some(cb) = callback {

--- a/src/orderbook/greeks_engine.rs
+++ b/src/orderbook/greeks_engine.rs
@@ -255,10 +255,10 @@ impl GreeksEngine {
     /// swallowed, so a single panicking listener can never permanently disable
     /// subscription.
     pub fn subscribe(&self, listener: GreeksUpdateListener) {
-        let mut listeners = self
-            .listeners
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut listeners = self.listeners.lock().unwrap_or_else(|poisoned| {
+            tracing::warn!("greeks listeners lock poisoned; recovering");
+            poisoned.into_inner()
+        });
         listeners.push(listener);
     }
 
@@ -286,8 +286,17 @@ impl GreeksEngine {
         style: OptionStyle,
         dividend_yield: f64,
     ) -> Result<Greek> {
-        // Validate inputs
+        // Validate inputs. These are cold rejection branches: the WARN only
+        // fires when an input is invalid and the Greek is skipped — the
+        // success path below emits nothing here.
         if spot <= 0.0 || strike <= 0.0 || tte_years <= 0.0 || iv <= 0.0 {
+            tracing::warn!(
+                spot,
+                strike,
+                tte_years,
+                iv,
+                "greeks input rejected: spot, strike, tte, and iv must be positive",
+            );
             return Err(Error::greeks(
                 "Invalid input: spot, strike, tte, and iv must be positive",
             ));
@@ -295,6 +304,10 @@ impl GreeksEngine {
         // The risk-free rate may legitimately be negative (negative-rate
         // regimes); only a non-finite value is invalid.
         if !risk_free_rate.is_finite() {
+            tracing::warn!(
+                risk_free_rate,
+                "greeks input rejected: risk_free_rate must be finite",
+            );
             return Err(Error::greeks(
                 "Invalid input: risk_free_rate must be finite",
             ));
@@ -302,6 +315,10 @@ impl GreeksEngine {
         // A true 0.0 dividend yield is the normal case for crypto options and
         // must be priced as 0.0 — only NaN/Inf or a negative value is invalid.
         if !dividend_yield.is_finite() || dividend_yield < 0.0 {
+            tracing::warn!(
+                dividend_yield,
+                "greeks input rejected: dividend_yield must be finite and non-negative",
+            );
             return Err(Error::greeks(
                 "Invalid input: dividend_yield must be finite and non-negative",
             ));
@@ -454,10 +471,10 @@ impl GreeksEngine {
     fn notify_listeners(&self, update: &GreeksUpdate) {
         // Snapshot under the lock, then drop the guard before invoking anyone.
         let listeners: Vec<GreeksUpdateListener> = {
-            let guard = self
-                .listeners
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let guard = self.listeners.lock().unwrap_or_else(|poisoned| {
+                tracing::warn!("greeks listeners lock poisoned; recovering");
+                poisoned.into_inner()
+            });
             guard.clone()
         };
 
@@ -483,6 +500,9 @@ impl GreeksEngine {
     ) {
         let now_ns = current_timestamp_ns();
         self.last_recalc_ns.store(now_ns, Ordering::Release);
+
+        // Cold path: the throttled recalc tick, not the per-quote read.
+        tracing::debug!(strike, trigger = %trigger, "greeks recalculated");
 
         let update = GreeksUpdate {
             strike,

--- a/src/orderbook/index_price_feed.rs
+++ b/src/orderbook/index_price_feed.rs
@@ -170,6 +170,12 @@ impl IndexPriceFeed for MockPriceFeed {
             Ok(mut listeners) => listeners.push((id, listener)),
             Err(poisoned) => poisoned.into_inner().push((id, listener)),
         }
+        // Cold path: feed wiring, not the per-tick `set_price` notification.
+        tracing::info!(
+            subscription_id = id.0,
+            source = "mock",
+            "index feed subscribed"
+        );
         id
     }
 
@@ -180,7 +186,14 @@ impl IndexPriceFeed for MockPriceFeed {
         };
         let before = guard.len();
         guard.retain(|(sub_id, _)| *sub_id != id);
-        guard.len() < before
+        let removed = guard.len() < before;
+        tracing::info!(
+            subscription_id = id.0,
+            removed,
+            source = "mock",
+            "index feed unsubscribed",
+        );
+        removed
     }
 
     fn source(&self) -> &str {
@@ -321,7 +334,14 @@ pub fn wire_feed_to_calculator(
         calculator.update_index_price(update.price);
     });
 
-    feed.subscribe(listener)
+    let subscription_id = feed.subscribe(listener);
+    // Cold path: one-time wiring of a feed to a mark-price calculator.
+    tracing::info!(
+        subscription_id = subscription_id.0,
+        source = feed.source(),
+        "index feed wired to mark-price calculator",
+    );
+    subscription_id
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/src/orderbook/mark_price.rs
+++ b/src/orderbook/mark_price.rs
@@ -542,7 +542,12 @@ impl MarkPriceCalculator {
                 Ordering::AcqRel,
                 Ordering::Acquire,
             ) {
-                Ok(_) => return Some(final_mark),
+                Ok(_) => {
+                    // Cold path: the mutating tick. The pure read
+                    // `current_mark_price()` deliberately logs nothing.
+                    tracing::debug!(mark_price = final_mark, "mark price refreshed");
+                    return Some(final_mark);
+                }
                 Err(actual_prev) => {
                     // Another thread updated the mark price; retry with the
                     // latest value so dampening is applied correctly.

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -1037,6 +1037,15 @@ impl StrikeOrderBookManager {
                     "instrument-id exhaustion: registry full; strike books left with instrument_id 0",
                 );
             }
+            // Cold path: emitted once, by the insertion winner only — never on
+            // the lookup/return path above, the order-submission path, or the
+            // per-quote read.
+            tracing::info!(
+                underlying = %self.underlying,
+                strike,
+                expiration = %self.expiration,
+                "strike created",
+            );
         }
         winner
     }
@@ -1119,13 +1128,21 @@ impl StrikeOrderBookManager {
         // winner and owns these side effects.
         if let Some(candidate) = &built
             && Arc::ptr_eq(candidate, &winner)
-            && let Err(err) = self.assign_instrument_ids(&winner, strike)
         {
-            tracing::error!(
+            if let Err(err) = self.assign_instrument_ids(&winner, strike) {
+                tracing::error!(
+                    underlying = %self.underlying,
+                    strike,
+                    error = %err,
+                    "instrument-id exhaustion: registry full; strike books left with instrument_id 0",
+                );
+            }
+            // Cold path: emitted once, by the insertion winner only.
+            tracing::info!(
                 underlying = %self.underlying,
                 strike,
-                error = %err,
-                "instrument-id exhaustion: registry full; strike books left with instrument_id 0",
+                expiration = %self.expiration,
+                "strike created",
             );
         }
         winner


### PR DESCRIPTION
## Summary

Several subsystems emitted no `tracing` at all, contrary to the crate's logging
rule, leaving lifecycle milestones and failures invisible to operators and
post-incident replay correlation. This adds **structured-field** tracing on
**cold paths only** (creation / transition / error), never on the hot
order/quote/match/aggregation paths, and never installing a global subscriber
from library code.

## Changes (all cold-path, structured fields)

- **strike.rs** — INFO `"strike created"` at the `get_or_create` insertion-winner
  (non-NATS and NATS paths): `underlying`, `strike`, `expiration`.
- **expiration.rs** — INFO `"expiration created"` at the
  `ExpirationOrderBookManager` insertion-winner (gated on `inserted`), so every
  creator — direct `get_or_create_expiration` and the scheduler alike — is
  covered (fixes the strike/expiration asymmetry).
- **expiry_scheduler.rs** — INFO `"strikes generated for expiration"` (the
  scheduler's own strike-generation step, kept distinct from the manager's
  creation INFO to avoid double-logging); ERROR on `strikes_generated` overflow.
- **expiry_lifecycle.rs** — INFO on settle/expire/remove transitions via a
  `#[cold]` log fn driven by a read-only loop over `result.events`; ERROR on
  date-overflow; WARN on the three `cancel_all()` failure paths.
- **greeks_engine.rs** — DEBUG `"greeks recalculated"` on the recalc tick; WARN on
  the #56 input-validation rejections; WARN + **recover (no panic)** on a poisoned
  listeners lock in `subscribe`/`notify_listeners`.
- **index_price_feed.rs** — INFO on feed subscribe/unsubscribe and
  `wire_feed_to_calculator`, with the `SubscriptionId`.
- **mark_price.rs** — DEBUG `"mark price refreshed"` on `advance_mark`'s CAS-success
  commit only (the mutating tick) — `current_mark_price` (the pure read) logs
  nothing.

## Technical decisions

Purely additive: no behavior, control-flow, signature, or public-surface change.
Verified by adversarial review:
- **Hot-path review:** zero tracing on `add_limit_order*`/`cancel_order`,
  `best_quote`/`current_mark_price`, the trade/match listener, or stats/aggregation
  (`book.rs` untouched). Creation INFOs are gated on the insertion-winner so a
  cache hit logs nothing.
- **Determinism review:** no `Utc::now()`/`rand` pulled into any field; the
  `map_err`/`ok_or_else` wrappers return the same value; the lifecycle log loop is
  read-only in push order; poison recovery preserves listener push order. No
  replay/journal/NATS payload changes.

No global subscriber is installed from library code (`tracing-subscriber` is a
dev-dependency only). Field names are consistent across subsystems (`underlying`,
`strike`, `expiration`, `status`, `subscription_id`, `error`).

## Public API impact

None. Version stays `0.5.0`. README unchanged.

## Testing

- [x] Existing 822 lib + 6 integration + 88 doctests pass unchanged (tracing is non-behavioral)
- [x] Poison-recovery path exercised by the existing panic-unwind listener test
- [x] `make pre-push` clean; `cargo build --features nats,sequencer` clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] `tracing` only — no `println!`/`eprintln!`/`dbg!`/`log`; structured fields, not interpolation
- [x] No tracing on hot paths; no global subscriber from library code
- [x] No `.unwrap()`/`.expect()` added (poisoned lock recovers via `into_inner`); no `unsafe`
- [x] No new dependencies / feature flags
- [x] Determinism preserved (no clock/rand in fields; no control-flow change)

Closes #83
