### PR TITLE
API hygiene: must_use, deterministic Debug/iter, Greeks # Errors (#75)

### DIFF
--- a/src/orderbook/greeks_engine.rs
+++ b/src/orderbook/greeks_engine.rs
@@ -277,6 +277,20 @@ impl GreeksEngine {
     /// # Returns
     ///
     /// Calculated Greeks or an error if calculation fails.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::GreeksError`] when an input fails validation or the
+    /// underlying `optionstratlib` calculation fails. Specifically:
+    ///
+    /// - `spot`, `strike`, `tte_years`, or `iv` is non-positive (`<= 0.0`);
+    /// - `risk_free_rate` is non-finite (`NaN` or `±∞`) — a negative rate is
+    ///   permitted to support negative-rate regimes;
+    /// - `dividend_yield` is non-finite or negative (a true `0.0` is valid);
+    /// - any validated value cannot be converted to a `Positive` or to a
+    ///   `Decimal` risk-free rate; or
+    /// - any individual Greek (delta, gamma, theta, vega, rho, vanna, vomma,
+    ///   veta, charm, color) fails to compute in `optionstratlib`.
     pub fn calculate_greeks(
         spot: f64,
         strike: f64,
@@ -420,6 +434,17 @@ impl GreeksEngine {
     /// # Returns
     ///
     /// Tuple of (call_greeks, put_greeks) or an error.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`Error::GreeksError`] if either the call or the put leg fails
+    /// to compute. Each leg delegates to [`calculate_greeks`](Self::calculate_greeks),
+    /// so the same input-validation conditions apply: non-positive `spot`,
+    /// `strike`, `tte_years`, `call_iv`, or `put_iv`; non-finite `risk_free_rate`;
+    /// non-finite or negative `dividend_yield`; a failed `Positive`/`Decimal`
+    /// conversion; or a failure inside an individual `optionstratlib` Greek.
+    /// The call leg is evaluated first, so its error short-circuits before the
+    /// put leg is computed.
     pub fn calculate_strike_greeks(
         spot: f64,
         strike: f64,

--- a/src/orderbook/instrument_registry.rs
+++ b/src/orderbook/instrument_registry.rs
@@ -63,6 +63,8 @@ impl InstrumentInfo {
     }
 
     /// Returns the expiration date.
+    // No `#[must_use]`: the return type `ExpirationDate` is itself `#[must_use]`,
+    // so a function-level attribute would be a `clippy::double_must_use` error.
     #[inline]
     pub const fn expiration(&self) -> &ExpirationDate {
         &self.expiration
@@ -113,6 +115,20 @@ pub struct InstrumentRegistry {
     next_id: AtomicU32,
     /// Reverse index mapping instrument ID → instrument info.
     index: DashMap<u32, InstrumentInfo>,
+}
+
+impl std::fmt::Debug for InstrumentRegistry {
+    /// Diagnostic summary. Deliberately a lightweight, **deterministic** summary
+    /// (next id + entry count) rather than a `#[derive(Debug)]` over the inner
+    /// `DashMap`, whose `Debug` dumps entries in arbitrary shard order — a
+    /// determinism footgun if such output were ever folded into a hash or event.
+    /// Use [`iter`](Self::iter) for the full, id-ordered contents.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InstrumentRegistry")
+            .field("next_id", &self.next_id.load(Ordering::Relaxed))
+            .field("len", &self.index.len())
+            .finish()
+    }
 }
 
 impl InstrumentRegistry {
@@ -216,9 +232,15 @@ impl InstrumentRegistry {
 
     /// Returns a snapshot of all registered `(id, InstrumentInfo)` pairs.
     ///
+    /// Yields entries in ascending instrument-id order (deterministic).
+    /// Instrument IDs are unique, so the ordering is total and stable across
+    /// calls — this matters because the registry is exposed to external
+    /// sequencer/journal consumers, where an arbitrary `DashMap` shard order
+    /// would be a determinism footgun.
+    ///
     /// The returned `Vec` is a point-in-time snapshot — concurrent
     /// registrations that occur after the call begins may or may not
-    /// be included. The order of entries is arbitrary.
+    /// be included.
     ///
     /// # Examples
     ///
@@ -242,10 +264,15 @@ impl InstrumentRegistry {
     /// ```
     #[must_use]
     pub fn iter(&self) -> Vec<(u32, InstrumentInfo)> {
-        self.index
+        let mut entries: Vec<(u32, InstrumentInfo)> = self
+            .index
             .iter()
             .map(|entry| (*entry.key(), entry.value().clone()))
-            .collect()
+            .collect();
+        // Ids are unique, so the key yields a total order: unstable sort is
+        // both deterministic and cheaper than a stable sort here.
+        entries.sort_unstable_by_key(|(id, _)| *id);
+        entries
     }
 }
 
@@ -520,9 +547,9 @@ mod tests {
         let entries = registry.iter();
         assert_eq!(entries.len(), 5);
 
-        // Verify all IDs are present (order is arbitrary)
-        let mut ids: Vec<u32> = entries.iter().map(|(id, _)| *id).collect();
-        ids.sort();
+        // iter() guarantees ascending instrument-id order (deterministic), so
+        // the ids appear already sorted without any post-processing.
+        let ids: Vec<u32> = entries.iter().map(|(id, _)| *id).collect();
         assert_eq!(ids, vec![1, 2, 3, 4, 5]);
 
         // Verify info is correct for one entry

--- a/src/orderbook/instrument_registry.rs
+++ b/src/orderbook/instrument_registry.rs
@@ -63,8 +63,9 @@ impl InstrumentInfo {
     }
 
     /// Returns the expiration date.
-    // No `#[must_use]`: the return type `ExpirationDate` is itself `#[must_use]`,
-    // so a function-level attribute would be a `clippy::double_must_use` error.
+    // No `#[must_use]`: the underlying type `ExpirationDate` (the referent of the
+    // returned `&ExpirationDate`) is itself `#[must_use]`, so a function-level
+    // attribute would be a `clippy::double_must_use` error.
     #[inline]
     pub const fn expiration(&self) -> &ExpirationDate {
         &self.expiration
@@ -118,11 +119,14 @@ pub struct InstrumentRegistry {
 }
 
 impl std::fmt::Debug for InstrumentRegistry {
-    /// Diagnostic summary. Deliberately a lightweight, **deterministic** summary
-    /// (next id + entry count) rather than a `#[derive(Debug)]` over the inner
-    /// `DashMap`, whose `Debug` dumps entries in arbitrary shard order — a
-    /// determinism footgun if such output were ever folded into a hash or event.
-    /// Use [`iter`](Self::iter) for the full, id-ordered contents.
+    /// Diagnostic summary (next id + entry count). Deliberately lightweight and
+    /// hand-rolled rather than a `#[derive(Debug)]` over the inner `DashMap`,
+    /// whose `Debug` dumps entries in arbitrary shard order — a footgun if such
+    /// output were ever folded into a hash or event. This avoids that
+    /// shard-order nondeterminism; note the two scalar fields are each read
+    /// independently, so under concurrent mutation the summary is a point-in-time
+    /// approximation, not a consistent snapshot. Use [`iter`](Self::iter) for the
+    /// full, id-ordered contents.
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("InstrumentRegistry")
             .field("next_id", &self.next_id.load(Ordering::Relaxed))

--- a/src/orderbook/symbol_index.rs
+++ b/src/orderbook/symbol_index.rs
@@ -61,6 +61,8 @@ impl SymbolRef {
     }
 
     /// Returns the expiration date.
+    // No `#[must_use]`: the return type `ExpirationDate` is itself `#[must_use]`,
+    // so a function-level attribute would be a `clippy::double_must_use` error.
     #[inline]
     pub const fn expiration(&self) -> &ExpirationDate {
         &self.expiration
@@ -203,6 +205,7 @@ impl SymbolIndex {
     }
 
     /// Returns an iterator over all registered symbols.
+    #[must_use]
     pub fn symbols(&self) -> Vec<String> {
         self.index.iter().map(|entry| entry.key().clone()).collect()
     }

--- a/src/orderbook/symbol_index.rs
+++ b/src/orderbook/symbol_index.rs
@@ -61,8 +61,9 @@ impl SymbolRef {
     }
 
     /// Returns the expiration date.
-    // No `#[must_use]`: the return type `ExpirationDate` is itself `#[must_use]`,
-    // so a function-level attribute would be a `clippy::double_must_use` error.
+    // No `#[must_use]`: the underlying type `ExpirationDate` (the referent of the
+    // returned `&ExpirationDate`) is itself `#[must_use]`, so a function-level
+    // attribute would be a `clippy::double_must_use` error.
     #[inline]
     pub const fn expiration(&self) -> &ExpirationDate {
         &self.expiration
@@ -204,7 +205,7 @@ impl SymbolIndex {
         self.index.is_empty()
     }
 
-    /// Returns an iterator over all registered symbols.
+    /// Returns a snapshot `Vec` of all registered symbols, in unspecified order.
     #[must_use]
     pub fn symbols(&self) -> Vec<String> {
         self.index.iter().map(|entry| entry.key().clone()).collect()


### PR DESCRIPTION
## Summary

A cluster of API-hygiene gaps that default clippy does not catch: missing
`#[must_use]` on a pure accessor, no `Debug` on `InstrumentRegistry`, missing
`# Errors` on two fallible Greeks functions, and — the substantive one —
`InstrumentRegistry::iter()` returning DashMap entries in arbitrary shard order
on an API explicitly exposed to sequencer/journal consumers (a determinism
footgun).

## Changes

- **`#[must_use]`** on `SymbolIndex::symbols` (returns `Vec<String>`).
- **Deterministic `InstrumentRegistry::iter()`**: collects and
  `sort_unstable_by_key` by id before returning. Ids are unique (monotonic
  `AtomicU32`), so the order is **total and deterministic** — replacing the
  previous arbitrary DashMap shard order. Documented as ascending-id order; the
  iter test now asserts the sorted order directly.
- **Manual `Debug` on `InstrumentRegistry`** (lightweight deterministic summary:
  `next_id` + entry count) rather than `#[derive(Debug)]` over the inner
  `DashMap`, whose derived `Debug` dumps entries in arbitrary shard order —
  keeping diagnostics deterministic too.
- **`# Errors`** sections on `calculate_greeks` and `calculate_strike_greeks`
  documenting the exact #56 validation branches.

## Technical decisions

`#[must_use]` was **not** added to `InstrumentInfo::expiration` /
`SymbolRef::expiration`: both return `&ExpirationDate`, and optionstratlib's
`ExpirationDate` is itself `#[must_use]`, so a function-level attribute triggers
`clippy::double_must_use` (a hard error under `-D warnings`) — the type-level
attribute already covers them. The siblings `strike()`/`option_style()` carry
`#[must_use]` only because `u64`/`OptionStyle` are not must-use types, so the
apparent inconsistency the issue flagged is correct as-is; explanatory comments
were left at each accessor. The `iter()` determinism fix and the manual `Debug`
together harden the registry's public surface for external sequencer/journal
consumers (verified by determinism audit: no in-repo production caller, the sort
key is tie-free).

## Public API impact

No signature changes (`iter()` already returned `Vec<(u32, InstrumentInfo)>`; it
is now ordered). `InstrumentRegistry` now implements `Debug`. README unchanged
(item/module docs only). Version stays `0.5.0`.

## Testing

- [x] `iter` test strengthened to assert ascending-id order directly
- [x] Existing registry/symbol-index/Greeks tests pass unchanged
- [x] `make pre-push` clean; `cargo build --features nats,sequencer` clean; clippy `-D warnings` (incl. `must_use` lints) clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] No behavior change except `iter()`'s now-deterministic order
- [x] Determinism improved (`iter()` and `Debug` no longer leak DashMap shard order)
- [x] No `unsafe`; `tracing` only; no new dependencies / feature flags

Closes #75
