### PR TITLE
Package tests/fixtures and reword get_or_create_inserted doc (#117)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ include = [
     "LICENSE",
     "examples/**/*.rs",
     "tests/**/*.rs",
+    "tests/fixtures/**/*",
     "Makefile",
     "rust-toolchain.toml",
 ]

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -802,7 +802,8 @@ impl ExpirationOrderBookManager {
     /// Identical guarantees to [`get_or_create`](Self::get_or_create): atomic,
     /// idempotent, lock-free. The winner is detected via
     /// [`Arc::ptr_eq`] against the locally built handle, so the `inserted` flag
-    /// is derived purely from the atomic insert result with no extra map probe.
+    /// is derived purely from the atomic insert result — no follow-up map probe
+    /// after `get_or_insert` (the up-front `get` fast-path still applies).
     #[must_use]
     pub fn get_or_create_inserted(
         &self,


### PR DESCRIPTION
## Summary

Three nits from the PR #113/#114/#115 Copilot reviews (tracked as #117).

## Changes

- **(#113) Package the journal fixture.** `sequencer.rs`'s back-compat test uses
  `include_str!("../../tests/fixtures/journal_event_v0.5.0.json")`, but
  `Cargo.toml`'s `include` listed `tests/**/*.rs` and **not** the fixtures — so
  `cargo test` from a packaged tarball failed to compile (missing fixture). Added
  `tests/fixtures/**/*` to `include`; verified the JSON now appears in
  `cargo package --list`.
- **(#115) Reword `get_or_create_inserted` doc.** It said the `inserted` flag is
  derived "with no extra map probe", which reads as if there's no `get()` at all.
  Reworded to "no follow-up map probe after `get_or_insert` (the up-front `get`
  fast-path still applies)".
- **(#114)** The sequencer rustdoc already links the default status to
  `InstrumentStatus::Active` (the variant, not the type), so no change was needed
  — verified.

## Public API impact

None — packaging + docs only. Version stays `0.5.0`.

## Testing

- [x] `cargo package --list` now includes `tests/fixtures/journal_event_v0.5.0.json`
- [x] `make pre-push` clean (clippy `-D warnings`, fmt, tests, doc)

## Checklist

- [x] Fixture is packaged (tarball would compile its tests)
- [x] No logic/signature changes
- [x] No new dependencies / feature flags

Closes #117
