### PR TITLE
Refresh stale crate/module docs and regenerate README (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,70 @@ what `orderbook_rs` accepts there).
 - [`orderbook::Quote`]: Two-sided market representation
 - [`orderbook::QuoteUpdate`]: Quote change tracking
 
+### Microstructure Coverage
+
+This crate is the option-chain *organization and aggregation* layer; the
+matching engine itself is `orderbook-rs`. On top of that engine it provides:
+
+- **Hierarchical option chain**: underlying → expiration → chain → strike →
+  contract, where each leaf [`orderbook::OptionOrderBook`] wraps one
+  `orderbook_rs::OrderBook<T>`. `get_or_create_*` traversal is idempotent and
+  returns shared handles.
+- **Two-sided quotes**: [`orderbook::Quote`] / [`orderbook::QuoteUpdate`]
+  expose top-of-book per side; a one-sided book yields a one-sided quote.
+- **Mark price**: [`orderbook::MarkPriceCalculator`] computes a configurable
+  weighted average of index / mid / last-trade prices with `Decimal`
+  dampening to bound per-update movement.
+- **Greeks**: [`orderbook::GreeksEngine`] prices each contract through
+  `optionstratlib` from a supplied implied volatility (read from a
+  [`orderbook::VolSurface`] by the integrator and passed in — the engine
+  takes the IV directly, it does not query the surface itself), and
+  [`orderbook::GreeksAggregator`] sums per-position Greeks across the
+  hierarchy into [`orderbook::AggregatedGreeks`] using `Decimal`.
+- **Expiry lifecycle**: [`orderbook::ExpiryCycleConfig`] /
+  [`orderbook::CycleRule`], [`orderbook::ExpiryLifecycleManager`], and
+  [`orderbook::ExpiryScheduler`] drive roll/expiry transitions with listeners.
+- **Scoped mass-cancel**: contract / strike / chain / expiration /
+  underlying / global, each returning a typed result counting what it
+  cancelled, iterated deterministically from the ordered `SkipMap`.
+- **Instrument & symbol services**: [`orderbook::SymbolIndex`],
+  [`orderbook::InstrumentRegistry`], [`orderbook::InstrumentStatus`],
+  [`orderbook::ContractSpecs`], [`orderbook::StrikeGenerator`], and
+  [`orderbook::StrikeRangeConfig`] for fast lookup and strike management.
+- **Order policy hooks**: a crate-local [`orderbook::ValidationConfig`]
+  (order/price/qty limits) plus the upstream [`orderbook::FeeSchedule`] and
+  self-trade prevention [`orderbook::STPMode`] — all applied by `orderbook-rs`
+  at the leaf engine.
+- **Optional eventing**: NATS publishing (`nats` feature) and a
+  command/event/journal/replay sequencer (`sequencer` feature).
+
+### Limitations
+
+- **Not a matching engine.** Order placement, matching, fills, fees, and STP
+  at the leaf are `orderbook-rs` behavior. This crate organizes and
+  aggregates many `OrderBook<T>` instances; it does not reimplement matching,
+  and options math is delegated to `optionstratlib` (no hand-rolled
+  Black-Scholes here).
+- **Async is opt-in.** `tokio` is pulled in only by the `nats` and
+  `sequencer` features. The default build, the hierarchy traversal, and the
+  order-submission / quote path are fully synchronous and lock-free — there
+  is no `.await` on the hot path.
+- **`ExpirationDate::Days` is wall-clock-relative.** A `Days(n)` expiry is a
+  moving relative day-count: it is resolved against the current clock when
+  materialized into a contract date or time-to-expiry, so the same `Days`
+  value maps to different calendar dates as time passes. Use
+  [`ExpirationDate::DateTime`](optionstratlib::ExpirationDate) for an
+  absolute, replay-stable expiry; lifecycle transitions operate only on the
+  `DateTime` form.
+- **Mark price is a derived, non-journaled value.** It is computed from
+  current inputs and is not part of the `sequencer` journal; replay
+  reconstructs order-book state, not historical mark prices.
+- **Pricing inputs are supplied by the integrator.** The crate ships only a
+  trivial [`orderbook::FlatVolSurface`] and mock / static index feeds
+  ([`orderbook::MockPriceFeed`], [`orderbook::StaticPriceFeed`]); a
+  production volatility surface and a live index price feed are the caller's
+  responsibility.
+
 ### Example Usage
 
 #### Creating a Hierarchical Order Book
