### PR TITLE
Add feature-gated integration tests and replay==live oracle (#86)

### DIFF
--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -1303,8 +1303,12 @@ impl SequencedUnderlyingOrderBook {
     /// inherit the hierarchy's shared configuration (validation / contract specs
     /// / STP mode / fee schedule), so a fresh book configured identically
     /// rebuilds an identical leaf. Registry-assigned instrument ids are NOT
-    /// journaled and need not match across runs; the equality oracle is the
-    /// structural / order state (resting orders + top-of-book), not numeric ids.
+    /// journaled, so they are not preserved when replaying into a non-empty or
+    /// differently-seeded registry. They ARE, however, reconstructed
+    /// deterministically when the same journal is replayed into a FRESH registry:
+    /// strike creation (the sole id-allocation site) runs in the same command
+    /// order on replay as live, so a fresh registry re-derives byte-identical
+    /// ids. The replay==live oracle relies on this fresh-registry determinism.
     ///
     /// The parsed underlying is validated against this book's underlying BEFORE
     /// any materialization — a mismatch is rejected and creates nothing.
@@ -1363,8 +1367,12 @@ impl SequencedUnderlyingOrderBook {
     /// of *structural / order state* — the set of resting orders (carried by id
     /// in each `AddOrder` command) and the top-of-book on each contract.
     /// Registry-assigned instrument ids are allocated at strike creation and are
-    /// NOT journaled, so they are free to differ between the live run and a
-    /// replay; they are not part of the equality contract. For a fresh book to
+    /// NOT journaled. They are therefore not preserved when replaying into a
+    /// non-empty or differently-seeded registry, but they ARE reconstructed
+    /// deterministically when the same journal is replayed into a FRESH registry,
+    /// because strike creation runs in the identical command order on replay as
+    /// live. The replay==live oracle exercises exactly this fresh-registry case
+    /// and so does assert id equality. For a fresh book to
     /// rebuild identical structural state it must be configured identically
     /// (validation / contract specs / STP mode / fee schedule), since those
     /// shared settings are applied to books created during replay.

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -2,3 +2,12 @@
 
 mod layering_tests;
 mod orderbook_tests;
+
+// Feature-gated cross-module test modules. They compile and run only under
+// `cargo test --all-features` (or the matching single feature) and are excluded
+// from the default build, so the default test matrix stays feature-free.
+#[cfg(feature = "sequencer")]
+mod sequencer_tests;
+
+#[cfg(feature = "nats")]
+mod nats_tests;

--- a/tests/unit/nats_tests.rs
+++ b/tests/unit/nats_tests.rs
@@ -1,0 +1,146 @@
+//! Cross-module integration tests for the NATS subject scheme (feature
+//! `nats`).
+//!
+//! These tests exercise the subject *construction and parse* end-to-end — no
+//! live broker is involved. The headline check is a round-trip: build a
+//! hierarchical NATS subject from a contract's coordinates via
+//! [`OptionChainSubjectBuilder`], then parse the subject tokens back into a
+//! contract symbol and rebuild the subject, asserting it is identical. This
+//! guards the documented, collision-free
+//! `{prefix}.{kind}.{underlying}.{expiry}.{strike}.{type}` scheme against drift.
+
+use option_chain_orderbook::SymbolParser;
+use option_chain_orderbook::orderbook::nats::OptionChainSubjectBuilder;
+use optionstratlib::OptionStyle;
+
+const PREFIX: &str = "optionchain";
+
+/// Parses one of this crate's hierarchical subjects back into its tokens.
+///
+/// Expected shape: `{prefix}.{kind}.{underlying}.{expiry}.{strike}.{type}`,
+/// where `kind` is `trades` or `book`. Returns
+/// `(kind, underlying, expiry, strike, option_type)`.
+fn parse_subject(subject: &str) -> (String, String, String, String, String) {
+    let tokens: Vec<&str> = subject.split('.').collect();
+    assert_eq!(
+        tokens.len(),
+        6,
+        "subject must have exactly 6 tokens: {subject}"
+    );
+    assert_eq!(tokens[0], PREFIX, "prefix token mismatch");
+    (
+        tokens[1].to_string(),
+        tokens[2].to_string(),
+        tokens[3].to_string(),
+        tokens[4].to_string(),
+        tokens[5].to_string(),
+    )
+}
+
+#[test]
+fn test_subject_round_trips_to_canonical_form_and_back() {
+    // Drive both a call and a put through the full build -> parse -> rebuild
+    // loop. The reconstructed contract symbol must re-parse to the same
+    // coordinates and rebuild byte-identical subjects.
+    for (symbol, expected_type) in [("BTC-20240329-50000-C", "C"), ("ETH-20240628-3000-P", "P")] {
+        let parsed = SymbolParser::parse(symbol).expect("symbol must parse");
+        let builder = OptionChainSubjectBuilder::from_symbol(symbol).expect("builder from symbol");
+
+        // The builder's components match the canonical symbol parse.
+        assert_eq!(builder.underlying(), parsed.underlying());
+        assert_eq!(builder.expiry(), parsed.expiration_str());
+        assert_eq!(builder.strike(), parsed.strike().to_string());
+        assert_eq!(builder.option_type(), expected_type);
+
+        let trade_subject = builder.trade_subject(PREFIX);
+        let book_subject = builder.book_subject(PREFIX);
+
+        // Canonical, documented form.
+        assert_eq!(
+            trade_subject,
+            format!(
+                "{PREFIX}.trades.{}.{}.{}.{}",
+                parsed.underlying(),
+                parsed.expiration_str(),
+                parsed.strike(),
+                expected_type
+            )
+        );
+        assert_eq!(
+            book_subject,
+            format!(
+                "{PREFIX}.book.{}.{}.{}.{}",
+                parsed.underlying(),
+                parsed.expiration_str(),
+                parsed.strike(),
+                expected_type
+            )
+        );
+
+        // ── Round-trip: parse the subject back to a contract symbol ──
+        let (trade_kind, t_underlying, t_expiry, t_strike, t_type) = parse_subject(&trade_subject);
+        assert_eq!(trade_kind, "trades");
+        let (book_kind, b_underlying, b_expiry, b_strike, b_type) = parse_subject(&book_subject);
+        assert_eq!(book_kind, "book");
+
+        // Trade and book subjects encode the same coordinates.
+        assert_eq!(
+            (&t_underlying, &t_expiry, &t_strike, &t_type),
+            (&b_underlying, &b_expiry, &b_strike, &b_type)
+        );
+
+        let reconstructed = format!("{t_underlying}-{t_expiry}-{t_strike}-{t_type}");
+        assert_eq!(
+            reconstructed, symbol,
+            "round-trip must yield the original symbol"
+        );
+
+        // Rebuilding a builder from the reconstructed symbol yields identical
+        // subjects — the loop closes.
+        let rebuilt = OptionChainSubjectBuilder::from_symbol(&reconstructed)
+            .expect("reconstructed symbol must rebuild");
+        assert_eq!(rebuilt.trade_subject(PREFIX), trade_subject);
+        assert_eq!(rebuilt.book_subject(PREFIX), book_subject);
+        assert_eq!(rebuilt.option_style(), parsed.option_style());
+    }
+}
+
+#[test]
+fn test_subject_builder_try_new_round_trips_explicit_components() {
+    // The explicit-component constructor must produce the same canonical subject
+    // and round-trip identically to the from-symbol path.
+    let builder = OptionChainSubjectBuilder::try_new("BTC", "20240329", "50000", "call")
+        .expect("valid components");
+
+    let trade_subject = builder.trade_subject(PREFIX);
+    let (kind, underlying, expiry, strike, option_type) = parse_subject(&trade_subject);
+
+    assert_eq!(kind, "trades");
+    assert_eq!(underlying, "BTC");
+    assert_eq!(expiry, "20240329");
+    assert_eq!(strike, "50000");
+    assert_eq!(option_type, "C");
+    assert_eq!(builder.option_style(), OptionStyle::Call);
+
+    // The from-symbol path over the reconstructed symbol agrees.
+    let reconstructed = format!("{underlying}-{expiry}-{strike}-{option_type}");
+    let from_symbol =
+        OptionChainSubjectBuilder::from_symbol(&reconstructed).expect("reconstructed parses");
+    assert_eq!(from_symbol.trade_subject(PREFIX), trade_subject);
+    assert_eq!(
+        from_symbol.book_subject(PREFIX),
+        builder.book_subject(PREFIX)
+    );
+}
+
+#[test]
+fn test_subject_tokens_are_collision_free_across_kinds() {
+    // The `trades` vs `book` kind token keeps the two streams in disjoint
+    // subject spaces for the same contract — a subscriber on one never receives
+    // the other.
+    let builder = OptionChainSubjectBuilder::from_symbol("BTC-20240329-50000-C").expect("builder");
+    let (trade, book) = builder.subjects(PREFIX);
+    assert_ne!(trade, book);
+    assert!(trade.contains(".trades."));
+    assert!(book.contains(".book."));
+}

--- a/tests/unit/sequencer_tests.rs
+++ b/tests/unit/sequencer_tests.rs
@@ -1,0 +1,553 @@
+//! Cross-module integration tests for the sequencer replay path (feature
+//! `sequencer`).
+//!
+//! The headline test is the **replay == live oracle** (issue #86): replaying a
+//! journaled command prefix into a freshly constructed book must rebuild state
+//! that is equal to the live book across the FULL comparable surface — not just
+//! top-of-book. The oracle snapshots the entire comparable state of a
+//! [`SequencedUnderlyingOrderBook`] and `assert_eq!`s the live snapshot against
+//! the replayed snapshot, so a future replay regression in ANY of these
+//! dimensions fails the test:
+//!
+//! - top-level counts (`expiration_count`, `total_order_count`);
+//! - per-underlying and per-chain stats;
+//! - per-contract **full depth ladder** — every bid and every ask price level
+//!   (price, visible + hidden size, per-level order count), plus the total
+//!   bid/ask depth and the bid/ask level counts. The prefix deliberately rests
+//!   multiple price levels per side, so a below-top (level-2) divergence that
+//!   left `best_quote` and `order_count` intact still fails the oracle;
+//! - per-contract lifecycle `status` (made load-bearing by halting a contract
+//!   through a `SetInstrumentStatus` command and proving the halt — and the
+//!   rejection of a subsequent add — replays faithfully);
+//! - the instrument registry ids and the symbol index.
+//!
+//! What is intentionally NOT asserted: intra-level queue position (FIFO /
+//! time-priority ordering of individual orders *within* a single price level),
+//! because the leaf exposes no public per-order-queue accessor. The depth ladder
+//! pins each level's aggregate (price/size/order-count) but not the order of
+//! orders inside it — see the follow-up note in the issue.
+//!
+//! Determinism is proven two ways: the test inputs are fully deterministic
+//! (fixed sequential order ids, fixed prices, fixed `YYYYMMDD` symbols that
+//! parse to absolute `ExpirationDate::DateTime` expiries — never clock-relative
+//! `Days`), and two independent fresh books replay the same journal and are
+//! asserted byte-for-byte equal to each other and to live.
+
+use option_chain_orderbook::SymbolParser;
+use option_chain_orderbook::orderbook::{
+    InMemoryOptionChainJournal, InstrumentRegistry, InstrumentStatus, MassCancelScope,
+    MassCancelType, OptionChainJournal, OptionOrderBook, SequencedUnderlyingOrderBook, SymbolIndex,
+};
+use optionstratlib::OptionStyle;
+use orderbook_rs::{OrderId, Side};
+use std::sync::Arc;
+
+// ── Deterministic test inputs ──────────────────────────────────────────────
+//
+// All symbols use absolute `YYYYMMDD` dates that parse to
+// `ExpirationDate::DateTime`, so the derived symbols are replay-stable — the
+// #84 limitation that clock-relative `Days` expiries would violate.
+
+/// A deterministic, sequential order id (no clock / RNG in the test inputs).
+fn oid(n: u64) -> OrderId {
+    OrderId::from_u64(n)
+}
+
+/// Drives the realistic command prefix through the (journaling) sequencer.
+///
+/// Mix: 15 `AddOrder`s spanning two expirations × three strikes, calls and
+/// puts, both sides, with multiple price levels per side so top-of-book is
+/// non-trivial; 2 `CancelOrder`s; 1 `SetInstrumentStatus` (halt a55c) followed
+/// by an `AddOrder` to the halted book that the LIVE run must reject (so the
+/// `status` dimension is load-bearing and the reject-on-replay path is
+/// exercised); and 2 `MassCancel`s (a by-book cancel-all and a by-side strike
+/// cancel). Returns the number of commands submitted.
+fn drive_command_prefix(book: &SequencedUnderlyingOrderBook) -> usize {
+    // ── Expiration A: strike 50000 (call/put), strike 55000 (call/put) ──
+    let a50c = "BTC-20240329-50000-C";
+    let a50p = "BTC-20240329-50000-P";
+    let a55c = "BTC-20240329-55000-C";
+    let a55p = "BTC-20240329-55000-P";
+    // ── Expiration B: strike 60000 (call/put) ──
+    let b60c = "BTC-20240628-60000-C";
+    let b60p = "BTC-20240628-60000-P";
+
+    // A 50000-C: two bid levels + two ask levels (rich top-of-book).
+    book.submit_add_order(a50c, oid(1), Side::Buy, 100, 10)
+        .expect("add a50c buy 100");
+    book.submit_add_order(a50c, oid(2), Side::Buy, 99, 5)
+        .expect("add a50c buy 99");
+    book.submit_add_order(a50c, oid(3), Side::Sell, 110, 8)
+        .expect("add a50c sell 110");
+    book.submit_add_order(a50c, oid(4), Side::Sell, 112, 4)
+        .expect("add a50c sell 112");
+
+    // A 50000-P: one level each side.
+    book.submit_add_order(a50p, oid(5), Side::Buy, 50, 6)
+        .expect("add a50p buy");
+    book.submit_add_order(a50p, oid(6), Side::Sell, 60, 3)
+        .expect("add a50p sell");
+
+    // A 55000-C: two bid levels + one ask level.
+    book.submit_add_order(a55c, oid(7), Side::Buy, 120, 4)
+        .expect("add a55c buy 120");
+    book.submit_add_order(a55c, oid(8), Side::Buy, 118, 2)
+        .expect("add a55c buy 118");
+    book.submit_add_order(a55c, oid(9), Side::Sell, 130, 7)
+        .expect("add a55c sell 130");
+
+    // A 55000-P: a lone resting sell (later wiped by a by-book mass cancel).
+    book.submit_add_order(a55p, oid(10), Side::Sell, 70, 5)
+        .expect("add a55p sell");
+
+    // B 60000-C: one bid + two ask levels (asks later wiped by-side).
+    book.submit_add_order(b60c, oid(11), Side::Buy, 200, 3)
+        .expect("add b60c buy");
+    book.submit_add_order(b60c, oid(12), Side::Sell, 210, 9)
+        .expect("add b60c sell 210");
+    book.submit_add_order(b60c, oid(13), Side::Sell, 215, 1)
+        .expect("add b60c sell 215");
+
+    // B 60000-P: two bid levels.
+    book.submit_add_order(b60p, oid(14), Side::Buy, 80, 12)
+        .expect("add b60p buy 80");
+    book.submit_add_order(b60p, oid(15), Side::Buy, 78, 4)
+        .expect("add b60p buy 78");
+
+    // ── Cancels: peel off the second level on each side of A 50000-C ──
+    book.submit_cancel_order(a50c, oid(4))
+        .expect("cancel a50c sell 112");
+    book.submit_cancel_order(a50c, oid(2))
+        .expect("cancel a50c buy 99");
+
+    // ── Halt a55c (already created above) AFTER its 3 orders rested. A halt
+    //    does not cancel resting orders; it stops the book accepting new ones.
+    //    This journaled status transition must be reconstructed on replay. ──
+    let halt = book
+        .submit_set_instrument_status(a55c, InstrumentStatus::Halted)
+        .expect("submit halt a55c");
+    assert!(
+        halt.result.is_success(),
+        "halting a55c must succeed: {halt:?}"
+    );
+
+    // ── AddOrder to the HALTED a55c: the live run rejects it (InstrumentNot
+    //    Active), so it neither rests nor changes top-of-book. Replay must
+    //    reconstruct Halted and reject the same add — making `status` real. ──
+    let rejected = book
+        .submit_add_order(a55c, oid(16), Side::Buy, 121, 1)
+        .expect("submit add to halted a55c");
+    assert!(
+        rejected.result.is_error(),
+        "add to a halted book must be rejected live: {rejected:?}"
+    );
+
+    // ── Mass cancel #1: cancel-all on the A 55000-P book (wipes oid 10) ──
+    book.submit_mass_cancel(MassCancelScope::Book(a55p.to_string()), MassCancelType::All)
+        .expect("mass cancel a55p book");
+
+    // ── Mass cancel #2: cancel the SELL side of the whole B 60000 strike ──
+    let exp_b = *SymbolParser::parse(b60c).expect("parse b60c").expiration();
+    book.submit_mass_cancel(
+        MassCancelScope::Strike {
+            expiration: exp_b,
+            strike: 60000,
+        },
+        MassCancelType::BySide(Side::Sell),
+    )
+    .expect("mass cancel b60 strike sell");
+
+    // 15 adds + 2 cancels + 1 halt + 1 rejected add + 2 mass cancels.
+    21
+}
+
+// ── Comparable full-state snapshot (the oracle) ────────────────────────────
+
+/// One price level in a contract's depth ladder: price, visible + hidden size,
+/// and the number of orders resting at that level. Capturing this for EVERY
+/// level (not just the top) is what makes the oracle full-depth equality rather
+/// than top-of-book equality — a level-2 divergence on replay fails here even
+/// when `best_quote` and the contract order count are unchanged.
+#[derive(Debug, PartialEq, Eq)]
+struct LevelSnapshot {
+    price: u128,
+    visible: u64,
+    hidden: u64,
+    order_count: usize,
+}
+
+/// Per-contract structural state: the full bid/ask depth ladder, top-of-book
+/// (bid/ask price + size), two-sidedness, total per-side depth, per-side level
+/// counts, resting order count, and lifecycle status. These are the dimensions
+/// a replay regression would disturb.
+///
+/// NOT captured: intra-level queue position (the order of individual orders
+/// within a single price level), because the leaf exposes no public
+/// per-order-queue accessor. `bids`/`asks` pin each level's aggregate, not the
+/// queue order inside it.
+#[derive(Debug, PartialEq)]
+struct ContractSnapshot {
+    symbol: String,
+    bid_price: Option<u128>,
+    bid_size: u64,
+    ask_price: Option<u128>,
+    ask_size: u64,
+    is_two_sided: bool,
+    order_count: usize,
+    status: InstrumentStatus,
+    // Full depth ladder (each side sorted by price for a deterministic compare).
+    bids: Vec<LevelSnapshot>,
+    asks: Vec<LevelSnapshot>,
+    total_bid_depth: u64,
+    total_ask_depth: u64,
+    bid_level_count: usize,
+    ask_level_count: usize,
+}
+
+/// Per-expiration state: the `OptionChainStats` (strike count + orders), the
+/// sorted strike list, and the call/put contract snapshots per strike.
+#[derive(Debug, PartialEq)]
+struct ExpirationSnapshot {
+    expiration: String,
+    chain_strike_count: usize,
+    chain_total_orders: usize,
+    strikes: Vec<u64>,
+    contracts: Vec<ContractSnapshot>,
+}
+
+/// One registry entry, captured via the deterministic id-sorted
+/// [`InstrumentRegistry::iter`] (#75).
+#[derive(Debug, PartialEq)]
+struct RegistryEntry {
+    id: u32,
+    symbol: String,
+    expiration: String,
+    strike: u64,
+    style: OptionStyle,
+}
+
+/// One symbol-index entry, sorted by symbol so the comparison is order-stable
+/// despite the index's arbitrary `DashMap` iteration order.
+#[derive(Debug, PartialEq)]
+struct SymbolIndexEntry {
+    symbol: String,
+    underlying: String,
+    expiration: String,
+    strike: u64,
+    style: OptionStyle,
+}
+
+/// The full comparable state of a [`SequencedUnderlyingOrderBook`]. Equality of
+/// two snapshots is the replay correctness oracle.
+#[derive(Debug, PartialEq)]
+struct BookSnapshot {
+    underlying: String,
+    expiration_count: usize,
+    total_order_count: usize,
+    stats_expiration_count: usize,
+    stats_total_strikes: usize,
+    stats_total_orders: usize,
+    expirations: Vec<ExpirationSnapshot>,
+    registry: Vec<RegistryEntry>,
+    symbol_index: Vec<SymbolIndexEntry>,
+}
+
+/// Depth large enough to capture every price level in the test prefix (max 2
+/// levels per side); oversized so a regression that adds spurious levels is
+/// still captured.
+const SNAPSHOT_DEPTH: usize = 16;
+
+/// Folds an order-book snapshot's price-level `Vec` into a deterministic,
+/// price-sorted ladder. The leaf snapshot's level order is not contractually
+/// stable, so both runs are sorted identically before comparison.
+fn level_ladder(levels: &[pricelevel::PriceLevelSnapshot]) -> Vec<LevelSnapshot> {
+    let mut ladder: Vec<LevelSnapshot> = levels
+        .iter()
+        .map(|level| LevelSnapshot {
+            price: level.price().as_u128(),
+            visible: level.visible_quantity().as_u64(),
+            hidden: level.hidden_quantity().as_u64(),
+            order_count: level.order_count(),
+        })
+        .collect();
+    ladder.sort_by_key(|level| level.price);
+    ladder
+}
+
+/// Snapshots a single contract's full depth ladder, top-of-book, and order
+/// state.
+fn contract_snapshot(leaf: &OptionOrderBook) -> ContractSnapshot {
+    let quote = leaf.best_quote();
+    let book = leaf.snapshot(SNAPSHOT_DEPTH);
+    ContractSnapshot {
+        symbol: leaf.symbol().to_string(),
+        bid_price: quote.bid_price().map(|p| p.as_u128()),
+        bid_size: quote.bid_size().as_u64(),
+        ask_price: quote.ask_price().map(|p| p.as_u128()),
+        ask_size: quote.ask_size().as_u64(),
+        is_two_sided: quote.is_two_sided(),
+        order_count: leaf.order_count(),
+        status: leaf.status(),
+        bids: level_ladder(&book.bids),
+        asks: level_ladder(&book.asks),
+        total_bid_depth: leaf.total_bid_depth(),
+        total_ask_depth: leaf.total_ask_depth(),
+        bid_level_count: leaf.bid_level_count(),
+        ask_level_count: leaf.ask_level_count(),
+    }
+}
+
+/// Walks the entire hierarchy of a sequenced book and captures its full
+/// comparable state. Traversal order is deterministic: expirations come from
+/// the ordered `ExpirationOrderBookManager::iter`, strikes from the sorted
+/// `strike_prices`, the registry from the id-sorted `iter`, and the symbol
+/// index is sorted by symbol here.
+fn snapshot(book: &SequencedUnderlyingOrderBook) -> BookSnapshot {
+    let underlying = book.underlying();
+    let stats = underlying.stats();
+
+    let mut expirations = Vec::new();
+    for (exp_date, exp_book) in underlying.expirations().iter() {
+        let chain_stats = exp_book.chain().stats();
+        let strikes = exp_book.strike_prices();
+        let mut contracts = Vec::with_capacity(strikes.len() * 2);
+        for &strike in &strikes {
+            let strike_book = exp_book
+                .get_strike(strike)
+                .expect("strike from strike_prices() must resolve");
+            contracts.push(contract_snapshot(strike_book.call()));
+            contracts.push(contract_snapshot(strike_book.put()));
+        }
+        expirations.push(ExpirationSnapshot {
+            expiration: exp_date.to_string(),
+            chain_strike_count: chain_stats.strike_count,
+            chain_total_orders: chain_stats.total_orders,
+            strikes,
+            contracts,
+        });
+    }
+
+    let registry = book
+        .registry()
+        .expect("oracle book is constructed with a registry")
+        .iter()
+        .into_iter()
+        .map(|(id, info)| RegistryEntry {
+            id,
+            symbol: info.symbol().to_string(),
+            expiration: info.expiration().to_string(),
+            strike: info.strike(),
+            style: info.option_style(),
+        })
+        .collect();
+
+    let mut symbol_index: Vec<SymbolIndexEntry> = book
+        .symbol_index()
+        .expect("oracle book is constructed with a symbol index")
+        .entries()
+        .into_iter()
+        .map(|(symbol, sym_ref)| SymbolIndexEntry {
+            symbol,
+            underlying: sym_ref.underlying().to_string(),
+            expiration: sym_ref.expiration().to_string(),
+            strike: sym_ref.strike(),
+            style: sym_ref.option_style(),
+        })
+        .collect();
+    symbol_index.sort_by(|a, b| a.symbol.cmp(&b.symbol));
+
+    BookSnapshot {
+        underlying: underlying.underlying().to_string(),
+        expiration_count: book.expiration_count(),
+        total_order_count: book.total_order_count(),
+        stats_expiration_count: stats.expiration_count,
+        stats_total_strikes: stats.total_strikes,
+        stats_total_orders: stats.total_orders,
+        expirations,
+        registry,
+        symbol_index,
+    }
+}
+
+/// Builds a fresh, registry+index-backed sequenced book sharing `journal`. Each
+/// book gets its OWN fresh registry/index so id allocation starts from 1 — that
+/// is what makes the registry ids comparable across the live and replayed runs.
+fn fresh_book(journal: &Arc<InMemoryOptionChainJournal>) -> SequencedUnderlyingOrderBook {
+    let journal_dyn: Arc<dyn OptionChainJournal> =
+        Arc::clone(journal) as Arc<dyn OptionChainJournal>;
+    SequencedUnderlyingOrderBook::with_journal_registry_and_index(
+        "BTC",
+        journal_dyn,
+        Arc::new(InstrumentRegistry::new()),
+        Arc::new(SymbolIndex::new()),
+    )
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn test_replay_equals_live_full_state_oracle() {
+    let journal = Arc::new(InMemoryOptionChainJournal::new());
+
+    // ── Live run: drive the journaled command prefix ──
+    let live = fresh_book(&journal);
+    let submitted = drive_command_prefix(&live);
+    assert_eq!(
+        journal.len(),
+        submitted,
+        "every submitted command must be journaled"
+    );
+
+    // Spot-check the live structure so the prefix's intent is explicit and a
+    // silently-rejected order would be caught before the oracle runs.
+    // The halted a55c keeps its 3 resting orders; the rejected add rested
+    // nothing, so the total is unchanged at 10.
+    assert_eq!(live.expiration_count(), 2);
+    assert_eq!(live.total_order_count(), 10);
+    let exp_a = live
+        .underlying()
+        .get_expiration(
+            SymbolParser::parse("BTC-20240329-50000-C")
+                .expect("parse a50c")
+                .expiration(),
+        )
+        .expect("exp A present");
+    let a50c = exp_a.get_strike(50000).expect("strike 50000 present");
+    let q = a50c.call().best_quote();
+    assert_eq!(q.bid_price().map(|p| p.as_u128()), Some(100));
+    assert_eq!(q.bid_size().as_u64(), 10);
+    assert_eq!(q.ask_price().map(|p| p.as_u128()), Some(110));
+    assert_eq!(q.ask_size().as_u64(), 8);
+    assert_eq!(a50c.call().order_count(), 2);
+
+    // a55c was halted AFTER its 3 orders rested; the halt is load-bearing.
+    let a55c = exp_a.get_strike(55000).expect("strike 55000 present");
+    assert_eq!(a55c.call().status(), InstrumentStatus::Halted);
+    assert_eq!(
+        a55c.call().order_count(),
+        3,
+        "halt preserves resting orders"
+    );
+    assert_eq!(a55c.call().bid_level_count(), 2, "two resting bid levels");
+    assert_eq!(a55c.call().best_bid(), Some(120));
+
+    let live_snapshot = snapshot(&live);
+
+    // ── Replay into a fresh, identically-configured book ──
+    let replay_a = fresh_book(&journal);
+    assert_eq!(replay_a.expiration_count(), 0, "fresh book starts empty");
+    assert_eq!(replay_a.total_order_count(), 0);
+    let replayed_a = replay_a.replay(0).expect("replay a");
+    assert_eq!(
+        replayed_a, submitted,
+        "replay re-runs every journaled command"
+    );
+
+    let snapshot_a = snapshot(&replay_a);
+
+    // THE ORACLE: replayed state equals live state in EVERY dimension —
+    // top-level counts, per-contract top-of-book + order counts, per-chain and
+    // per-underlying stats, registry ids, and the symbol index.
+    assert_eq!(
+        live_snapshot, snapshot_a,
+        "replayed state must equal live state across the full comparable surface"
+    );
+
+    // ── Run-to-run determinism: a second independent replay is identical ──
+    let replay_b = fresh_book(&journal);
+    let replayed_b = replay_b.replay(0).expect("replay b");
+    assert_eq!(replayed_b, submitted);
+    let snapshot_b = snapshot(&replay_b);
+
+    assert_eq!(
+        snapshot_a, snapshot_b,
+        "two independent replays of the same journal must be byte-for-byte equal"
+    );
+    assert_eq!(
+        live_snapshot, snapshot_b,
+        "the second replay must also equal live"
+    );
+}
+
+#[test]
+fn test_replay_registry_ids_match_live() {
+    // A focused assertion that the registry-assigned instrument ids — not just
+    // the symbols — are identical between live and replay. They match because
+    // strike creation (the sole id-allocation site) happens in the SAME
+    // deterministic command order on both runs.
+    let journal = Arc::new(InMemoryOptionChainJournal::new());
+
+    let live = fresh_book(&journal);
+    drive_command_prefix(&live);
+
+    let replay = fresh_book(&journal);
+    replay.replay(0).expect("replay");
+
+    let live_ids = live.registry().expect("live registry").iter();
+    let replay_ids = replay.registry().expect("replay registry").iter();
+
+    assert_eq!(
+        live_ids.len(),
+        replay_ids.len(),
+        "same number of instruments registered"
+    );
+    for ((live_id, live_info), (replay_id, replay_info)) in live_ids.iter().zip(replay_ids.iter()) {
+        assert_eq!(live_id, replay_id, "instrument id diverged on replay");
+        assert_eq!(
+            live_info.symbol(),
+            replay_info.symbol(),
+            "instrument symbol diverged for id {live_id}"
+        );
+    }
+    // Six leaf books: 3 strikes × (call + put).
+    assert_eq!(live_ids.len(), 6);
+}
+
+#[test]
+fn test_replay_determinism_repeated() {
+    // Loop many independent replays of the same journal and assert each rebuilds
+    // a snapshot identical to live — proving replay is deterministic run-to-run
+    // within a single process (no map-order / clock leakage).
+    let journal = Arc::new(InMemoryOptionChainJournal::new());
+
+    let live = fresh_book(&journal);
+    drive_command_prefix(&live);
+    let live_snapshot = snapshot(&live);
+
+    for round in 0..16 {
+        let replay = fresh_book(&journal);
+        replay.replay(0).expect("replay round");
+        assert_eq!(
+            live_snapshot,
+            snapshot(&replay),
+            "replay round {round} diverged from live"
+        );
+    }
+}
+
+#[test]
+fn test_replay_into_empty_book_then_resume_is_consistent() {
+    // After replay rebuilds state, the sequencer is advanced past the replayed
+    // range, so a NEW command appends at the correct sequence and lands in the
+    // rebuilt hierarchy — replay leaves a usable, consistent book.
+    let journal = Arc::new(InMemoryOptionChainJournal::new());
+
+    let live = fresh_book(&journal);
+    let submitted = drive_command_prefix(&live);
+
+    let resumed = fresh_book(&journal);
+    resumed.replay(0).expect("replay");
+    assert!(
+        resumed.current_sequence() >= submitted as u64,
+        "sequencer must advance past the replayed range"
+    );
+
+    // A post-replay command rests in the rebuilt hierarchy and journals next.
+    let new_oid = oid(1000);
+    resumed
+        .submit_add_order("BTC-20240329-50000-C", new_oid, Side::Buy, 101, 2)
+        .expect("post-replay add");
+    assert_eq!(journal.len(), submitted + 1);
+    // 10 rebuilt resting orders + 1 new.
+    assert_eq!(resumed.total_order_count(), 11);
+}


### PR DESCRIPTION
## Summary

The integration tree had no sequencer/nats coverage, and the sequencer replay
tests asserted only the replayed-event count and that the sequence advanced —
never the binding oracle that **replayed state equals live state**. That gap is
exactly why the replay-rebuild bug (#52) went undetected. This adds the real
oracle.

## Changes

- **Feature-gated integration modules** in `tests/unit/` (`#[cfg(feature = "sequencer")]`
  and `#[cfg(feature = "nats")]`), run under `cargo test --all-features`.
- **The replay==live oracle**: drive a deterministic 21-command prefix (`AddOrder`
  both legs / both sides at multiple price levels, `CancelOrder`, two `MassCancel`
  scopes, and a `SetInstrumentStatus → Halted` with a reject-on-halt `AddOrder`)
  through a journaled live book, then replay the journal into fresh books and
  `assert_eq!` a full `BookSnapshot`:
  - top-level counts; per-underlying / per-chain stats + sorted strikes;
  - per contract: the **complete bid/ask depth ladder** (price, visible, hidden,
    per-level order count via `OptionOrderBook::snapshot`), total bid/ask depth,
    level counts, top-of-book, `is_two_sided`, `order_count`, and lifecycle
    `status`;
  - id-sorted `InstrumentRegistry` ids; symbol-sorted `SymbolIndex`.
  Intra-level FIFO/queue order is the only excluded dimension (no public per-order
  accessor) — documented.
- **Replay determinism**: 16 independent fresh replays all equal live; a 10× loop
  is non-flaky. Inputs are clock/RNG-free (fixed ids/prices, absolute
  `ExpirationDate::DateTime`).
- **NATS subject-builder round-trip** test (build→parse→rebuild, canonical
  trades/book subjects, call/put, collision-free).

## Technical decisions

The oracle is genuinely full-depth equality, not a top-of-book subset (an
adversarial review caught the earlier top-of-book-only projection — now it
compares the whole depth ladder, so a below-top divergence fails). The halt makes
the `status` dimension load-bearing and exercises **reject-on-replay parity** (the
most delicate reconstruction — it revealed no bug). The `sequencer.rs` doc is
reconciled: instrument ids are not journaled and not preserved across a non-fresh
registry, but replaying the same journal into a **fresh** registry reconstructs
identical ids deterministically (creation runs in the same command order) — which
the oracle relies on and asserts.

Deferred to a follow-up (tracked): a crossing/partial-fill command to cover the
match path, an intra-level FIFO/time-priority check, and a single
top-of-book-moving `CancelOrder`.

## Public API impact

None — test-only (plus a doc-only clarification in `sequencer.rs`). No production
logic changed. Version stays `0.5.0`.

## Testing

- [x] `cargo test --all-features` — 4 sequencer + 3 nats integration tests pass; oracle non-flaky (16 replays + 10× loop)
- [x] `make pre-push` clean; clippy `-D warnings` clean; fmt clean

## Checklist

- [x] Full structural equality (depth ladder + counts + stats + registry ids + symbol index), not a subset
- [x] Replay determinism proven across independent runs; inputs clock/RNG-free
- [x] Feature-gated; runs under `--all-features`, excluded from default build
- [x] No new dependencies / feature flags; no `unsafe`

Closes #86