@@ -238,12 +302,24 @@ Built on OrderBook-rs's lock-free architecture:
 
 ### Dependencies
 
-- **orderbook-rs** (0.6): Lock-free order book engine
-- **optionstratlib** (0.15): Options pricing, Greeks, and strategy analysis
-- **crossbeam-skiplist** (0.1): Lock-free concurrent skip list
-- **rust_decimal** (1.40): Precise decimal arithmetic
-- **thiserror** (2.0): Error handling
-- **serde** (1.0): Serialization support
+See `Cargo.toml` for the exact pinned versions (kept there so this list
+cannot go stale). The core dependencies are:
+
+- **orderbook-rs**: lock-free matching engine and price levels — the actual
+  order book this crate organizes (`special_orders` feature on)
+- **pricelevel**: per-level engine and boundary newtypes (`OrderId`,
+  `Price`, `Quantity`, `Side`, `OrderType`, `TimeInForce`, `Hash32`)
+- **optionstratlib**: options pricing, Greeks, `ExpirationDate`,
+  `OptionStyle`, and `Positive`
+- **crossbeam-skiplist**: ordered lock-free skip list (manager children)
+- **dashmap**: lock-free concurrent hash map (secondary indexes)
+- **rust_decimal**: exact decimal arithmetic for mark price and Greeks
+- **thiserror**: typed error handling
+- **serde** / **serde_json**: serialization for events and config DTOs
+- **tracing**: structured logging (no global subscriber installed by the
+  library)
+- **tokio** *(optional)*: async runtime, pulled in only by the `nats` and
+  `sequencer` features
 
 
 ## 🛠 Makefile Commands

--- a/README.md
+++ b/README.md
@@ -151,8 +151,11 @@ matching engine itself is `orderbook-rs`. On top of that engine it provides:
   Black-Scholes here).
 - **Async is opt-in.** `tokio` is pulled in only by the `nats` and
   `sequencer` features. The default build, the hierarchy traversal, and the
-  order-submission / quote path are fully synchronous and lock-free — there
-  is no `.await` on the hot path.
+  order-submission / quote path are fully synchronous — there is no `.await`
+  on the hot path. The matching engine underneath (`orderbook-rs`) is
+  lock-free, and the hierarchy itself is lock-free skip-maps + atomics; the
+  only mutexes are around rarely-contended state (e.g. opt-in trade capture,
+  config holders), not the matching path.
 - **`ExpirationDate::Days` is wall-clock-relative.** A `Days(n)` expiry is a
   moving relative day-count: it is resolved against the current clock when
   materialized into a contract date or time-to-expiry, so the same `Days`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,70 @@
 //! - [`orderbook::Quote`]: Two-sided market representation
 //! - [`orderbook::QuoteUpdate`]: Quote change tracking
 //!
+//! ## Microstructure Coverage
+//!
+//! This crate is the option-chain *organization and aggregation* layer; the
+//! matching engine itself is `orderbook-rs`. On top of that engine it provides:
+//!
+//! - **Hierarchical option chain**: underlying → expiration → chain → strike →
+//!   contract, where each leaf [`orderbook::OptionOrderBook`] wraps one
+//!   `orderbook_rs::OrderBook<T>`. `get_or_create_*` traversal is idempotent and
+//!   returns shared handles.
+//! - **Two-sided quotes**: [`orderbook::Quote`] / [`orderbook::QuoteUpdate`]
+//!   expose top-of-book per side; a one-sided book yields a one-sided quote.
+//! - **Mark price**: [`orderbook::MarkPriceCalculator`] computes a configurable
+//!   weighted average of index / mid / last-trade prices with `Decimal`
+//!   dampening to bound per-update movement.
+//! - **Greeks**: [`orderbook::GreeksEngine`] prices each contract through
+//!   `optionstratlib` from a supplied implied volatility (read from a
+//!   [`orderbook::VolSurface`] by the integrator and passed in — the engine
+//!   takes the IV directly, it does not query the surface itself), and
+//!   [`orderbook::GreeksAggregator`] sums per-position Greeks across the
+//!   hierarchy into [`orderbook::AggregatedGreeks`] using `Decimal`.
+//! - **Expiry lifecycle**: [`orderbook::ExpiryCycleConfig`] /
+//!   [`orderbook::CycleRule`], [`orderbook::ExpiryLifecycleManager`], and
+//!   [`orderbook::ExpiryScheduler`] drive roll/expiry transitions with listeners.
+//! - **Scoped mass-cancel**: contract / strike / chain / expiration /
+//!   underlying / global, each returning a typed result counting what it
+//!   cancelled, iterated deterministically from the ordered `SkipMap`.
+//! - **Instrument & symbol services**: [`orderbook::SymbolIndex`],
+//!   [`orderbook::InstrumentRegistry`], [`orderbook::InstrumentStatus`],
+//!   [`orderbook::ContractSpecs`], [`orderbook::StrikeGenerator`], and
+//!   [`orderbook::StrikeRangeConfig`] for fast lookup and strike management.
+//! - **Order policy hooks**: a crate-local [`orderbook::ValidationConfig`]
+//!   (order/price/qty limits) plus the upstream [`orderbook::FeeSchedule`] and
+//!   self-trade prevention [`orderbook::STPMode`] — all applied by `orderbook-rs`
+//!   at the leaf engine.
+//! - **Optional eventing**: NATS publishing (`nats` feature) and a
+//!   command/event/journal/replay sequencer (`sequencer` feature).
+//!
+//! ## Limitations
+//!
+//! - **Not a matching engine.** Order placement, matching, fills, fees, and STP
+//!   at the leaf are `orderbook-rs` behavior. This crate organizes and
+//!   aggregates many `OrderBook<T>` instances; it does not reimplement matching,
+//!   and options math is delegated to `optionstratlib` (no hand-rolled
+//!   Black-Scholes here).
+//! - **Async is opt-in.** `tokio` is pulled in only by the `nats` and
+//!   `sequencer` features. The default build, the hierarchy traversal, and the
+//!   order-submission / quote path are fully synchronous and lock-free — there
+//!   is no `.await` on the hot path.
+//! - **`ExpirationDate::Days` is wall-clock-relative.** A `Days(n)` expiry is a
+//!   moving relative day-count: it is resolved against the current clock when
+//!   materialized into a contract date or time-to-expiry, so the same `Days`
+//!   value maps to different calendar dates as time passes. Use
+//!   [`ExpirationDate::DateTime`](optionstratlib::ExpirationDate) for an
+//!   absolute, replay-stable expiry; lifecycle transitions operate only on the
+//!   `DateTime` form.
+//! - **Mark price is a derived, non-journaled value.** It is computed from
+//!   current inputs and is not part of the `sequencer` journal; replay
+//!   reconstructs order-book state, not historical mark prices.
+//! - **Pricing inputs are supplied by the integrator.** The crate ships only a
+//!   trivial [`orderbook::FlatVolSurface`] and mock / static index feeds
+//!   ([`orderbook::MockPriceFeed`], [`orderbook::StaticPriceFeed`]); a
+//!   production volatility surface and a live index price feed are the caller's
+//!   responsibility.
+//!
 //! ## Example Usage
 //!
 //! ### Creating a Hierarchical Order Book
@@ -224,12 +288,24 @@
 //!
 //! ## Dependencies
 //!
-//! - **orderbook-rs** (0.6): Lock-free order book engine
-//! - **optionstratlib** (0.15): Options pricing, Greeks, and strategy analysis
-//! - **crossbeam-skiplist** (0.1): Lock-free concurrent skip list
-//! - **rust_decimal** (1.40): Precise decimal arithmetic
-//! - **thiserror** (2.0): Error handling
-//! - **serde** (1.0): Serialization support
+//! See `Cargo.toml` for the exact pinned versions (kept there so this list
+//! cannot go stale). The core dependencies are:
+//!
+//! - **orderbook-rs**: lock-free matching engine and price levels — the actual
+//!   order book this crate organizes (`special_orders` feature on)
+//! - **pricelevel**: per-level engine and boundary newtypes (`OrderId`,
+//!   `Price`, `Quantity`, `Side`, `OrderType`, `TimeInForce`, `Hash32`)
+//! - **optionstratlib**: options pricing, Greeks, `ExpirationDate`,
+//!   `OptionStyle`, and `Positive`
+//! - **crossbeam-skiplist**: ordered lock-free skip list (manager children)
+//! - **dashmap**: lock-free concurrent hash map (secondary indexes)
+//! - **rust_decimal**: exact decimal arithmetic for mark price and Greeks
+//! - **thiserror**: typed error handling
+//! - **serde** / **serde_json**: serialization for events and config DTOs
+//! - **tracing**: structured logging (no global subscriber installed by the
+//!   library)
+//! - **tokio** *(optional)*: async runtime, pulled in only by the `nats` and
+//!   `sequencer` features
 
 pub mod error;
 pub mod orderbook;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,11 @@
 //!   Black-Scholes here).
 //! - **Async is opt-in.** `tokio` is pulled in only by the `nats` and
 //!   `sequencer` features. The default build, the hierarchy traversal, and the
-//!   order-submission / quote path are fully synchronous and lock-free — there
-//!   is no `.await` on the hot path.
+//!   order-submission / quote path are fully synchronous — there is no `.await`
+//!   on the hot path. The matching engine underneath (`orderbook-rs`) is
+//!   lock-free, and the hierarchy itself is lock-free skip-maps + atomics; the
+//!   only mutexes are around rarely-contended state (e.g. opt-in trade capture,
+//!   config holders), not the matching path.
 //! - **`ExpirationDate::Days` is wall-clock-relative.** A `Days(n)` expiry is a
 //!   moving relative day-count: it is resolved against the current clock when
 //!   materialized into a contract date or time-to-expiry, so the same `Days`

--- a/src/orderbook/mark_price.rs
+++ b/src/orderbook/mark_price.rs
@@ -341,10 +341,16 @@ impl MarkPriceConfigBuilder {
 ///
 /// ## Precision
 ///
-/// Prices are stored as `u64` and converted to `f64` for the weighted
-/// average calculation. Values above 2^53 (≈ 9 × 10^15) may lose
-/// integer precision through the `f64` round-trip. For typical financial
-/// prices in smallest units (satoshis, wei, cents) this is not a concern.
+/// Prices are stored as `u64` (smallest price units), and the weighted average
+/// and dampening are computed entirely in [`rust_decimal::Decimal`] — there is
+/// no `f64` round-trip in the calculation. Each `u64` input is converted to
+/// `Decimal` exactly (`Decimal` represents the full `u64` range), the weighting
+/// and the dampening band are exact `Decimal` arithmetic, and the result is then
+/// converted back to `u64`. The only loss is that final integer conversion,
+/// which deterministically truncates the fractional part (the mark is quantized
+/// to whole price units); it is not floating-point drift. The weight and
+/// dampening-factor values are also stored as `Decimal` (built once from `f64`
+/// at config time), so the running computation never touches `f64`.
 ///
 /// ## Example
 ///

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -30,21 +30,28 @@
 //!
 //! ## Example
 //!
-//! ```rust,ignore
+//! ```rust
 //! use option_chain_orderbook::orderbook::UnderlyingOrderBookManager;
+//! use option_chain_orderbook::{OrderId, Side};
+//! use optionstratlib::ExpirationDate;
+//! use optionstratlib::prelude::pos_or_panic;
 //!
-//! let mut manager = UnderlyingOrderBookManager::new();
+//! let manager = UnderlyingOrderBookManager::new();
 //!
-//! // Create BTC option chain
+//! // Create a BTC option chain at a 30-day expiry and a 50_000 strike.
 //! let btc = manager.get_or_create("BTC");
-//! let exp = btc.get_or_create_expiration("20240329");
-//! let strike = exp.get_or_create_strike(50000);
+//! let exp = btc.get_or_create_expiration(ExpirationDate::Days(pos_or_panic!(30.0)));
+//! let strike = exp.get_or_create_strike(50_000);
 //!
-//! // Add orders to call
-//! strike.call().add_limit_order(order_id, Side::Buy, 100, 10)?;
+//! // Add a two-sided market to the call book.
+//! strike.call().add_limit_order(OrderId::new(), Side::Buy, 100, 10)
+//!     .expect("add bid should succeed");
+//! strike.call().add_limit_order(OrderId::new(), Side::Sell, 105, 5)
+//!     .expect("add ask should succeed");
 //!
-//! // Get quote
+//! // Read the best quote.
 //! let quote = strike.call().best_quote();
+//! assert!(quote.is_two_sided());
 //! ```
 
 mod book;

--- a/src/orderbook/nats.rs
+++ b/src/orderbook/nats.rs
@@ -261,7 +261,8 @@ impl OptionChainSubjectBuilder {
     /// ```
     /// use option_chain_orderbook::orderbook::nats::OptionChainSubjectBuilder;
     ///
-    /// let builder = OptionChainSubjectBuilder::from_symbol("BTC-20240329-50000-C").unwrap();
+    /// let builder = OptionChainSubjectBuilder::from_symbol("BTC-20240329-50000-C")
+    ///     .expect("well-formed contract symbol should parse");
     /// assert_eq!(builder.underlying(), "BTC");
     /// assert_eq!(builder.expiry(), "20240329");
     /// assert_eq!(builder.strike(), "50000");

--- a/src/orderbook/stp.rs
+++ b/src/orderbook/stp.rs
@@ -4,7 +4,7 @@
 //! contract books they create. STP prevents a trader's incoming order from
 //! matching against their own resting orders.
 //!
-//! The underlying `OrderBook<T>` supports these STP modes via
+//! The underlying `OrderBook<T>` supports all four STP modes via
 //! [`STPMode`](orderbook_rs::STPMode):
 //! - **None** (default) — no self-trade prevention
 //! - **CancelTaker** — cancel the incoming order on self-trade


### PR DESCRIPTION
## Summary

Multiple docs shipped wrong information to consumers. This refreshes them — all
changes are **docs/comments only** (zero logic/signature changes). Per the issue,
`README.md` is **not** hand-edited; the crate `//!` docs were updated and README
regenerated via `make readme`.

## Changes

- **`lib.rs` Dependencies block**: dropped the stale hard-coded versions
  (`orderbook-rs 0.6` / `optionstratlib 0.15` / `rust_decimal 1.40`) and the
  missing crates; now points at `Cargo.toml` for exact pins and lists `pricelevel`
  and `dashmap`, noting `tokio` is opt-in (`nats`/`sequencer`).
- **`mod.rs` example**: was ` ```rust,ignore ` passing a `&str` where
  `ExpirationDate` is required (plus an unnecessary `mut` and an undefined
  `order_id`). Now a **real compiling doctest** building
  `ExpirationDate::Days(pos_or_panic!(30.0))`.
- **`mark_price.rs` Precision section**: removed the false "f64 round-trip drift"
  claim — `raw_weighted_average`/`dampen` compute entirely in `rust_decimal::Decimal`
  (f64 only at config-time setters). Documents the one real effect: the final
  `to_u64()` truncates the fractional part (integer quantization, not float drift).
- **`stp.rs`**: makes the mode count explicit and correct ("all four" STP modes).
  **`nats.rs`** doctest: bare `.unwrap()` → `.expect()`.
- **README Microstructure Coverage + honest Limitations** (via crate docs): not a
  matching engine; async opt-in; `ExpirationDate::Days` wall-clock-relative
  (lifecycle operates on `DateTime`); mark price derived/non-journaled; only
  `FlatVolSurface` + `Mock`/`Static` feeds ship.

## Technical decisions

Every microstructure claim and limitation was verified against the code by an
adversarial review. Two phrasings were tightened after that review: the Greeks
bullet now states the engine takes a **supplied IV** (read from a `VolSurface` by
the integrator and passed in — the engine doesn't query the surface itself), and
the order-policy bullet clarifies `ValidationConfig` is crate-local while
`FeeSchedule`/`STPMode` are applied by `orderbook-rs` at the leaf. The mark-price
precision rewrite was confirmed exact-`Decimal` (the `.ceil()` is on the dampening
band width, lossless; the only quantization is the final mark `to_u64()`).

## Public API impact

None — docs only. README regenerated via `make readme` (idempotent). Version stays
`0.5.0`.

## Testing

- [x] `cargo test --all-features` — 89 doctests pass (incl. the new compiling `mod.rs` example), 0 failed
- [x] `make readme` regenerated README (not hand-edited); re-running is idempotent
- [x] `make pre-push` clean; `cargo build --features nats,sequencer` clean (the nats doctest)

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] Docs accurate, not overclaiming (verified against code)
- [x] No bare `.unwrap()` in touched doctests; doctests compile + pass
- [x] README via `make readme`, never hand-edited
- [x] No logic/signature changes; no new dependencies / feature flags

Closes #84
