### PR TITLE
tests: add proptest invariant suite (#87)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ sequencer = ["dep:tokio", "orderbook-rs/journal"]
 [dev-dependencies]
 criterion = { version = "0.8", default-features = false, features = ["html_reports"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+proptest = "1"
 
 [[test]]
 name = "tests"

--- a/tests/unit/common/mod.rs
+++ b/tests/unit/common/mod.rs
@@ -1,0 +1,7 @@
+//! Shared test support for the property-based (`proptest`) suites.
+//!
+//! Only the strategy/fixture helpers live here; every invariant assertion lives
+//! in its own `props_<invariant>` sibling module. Driven exclusively through the
+//! crate's public API.
+
+pub mod strategies;

--- a/tests/unit/common/strategies.rs
+++ b/tests/unit/common/strategies.rs
@@ -1,0 +1,217 @@
+//! Shared `proptest` strategies and fixtures for the invariant suites.
+//!
+//! Everything here goes through the crate's **public API** and the validated
+//! `pricelevel` / `orderbook_rs` newtypes (`OrderId`, `Side`, `Price`,
+//! `Quantity`) and `optionstratlib` types (`ExpirationDate`, `OptionStyle`).
+//!
+//! ## Why the input space is deliberately tiny
+//!
+//! * **Small underlying / expiration / strike pools** — so `get_or_create`
+//!   collisions and cross-strike aggregation actually happen on short streams. A
+//!   wide pool produces vacuous tests (every key unique, nothing to aggregate).
+//! * **Tight price band (`99..=101`)** — so submitted orders frequently *cross*
+//!   and match, exercising the quote / matching path instead of a flat book that
+//!   never trades.
+//! * **Side bias toward `Buy` (2:1)** — so the book is frequently left
+//!   *one-sided* (bid-only) after crossings clear the asks, exercising the
+//!   one-sided quote path as well as the two-sided one.
+//! * **Small `OrderId` pool (`0..16`)** — so a generated `CancelById` actually
+//!   hits a resting order often enough to matter.
+//!
+//! ## Expirations are always absolute (`DateTime`)
+//!
+//! Every expiration is an [`ExpirationDate::DateTime`] drawn from a fixed pool.
+//! The `Days` variant is wall-clock-relative (it re-resolves against "now"), so
+//! it is never used in inputs that feed symbol parsing, stats aggregation, or
+//! `get_or_create` keys — those must be replay-stable.
+
+use chrono::{TimeZone, Utc};
+use option_chain_orderbook::orderbook::OptionOrderBook;
+use option_chain_orderbook::{OrderId, Side};
+use optionstratlib::{ExpirationDate, OptionStyle};
+use proptest::collection::vec;
+use proptest::prelude::*;
+
+/// Fixed, tiny underlying pool. Kept short so `get_or_create` collisions are
+/// common on short generated streams.
+pub const UNDERLYINGS: &[&str] = &["BTC", "ETH", "SOL"];
+
+/// Fixed, tiny strike pool. Distinct strikes are distinct leaf books, so cancel
+/// scoping at one strike can never touch another — handy for out-of-scope
+/// witnesses.
+pub const STRIKES: &[u64] = &[100, 200, 300];
+
+/// Fixed absolute-date expiration pool, as `(year, month, day)`. All days are
+/// `<= 28` so every `(y, m, d)` is a valid calendar date for any month.
+const EXP_DATES: &[(i32, u32, u32)] = &[(2026, 1, 30), (2026, 6, 26), (2026, 12, 18)];
+
+/// Number of distinct expirations in the fixed pool.
+pub const EXP_POOL_LEN: usize = EXP_DATES.len();
+
+/// Returns the `i`th fixed-pool expiration as an absolute
+/// [`ExpirationDate::DateTime`] (`23:59:59 UTC`, matching the crate's canonical
+/// symbol-expiry time-of-day). Index wraps modulo the pool length.
+// `ExpirationDate` is itself `#[must_use]`, so no attribute here (double_must_use).
+pub fn nth_expiration(i: usize) -> ExpirationDate {
+    let (y, m, d) = EXP_DATES[i % EXP_DATES.len()];
+    let dt = match Utc.with_ymd_and_hms(y, m, d, 23, 59, 59) {
+        chrono::LocalResult::Single(dt) => dt,
+        _ => panic!("fixed expiration pool date must be unambiguous"),
+    };
+    ExpirationDate::DateTime(dt)
+}
+
+/// Strategy yielding a [`Side`], biased 2:1 toward `Buy` so crossings tend to
+/// clear the asks and leave a one-sided (bid-only) book.
+fn side() -> impl Strategy<Value = Side> {
+    prop_oneof![2 => Just(Side::Buy), 1 => Just(Side::Sell)]
+}
+
+/// Strategy yielding an [`OptionStyle`].
+pub fn any_style() -> impl Strategy<Value = OptionStyle> {
+    prop_oneof![Just(OptionStyle::Call), Just(OptionStyle::Put)]
+}
+
+/// Strategy yielding an [`OrderId`] from a tiny pool so `CancelById` hits real
+/// resting orders often.
+fn order_id() -> impl Strategy<Value = OrderId> {
+    (0u64..16).prop_map(OrderId::from_u64)
+}
+
+/// A single generated operation against one leaf [`OptionOrderBook`].
+///
+/// Local to the test crate so it is never re-exported by accident.
+#[derive(Clone, Debug)]
+pub enum Op {
+    /// Submit a GTC limit order through the validated newtypes.
+    Submit {
+        /// Order identity (small pool).
+        id: OrderId,
+        /// Buy or Sell.
+        side: Side,
+        /// Limit price in the tight crossing band.
+        price: u128,
+        /// Order quantity (always positive).
+        qty: u64,
+    },
+    /// Cancel one order by id (often a no-op — exercises the miss path too).
+    CancelById(OrderId),
+    /// Cancel every resting order on the book.
+    CancelAll,
+}
+
+fn submit() -> impl Strategy<Value = Op> {
+    // Tight price band forces crossings; qty is always >= 1 so the engine never
+    // rejects on a zero quantity.
+    (order_id(), side(), 99u128..=101, 1u64..=100).prop_map(|(id, side, price, qty)| Op::Submit {
+        id,
+        side,
+        price,
+        qty,
+    })
+}
+
+fn op() -> impl Strategy<Value = Op> {
+    prop_oneof![
+        7 => submit(),
+        2 => order_id().prop_map(Op::CancelById),
+        1 => Just(Op::CancelAll),
+    ]
+}
+
+/// A stream of leaf-book operations of length within `len`.
+pub fn op_stream(len: std::ops::Range<usize>) -> impl Strategy<Value = Vec<Op>> {
+    vec(op(), len)
+}
+
+/// Applies one [`Op`] to a leaf [`OptionOrderBook`], ignoring the (expected)
+/// errors from duplicate ids, cancel misses, and self-trade matches — the test
+/// asserts on the *resulting state*, not on each op's success.
+pub fn apply_op(book: &OptionOrderBook, op: &Op) {
+    match op {
+        Op::Submit {
+            id,
+            side,
+            price,
+            qty,
+        } => {
+            let _ = book.add_limit_order(*id, *side, *price, *qty);
+        }
+        Op::CancelById(id) => {
+            let _ = book.cancel_order(*id);
+        }
+        Op::CancelAll => {
+            let _ = book.cancel_all();
+        }
+    }
+}
+
+/// A generated operation routed to a `(strike, leg)` within one chain.
+#[derive(Clone, Debug)]
+pub struct ChainOp {
+    /// Index into [`STRIKES`].
+    pub strike_idx: usize,
+    /// Call or Put leg.
+    pub style: OptionStyle,
+    /// The leaf operation.
+    pub op: Op,
+}
+
+fn chain_op() -> impl Strategy<Value = ChainOp> {
+    (0usize..STRIKES.len(), any_style(), op()).prop_map(|(strike_idx, style, op)| ChainOp {
+        strike_idx,
+        style,
+        op,
+    })
+}
+
+/// A stream of chain-routed operations across the fixed strike pool.
+pub fn chain_op_stream(len: std::ops::Range<usize>) -> impl Strategy<Value = Vec<ChainOp>> {
+    vec(chain_op(), len)
+}
+
+/// Resolves the strike price a [`ChainOp`] targets.
+#[must_use]
+pub fn chain_op_strike(routed: &ChainOp) -> u64 {
+    STRIKES[routed.strike_idx % STRIKES.len()]
+}
+
+/// A generated operation routed to a full `(underlying, expiration, strike, leg)`
+/// coordinate in the hierarchy.
+#[derive(Clone, Debug)]
+pub struct HierOp {
+    /// Index into [`UNDERLYINGS`].
+    pub underlying_idx: usize,
+    /// Index into the fixed expiration pool.
+    pub expiration_idx: usize,
+    /// Index into [`STRIKES`].
+    pub strike_idx: usize,
+    /// Call or Put leg.
+    pub style: OptionStyle,
+    /// The leaf operation.
+    pub op: Op,
+}
+
+fn hier_op() -> impl Strategy<Value = HierOp> {
+    (
+        0usize..UNDERLYINGS.len(),
+        0usize..EXP_POOL_LEN,
+        0usize..STRIKES.len(),
+        any_style(),
+        op(),
+    )
+        .prop_map(
+            |(underlying_idx, expiration_idx, strike_idx, style, op)| HierOp {
+                underlying_idx,
+                expiration_idx,
+                strike_idx,
+                style,
+                op,
+            },
+        )
+}
+
+/// A stream of hierarchy-routed operations across the fixed pools.
+pub fn hier_op_stream(len: std::ops::Range<usize>) -> impl Strategy<Value = Vec<HierOp>> {
+    vec(hier_op(), len)
+}

--- a/tests/unit/mod.rs
+++ b/tests/unit/mod.rs
@@ -3,6 +3,16 @@
 mod layering_tests;
 mod orderbook_tests;
 
+// Shared `proptest` strategies/fixtures and the property-based invariant suites.
+// All driven through the public API only.
+mod common;
+mod props_best_quote;
+mod props_chain_stats_aggregate;
+mod props_get_or_create_idempotent;
+mod props_greeks_aggregation;
+mod props_mass_cancel_scope;
+mod props_symbol_roundtrip;
+
 // Feature-gated cross-module test modules. They compile and run only under
 // `cargo test --all-features` (or the matching single feature) and are excluded
 // from the default build, so the default test matrix stays feature-free.

--- a/tests/unit/props_best_quote.rs
+++ b/tests/unit/props_best_quote.rs
@@ -1,0 +1,134 @@
+//! Property: `best_quote()` matches the book's top-of-book on each side, and a
+//! quote is two-sided iff orders rest on both sides.
+//!
+//! Invariant asserted, after applying a generated op stream to one leaf
+//! [`OptionOrderBook`]:
+//!
+//! * `quote.bid_price()` equals `book.best_bid()` and `quote.ask_price()` equals
+//!   `book.best_ask()` (top-of-book on each side);
+//! * `quote.is_two_sided()` is true iff both sides rest (and equals
+//!   `book.has_both_sides()`);
+//! * a missing side carries `None` price and `Quantity::ZERO`, a present side
+//!   carries the exact best-level depth (cross-checked against the order-book
+//!   snapshot's top level, an independent read path from `best_quote`).
+//!
+//! The strategy's tight price band forces crossings and its `Buy`-biased side
+//! leaves one-sided books frequently. The three deterministic examples below
+//! pin the two-sided, one-sided, and crossing-clears-a-side cases so they are
+//! exercised regardless of the random seed.
+
+use crate::common::strategies::{apply_op, op_stream};
+use option_chain_orderbook::orderbook::OptionOrderBook;
+use option_chain_orderbook::{OrderId, Quantity, Side};
+use optionstratlib::OptionStyle;
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        max_shrink_iters: 50_000,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn best_quote_reflects_top_of_book(stream in op_stream(1..200)) {
+        let book = OptionOrderBook::new("BTC-20260130-50000-C", OptionStyle::Call);
+        for op in &stream {
+            apply_op(&book, op);
+        }
+
+        let quote = book.best_quote();
+        let bid = book.best_bid();
+        let ask = book.best_ask();
+
+        // Top-of-book price per side, wrapped through the `Price` newtype.
+        prop_assert_eq!(quote.bid_price().map(|p| p.as_u128()), bid);
+        prop_assert_eq!(quote.ask_price().map(|p| p.as_u128()), ask);
+
+        // Two-sided iff both sides rest — consistent with the cheap predicate.
+        prop_assert_eq!(quote.is_two_sided(), bid.is_some() && ask.is_some());
+        prop_assert_eq!(quote.is_two_sided(), book.has_both_sides());
+
+        // A missing side has no price and zero size; a present side carries the
+        // *exact* best-level depth. The oracle is the order-book snapshot's best
+        // level — an independent read path from `best_quote`'s own
+        // `total_depth_at_levels(1)`, so a wrong-but-nonzero size (e.g. summing
+        // every level instead of only the top) is caught, not just a zero fill.
+        // The test stream submits only plain limit orders, so hidden quantity is
+        // always zero and `visible_quantity()` equals the level's total depth.
+        let snap = book.snapshot(1);
+        match bid {
+            Some(_) => {
+                let top_bid_depth = snap.bids.first().expect("bid level present").visible_quantity();
+                prop_assert!(quote.bid_size().as_u64() > 0);
+                prop_assert_eq!(quote.bid_size(), top_bid_depth);
+            }
+            None => {
+                prop_assert!(quote.bid_price().is_none());
+                prop_assert_eq!(quote.bid_size(), Quantity::ZERO);
+            }
+        }
+        match ask {
+            Some(_) => {
+                let top_ask_depth = snap.asks.first().expect("ask level present").visible_quantity();
+                prop_assert!(quote.ask_size().as_u64() > 0);
+                prop_assert_eq!(quote.ask_size(), top_ask_depth);
+            }
+            None => {
+                prop_assert!(quote.ask_price().is_none());
+                prop_assert_eq!(quote.ask_size(), Quantity::ZERO);
+            }
+        }
+    }
+}
+
+#[test]
+fn two_sided_book_yields_two_sided_quote() {
+    let book = OptionOrderBook::new("BTC-20260130-50000-C", OptionStyle::Call);
+    // Non-crossing: bid below ask, both rest.
+    book.add_limit_order(OrderId::from_u64(1), Side::Buy, 99, 10)
+        .expect("add buy");
+    book.add_limit_order(OrderId::from_u64(2), Side::Sell, 101, 5)
+        .expect("add sell");
+
+    let quote = book.best_quote();
+    assert!(quote.is_two_sided());
+    assert_eq!(quote.bid_price().map(|p| p.as_u128()), Some(99));
+    assert_eq!(quote.ask_price().map(|p| p.as_u128()), Some(101));
+    assert_eq!(quote.bid_price().map(|p| p.as_u128()), book.best_bid());
+    assert_eq!(quote.ask_price().map(|p| p.as_u128()), book.best_ask());
+}
+
+#[test]
+fn one_sided_book_yields_one_sided_quote() {
+    let book = OptionOrderBook::new("BTC-20260130-50000-C", OptionStyle::Call);
+    // Only a bid rests — the ask side is empty.
+    book.add_limit_order(OrderId::from_u64(1), Side::Buy, 100, 7)
+        .expect("add buy");
+
+    let quote = book.best_quote();
+    assert!(!quote.is_two_sided());
+    assert!(!book.has_both_sides());
+    assert_eq!(quote.bid_price().map(|p| p.as_u128()), Some(100));
+    assert!(quote.ask_price().is_none());
+    assert_eq!(quote.ask_size(), Quantity::ZERO);
+}
+
+#[test]
+fn crossing_orders_clear_a_side() {
+    let book = OptionOrderBook::new("BTC-20260130-50000-C", OptionStyle::Call);
+    // Resting bid, then an aggressing sell that crosses it (99 <= 101) and
+    // fully matches — clearing the ask side and leaving a bid-only book.
+    book.add_limit_order(OrderId::from_u64(1), Side::Buy, 101, 10)
+        .expect("add buy");
+    book.add_limit_order(OrderId::from_u64(2), Side::Sell, 99, 4)
+        .expect("add crossing sell");
+
+    let quote = book.best_quote();
+    // The aggressing sell matched against the bid and did not rest.
+    assert!(book.best_ask().is_none());
+    assert!(!quote.is_two_sided());
+    // Residual bid quantity (10 - 4 = 6) rests at 101.
+    assert_eq!(quote.bid_price().map(|p| p.as_u128()), Some(101));
+    assert_eq!(quote.bid_size(), Quantity::new(6));
+}

--- a/tests/unit/props_chain_stats_aggregate.rs
+++ b/tests/unit/props_chain_stats_aggregate.rs
@@ -1,0 +1,91 @@
+//! Property: stats aggregate as the deterministic sum of their children.
+//!
+//! Invariants asserted:
+//!
+//! * `OptionChainStats` — `strike_count` equals the number of strikes created
+//!   and `total_orders` equals `Σ strike.order_count()` over every child strike
+//!   (the deterministic, ordered `SkipMap` walk).
+//! * `GlobalStats` (the top manager) — `underlying_count`, `total_expirations`,
+//!   `total_strikes`, and `total_orders` equal an independent walk of the public
+//!   tree (underlyings → expirations → chains → strikes → leaf `order_count()`).
+//!
+//! Both are checked against a *separately computed* sum, not against the
+//! single-pass `stats()` implementation, so the test genuinely cross-checks the
+//! aggregation rather than restating it.
+
+use crate::common::strategies::{
+    EXP_POOL_LEN, STRIKES, UNDERLYINGS, apply_op, chain_op_stream, chain_op_strike, hier_op_stream,
+    nth_expiration,
+};
+use option_chain_orderbook::orderbook::{OptionChainOrderBook, UnderlyingOrderBookManager};
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        max_shrink_iters: 50_000,
+        ..ProptestConfig::default()
+    })]
+
+    /// Chain stats equal the deterministic sum of the child strike stats.
+    #[test]
+    fn chain_stats_equal_child_sum(stream in chain_op_stream(1..160)) {
+        let chain = OptionChainOrderBook::new("BTC", nth_expiration(0));
+        for routed in &stream {
+            let strike = chain.get_or_create_strike(chain_op_strike(routed));
+            apply_op(strike.get(routed.style), &routed.op);
+        }
+
+        // Deterministic, ordered walk of the children.
+        let strike_prices = chain.strike_prices();
+        let mut expected_orders = 0usize;
+        for price in &strike_prices {
+            let strike = chain.get_strike(*price).expect("listed strike must exist");
+            expected_orders += strike.order_count();
+        }
+
+        let stats = chain.stats();
+        prop_assert_eq!(stats.strike_count, strike_prices.len());
+        prop_assert_eq!(stats.total_orders, expected_orders);
+    }
+
+    /// Global stats equal an independent walk of the whole public tree.
+    #[test]
+    fn global_stats_equal_tree_walk(stream in hier_op_stream(1..160)) {
+        let manager = UnderlyingOrderBookManager::new();
+        for h in &stream {
+            let underlying = manager.get_or_create(UNDERLYINGS[h.underlying_idx]);
+            let expiration = underlying.get_or_create_expiration(nth_expiration(h.expiration_idx));
+            let strike = expiration.get_or_create_strike(STRIKES[h.strike_idx]);
+            apply_op(strike.get(h.style), &h.op);
+        }
+
+        let mut exp_underlyings = 0usize;
+        let mut exp_expirations = 0usize;
+        let mut exp_strikes = 0usize;
+        let mut exp_orders = 0usize;
+
+        for sym in manager.underlying_symbols() {
+            let underlying = manager.get(sym.as_str()).expect("listed underlying must exist");
+            exp_underlyings += 1;
+            for ei in 0..EXP_POOL_LEN {
+                let exp = nth_expiration(ei);
+                if let Ok(expiration) = underlying.get_expiration(&exp) {
+                    exp_expirations += 1;
+                    let chain = expiration.chain();
+                    for price in chain.strike_prices() {
+                        exp_strikes += 1;
+                        let strike = chain.get_strike(price).expect("listed strike must exist");
+                        exp_orders += strike.order_count();
+                    }
+                }
+            }
+        }
+
+        let stats = manager.stats();
+        prop_assert_eq!(stats.underlying_count, exp_underlyings);
+        prop_assert_eq!(stats.total_expirations, exp_expirations);
+        prop_assert_eq!(stats.total_strikes, exp_strikes);
+        prop_assert_eq!(stats.total_orders, exp_orders);
+    }
+}

--- a/tests/unit/props_get_or_create_idempotent.rs
+++ b/tests/unit/props_get_or_create_idempotent.rs
@@ -1,0 +1,101 @@
+//! Property: `get_or_create_*` is idempotent.
+//!
+//! Invariant asserted: a second `get_or_create` (underlying / expiration /
+//! strike) with the *same key* returns the **same** `Arc` (`Arc::ptr_eq`), never
+//! a freshly allocated book — both for an immediate repeat call and for a later
+//! collision on the same key anywhere in the generated stream.
+//!
+//! The strategy draws keys from the small fixed pools in
+//! [`crate::common::strategies`], so collisions are frequent on short streams.
+
+use crate::common::strategies::{EXP_POOL_LEN, STRIKES, UNDERLYINGS, nth_expiration};
+use option_chain_orderbook::orderbook::{
+    ExpirationOrderBook, StrikeOrderBook, UnderlyingOrderBook, UnderlyingOrderBookManager,
+};
+use proptest::prelude::*;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        max_shrink_iters: 50_000,
+        ..ProptestConfig::default()
+    })]
+
+    /// For every generated `(underlying, expiration, strike)` key:
+    /// an immediate second `get_or_create_*` returns the same `Arc`, and any
+    /// later access of a previously seen key returns that same `Arc` too.
+    #[test]
+    fn get_or_create_returns_same_handle(
+        keys in prop::collection::vec(
+            (0usize..UNDERLYINGS.len(), 0usize..EXP_POOL_LEN, 0usize..STRIKES.len()),
+            1..64,
+        ),
+    ) {
+        let manager = UnderlyingOrderBookManager::new();
+
+        // First-seen handle per canonical key — used to assert later collisions
+        // resolve to the identical allocation.
+        let mut seen_u: HashMap<usize, Arc<UnderlyingOrderBook>> = HashMap::new();
+        let mut seen_e: HashMap<(usize, usize), Arc<ExpirationOrderBook>> = HashMap::new();
+        let mut seen_s: HashMap<(usize, usize, usize), Arc<StrikeOrderBook>> = HashMap::new();
+
+        for (ui, ei, si) in keys {
+            let u_sym = UNDERLYINGS[ui];
+            let exp = nth_expiration(ei);
+            let strike = STRIKES[si];
+
+            // ── Underlying level ────────────────────────────────────────────
+            let first_u = manager.get_or_create(u_sym);
+            let again_u = manager.get_or_create(u_sym);
+            prop_assert!(
+                Arc::ptr_eq(&first_u, &again_u),
+                "second get_or_create(underlying) must return the same Arc"
+            );
+            if let Some(prev) = seen_u.get(&ui) {
+                prop_assert!(
+                    Arc::ptr_eq(prev, &first_u),
+                    "a repeat underlying key must resolve to the originally created Arc"
+                );
+            } else {
+                seen_u.insert(ui, Arc::clone(&first_u));
+            }
+
+            // ── Expiration level ────────────────────────────────────────────
+            let first_e = first_u.get_or_create_expiration(exp);
+            let again_e = first_u.get_or_create_expiration(exp);
+            prop_assert!(
+                Arc::ptr_eq(&first_e, &again_e),
+                "second get_or_create_expiration must return the same Arc"
+            );
+            if let Some(prev) = seen_e.get(&(ui, ei)) {
+                prop_assert!(
+                    Arc::ptr_eq(prev, &first_e),
+                    "a repeat expiration key must resolve to the originally created Arc"
+                );
+            } else {
+                seen_e.insert((ui, ei), Arc::clone(&first_e));
+            }
+
+            // ── Strike level ────────────────────────────────────────────────
+            let first_s = first_e.get_or_create_strike(strike);
+            let again_s = first_e.get_or_create_strike(strike);
+            prop_assert!(
+                Arc::ptr_eq(&first_s, &again_s),
+                "second get_or_create_strike must return the same Arc"
+            );
+            if let Some(prev) = seen_s.get(&(ui, ei, si)) {
+                prop_assert!(
+                    Arc::ptr_eq(prev, &first_s),
+                    "a repeat strike key must resolve to the originally created Arc"
+                );
+            } else {
+                seen_s.insert((ui, ei, si), Arc::clone(&first_s));
+            }
+        }
+
+        // The manager must not have created more than the distinct keys seen.
+        prop_assert_eq!(manager.len(), seen_u.len());
+    }
+}

--- a/tests/unit/props_greeks_aggregation.rs
+++ b/tests/unit/props_greeks_aggregation.rs
@@ -1,0 +1,118 @@
+//! Property: aggregated Greeks equal the hand-computed `Σ (quantity × greek)`.
+//!
+//! Invariant asserted: for a set of added [`Position`]s under one underlying,
+//! every field of `GreeksAggregator::aggregate_by_underlying` equals the
+//! hand-computed `Σ (quantity × greek)` **exactly** in [`Decimal`] (no
+//! tolerance). The bounded strategy keeps every product and sum well within
+//! `Decimal` range, so the result is exact and the `saturated` flag stays
+//! `false`. A separate deterministic test forces an overflow and asserts the
+//! `saturated` flag is set (the skill's saturation hint).
+//!
+//! Aggregation iterates an unordered `DashMap` / `HashMap`, but exact `Decimal`
+//! addition is associative and commutative, so the sum is order-independent —
+//! the equality is not flaky.
+
+use option_chain_orderbook::orderbook::{GreeksAggregator, Position};
+use optionstratlib::greeks::Greek;
+use proptest::prelude::*;
+use rust_decimal::Decimal;
+
+/// Builds a per-instrument `Greek` from 12 raw integers, each scaled by 1e-2 so
+/// the fields carry two decimal places (exercising non-integer `Decimal`s while
+/// staying exact).
+fn greek_from(raws: &[i64; 12]) -> Greek {
+    let s = |i: usize| Decimal::new(raws[i], 2);
+    Greek {
+        delta: s(0),
+        gamma: s(1),
+        theta: s(2),
+        vega: s(3),
+        rho: s(4),
+        rho_d: s(5),
+        alpha: s(6),
+        vanna: s(7),
+        vomma: s(8),
+        veta: s(9),
+        charm: s(10),
+        color: s(11),
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        max_shrink_iters: 50_000,
+        ..ProptestConfig::default()
+    })]
+
+    /// Aggregated Greeks for `"BTC"` equal `Σ (quantity × greek)`, exact.
+    #[test]
+    fn aggregate_by_underlying_equals_manual_sum(
+        positions in prop::collection::vec(
+            (-1_000i64..=1_000, proptest::array::uniform12(-50i64..=50)),
+            0..16,
+        ),
+    ) {
+        let agg = GreeksAggregator::new();
+
+        // Hand-computed expected sums, one Decimal per Greek field.
+        let mut expected = [Decimal::ZERO; 12];
+        for (idx, (qty, raws)) in positions.iter().enumerate() {
+            // Unique instrument symbol per position so none replaces another.
+            let symbol = format!("BTC-20260130-{}-C", idx + 1);
+            agg.add_position("acct", Position::new(symbol, "BTC", *qty, greek_from(raws)));
+
+            let q = Decimal::from(*qty);
+            for (field, raw) in expected.iter_mut().zip(raws.iter()) {
+                *field += q * Decimal::new(*raw, 2);
+            }
+        }
+
+        let result = agg.aggregate_by_underlying("BTC");
+
+        prop_assert_eq!(result.delta, expected[0]);
+        prop_assert_eq!(result.gamma, expected[1]);
+        prop_assert_eq!(result.theta, expected[2]);
+        prop_assert_eq!(result.vega, expected[3]);
+        prop_assert_eq!(result.rho, expected[4]);
+        prop_assert_eq!(result.rho_d, expected[5]);
+        prop_assert_eq!(result.alpha, expected[6]);
+        prop_assert_eq!(result.vanna, expected[7]);
+        prop_assert_eq!(result.vomma, expected[8]);
+        prop_assert_eq!(result.veta, expected[9]);
+        prop_assert_eq!(result.charm, expected[10]);
+        prop_assert_eq!(result.color, expected[11]);
+
+        prop_assert_eq!(result.position_count, positions.len());
+        // Bounded inputs never saturate.
+        prop_assert!(!result.saturated);
+    }
+}
+
+#[test]
+fn saturating_quantity_sets_the_flag() {
+    let agg = GreeksAggregator::new();
+    // delta = Decimal::MAX, quantity = 2  ⇒  MAX * 2 overflows ⇒ saturates.
+    let greeks = Greek {
+        delta: Decimal::MAX,
+        gamma: Decimal::ZERO,
+        theta: Decimal::ZERO,
+        vega: Decimal::ZERO,
+        rho: Decimal::ZERO,
+        rho_d: Decimal::ZERO,
+        alpha: Decimal::ZERO,
+        vanna: Decimal::ZERO,
+        vomma: Decimal::ZERO,
+        veta: Decimal::ZERO,
+        charm: Decimal::ZERO,
+        color: Decimal::ZERO,
+    };
+    agg.add_position("acct", Position::new("BTC-20260130-1-C", "BTC", 2, greeks));
+
+    let result = agg.aggregate_by_underlying("BTC");
+    assert!(
+        result.saturated,
+        "aggregation that overflows Decimal::MAX must set the saturated flag"
+    );
+    assert_eq!(result.delta, Decimal::MAX);
+}

--- a/tests/unit/props_mass_cancel_scope.rs
+++ b/tests/unit/props_mass_cancel_scope.rs
@@ -1,0 +1,179 @@
+//! Property: a scoped `cancel_all` cancels exactly the resting orders in scope.
+//!
+//! Invariant asserted, for strike / chain / expiration scopes after a generated
+//! op stream:
+//!
+//! * the returned `*MassCancelResult.total_cancelled()` equals the count of
+//!   resting orders in that scope *before* the cancel;
+//! * the in-scope book is empty afterwards; and
+//! * every out-of-scope book is left **untouched**.
+//!
+//! Each proptest seeds a structurally-separate, buy-only **witness** book (a
+//! sibling strike outside the stream's strike pool / a different expiration's
+//! chain / a second expiration). Buy-only ⇒ nothing crosses ⇒ all witness
+//! orders rest, guaranteeing a non-empty out-of-scope book in *every* case; the
+//! submit-heavy stream keeps the in-scope book non-empty most of the time. The
+//! concrete `*_concrete` test pins exact in- and out-of-scope counts.
+
+use crate::common::strategies::{
+    STRIKES, apply_op, chain_op_stream, chain_op_strike, nth_expiration,
+};
+use option_chain_orderbook::orderbook::{
+    ExpirationOrderBook, OptionChainOrderBook, StrikeOrderBook,
+};
+use option_chain_orderbook::{OrderId, Side};
+use proptest::prelude::*;
+use std::sync::Arc;
+
+/// Strike price reserved as an out-of-scope witness: deliberately NOT in
+/// [`STRIKES`], so the chain-routed stream never references it.
+const WITNESS_STRIKE: u64 = 900;
+
+/// Seeds `count` buy-only resting orders into a strike's call leg. Buy-only ⇒
+/// no crossing ⇒ all rest, so the strike ends with exactly `count` orders.
+fn seed_buy_only(strike: &Arc<StrikeOrderBook>, count: u64) {
+    for k in 0..count {
+        strike
+            .call()
+            .add_limit_order(
+                OrderId::from_u64(1_000 + k),
+                Side::Buy,
+                50 + u128::from(k),
+                1,
+            )
+            .expect("buy-only seed never crosses and must rest");
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        max_shrink_iters: 50_000,
+        ..ProptestConfig::default()
+    })]
+
+    /// Strike-scope cancel: cancels exactly one strike, siblings untouched.
+    #[test]
+    fn strike_scope_cancel_counts(
+        stream in chain_op_stream(1..120),
+        witness_count in 1u64..=5,
+    ) {
+        let chain = OptionChainOrderBook::new("BTC", nth_expiration(0));
+
+        // Out-of-scope witness (separate strike book, never in the stream pool).
+        let witness = chain.get_or_create_strike(WITNESS_STRIKE);
+        seed_buy_only(&witness, witness_count);
+        let witness_before = witness.order_count();
+
+        for routed in &stream {
+            let strike = chain.get_or_create_strike(chain_op_strike(routed));
+            apply_op(strike.get(routed.style), &routed.op);
+        }
+
+        // Scope = the first pool strike; the others are out-of-scope siblings.
+        let target = chain.get_or_create_strike(STRIKES[0]);
+        let sibling_a = chain.get_or_create_strike(STRIKES[1]);
+        let sibling_b = chain.get_or_create_strike(STRIKES[2]);
+
+        let target_before = target.order_count();
+        let sibling_a_before = sibling_a.order_count();
+        let sibling_b_before = sibling_b.order_count();
+
+        let result = target.cancel_all().expect("strike cancel_all");
+
+        prop_assert_eq!(result.total_cancelled(), target_before);
+        prop_assert_eq!(target.order_count(), 0);
+        // Out-of-scope books untouched.
+        prop_assert_eq!(sibling_a.order_count(), sibling_a_before);
+        prop_assert_eq!(sibling_b.order_count(), sibling_b_before);
+        prop_assert_eq!(witness.order_count(), witness_before);
+    }
+
+    /// Chain-scope cancel: cancels the whole chain, a sibling chain untouched.
+    #[test]
+    fn chain_scope_cancel_counts(
+        stream in chain_op_stream(1..120),
+        witness_count in 1u64..=5,
+    ) {
+        let chain_a = OptionChainOrderBook::new("BTC", nth_expiration(0));
+        // Out-of-scope witness: a different expiration's chain (separate books).
+        let chain_b = OptionChainOrderBook::new("BTC", nth_expiration(1));
+        seed_buy_only(&chain_b.get_or_create_strike(STRIKES[0]), witness_count);
+        let witness_before = chain_b.total_order_count();
+
+        for routed in &stream {
+            let strike = chain_a.get_or_create_strike(chain_op_strike(routed));
+            apply_op(strike.get(routed.style), &routed.op);
+        }
+
+        let before = chain_a.total_order_count();
+        let result = chain_a.cancel_all().expect("chain cancel_all");
+
+        prop_assert_eq!(result.total_cancelled(), before);
+        prop_assert_eq!(chain_a.total_order_count(), 0);
+        prop_assert_eq!(chain_b.total_order_count(), witness_before);
+    }
+
+    /// Expiration-scope cancel: cancels one expiration, another untouched.
+    #[test]
+    fn expiration_scope_cancel_counts(
+        stream in chain_op_stream(1..120),
+        witness_count in 1u64..=5,
+    ) {
+        let exp_a = ExpirationOrderBook::new("BTC", nth_expiration(0));
+        let exp_b = ExpirationOrderBook::new("BTC", nth_expiration(1));
+        seed_buy_only(&exp_b.get_or_create_strike(STRIKES[0]), witness_count);
+        let witness_before = exp_b.total_order_count();
+
+        for routed in &stream {
+            let strike = exp_a.get_or_create_strike(chain_op_strike(routed));
+            apply_op(strike.get(routed.style), &routed.op);
+        }
+
+        let before = exp_a.total_order_count();
+        let result = exp_a.cancel_all().expect("expiration cancel_all");
+
+        prop_assert_eq!(result.total_cancelled(), before);
+        prop_assert_eq!(exp_a.total_order_count(), 0);
+        prop_assert_eq!(exp_b.total_order_count(), witness_before);
+    }
+}
+
+#[test]
+fn strike_scope_cancel_counts_concrete() {
+    let chain = OptionChainOrderBook::new("BTC", nth_expiration(0));
+
+    // In-scope strike 100: two resting call orders (non-crossing) + one put.
+    let target = chain.get_or_create_strike(100);
+    target
+        .call()
+        .add_limit_order(OrderId::from_u64(1), Side::Buy, 99, 5)
+        .expect("add buy");
+    target
+        .call()
+        .add_limit_order(OrderId::from_u64(2), Side::Sell, 101, 3)
+        .expect("add sell");
+    target
+        .put()
+        .add_limit_order(OrderId::from_u64(3), Side::Buy, 50, 1)
+        .expect("add put buy");
+    assert_eq!(target.order_count(), 3);
+
+    // Out-of-scope strike 200: one resting order.
+    let sibling = chain.get_or_create_strike(200);
+    sibling
+        .call()
+        .add_limit_order(OrderId::from_u64(4), Side::Buy, 10, 1)
+        .expect("add sibling buy");
+    assert_eq!(sibling.order_count(), 1);
+
+    let result = chain
+        .get_or_create_strike(100)
+        .cancel_all()
+        .expect("strike cancel_all");
+
+    // Exactly the three in-scope orders cancelled; sibling untouched.
+    assert_eq!(result.total_cancelled(), 3);
+    assert_eq!(target.order_count(), 0);
+    assert_eq!(sibling.order_count(), 1);
+}

--- a/tests/unit/props_symbol_roundtrip.rs
+++ b/tests/unit/props_symbol_roundtrip.rs
@@ -1,0 +1,60 @@
+//! Property: a valid symbol round-trips through the parser.
+//!
+//! Invariant asserted: for a canonically-formatted, valid symbol `s`,
+//! `SymbolParser::parse(s)?.to_symbol() == s`, the parsed components echo the
+//! generated inputs, the derived expiration is an absolute
+//! [`ExpirationDate::DateTime`] (never the wall-clock-relative `Days`), and
+//! re-parsing the reconstructed string yields an equal `ParsedSymbol`.
+//!
+//! The grammar `{UNDERLYING}-{YYYYMMDD}-{STRIKE}-{C|P}` is generated in
+//! canonical form (uppercase underlying with no `-`, zero-padded 8-digit date,
+//! decimal strike with no leading zeros, uppercase option letter) so the exact
+//! round-trip is the genuine invariant rather than an artifact of formatting.
+//! Days are capped at 28 so every `(year, month, day)` is a real calendar date.
+
+use option_chain_orderbook::SymbolParser;
+use optionstratlib::{ExpirationDate, OptionStyle};
+use proptest::prelude::*;
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 256,
+        max_shrink_iters: 50_000,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn parse_then_to_symbol_is_identity(
+        underlying in "[A-Z]{1,4}",
+        year in 2000u32..=2099,
+        month in 1u32..=12,
+        day in 1u32..=28,
+        strike in 1u64..=10_000_000,
+        is_call in any::<bool>(),
+    ) {
+        let opt = if is_call { "C" } else { "P" };
+        let date = format!("{year:04}{month:02}{day:02}");
+        let symbol = format!("{underlying}-{date}-{strike}-{opt}");
+
+        let parsed = SymbolParser::parse(&symbol).expect("canonical symbol must parse");
+
+        // The headline round-trip.
+        prop_assert_eq!(parsed.to_symbol(), symbol.clone());
+
+        // Parsed components echo the generated inputs.
+        prop_assert_eq!(parsed.underlying(), underlying.as_str());
+        prop_assert_eq!(parsed.expiration_str(), date.as_str());
+        prop_assert_eq!(parsed.strike(), strike);
+        prop_assert_eq!(
+            parsed.option_style(),
+            if is_call { OptionStyle::Call } else { OptionStyle::Put }
+        );
+
+        // Expiry is absolute (replay-stable), never the relative `Days` variant.
+        prop_assert!(matches!(parsed.expiration(), ExpirationDate::DateTime(_)));
+
+        // Reconstruct → re-parse is stable (the type invariant).
+        let reparsed = SymbolParser::parse(&parsed.to_symbol()).expect("reconstructed must re-parse");
+        prop_assert_eq!(parsed, reparsed);
+    }
+}


### PR DESCRIPTION
## Summary

Property-based (`proptest`) regression suite covering six load-bearing
invariants of the order-book hierarchy, exercised only through the public API.
`proptest` is added as a **dev-dependency only** — no change to the shipped
dependency set, no new feature flag.

## Properties

| File | Invariant |
|------|-----------|
| `props_best_quote.rs` | `best_quote()` equals top-of-book price on each side; size equals the **exact** best-level depth (oracle = order-book snapshot's top level, an independent read path); two-sided iff both sides rest. |
| `props_get_or_create_idempotent.rs` | `get_or_create_*` returns the same `Arc` (`ptr_eq`) for a repeated key at every level; `len()` equals the distinct-key count (no over-creation). |
| `props_chain_stats_aggregate.rs` | Chain `stats()` and global `stats()` equal an **independent tree walk** over the hierarchy (different traversal than the impl). |
| `props_greeks_aggregation.rs` | Aggregated Greeks equal an exact `Decimal` `Σ(qty × greek)` on all 12 fields; the saturation flag is forced by an overflowing position. |
| `props_mass_cancel_scope.rs` | Scoped `cancel_all` cancels exactly the in-scope resting count and leaves every out-of-scope (witness) book untouched, at strike / chain / expiration scope. |
| `props_symbol_roundtrip.rs` | `parse(s).to_symbol() == s` for canonical symbols; re-parse stability; expiration is `DateTime`-backed. |

## Design

- **Shared strategies** (`tests/unit/common/strategies.rs`) route every input
  through the `pricelevel` newtypes. Fixed underlying / strike pools, three
  absolute `ExpirationDate::DateTime` dates (no wall-clock `Days`), a tight
  `99..=101` price band to force crossings, a small `OrderId` pool to force
  collisions/cancels, and submit-biased op streams to keep books live.
- **Config:** every block uses `ProptestConfig { cases: 256, max_shrink_iters: 50_000, .. }`.
- **Deterministic companions** pin the one-sided / two-sided / crossing-clears-a-side
  and concrete mis-scope cases so coverage never depends on the seed.
- **Order-independence:** all asserted equalities are commutative `Decimal`
  sums or scalar counts — no `DashMap` / `HashMap` iteration order, no
  wall-clock, reaches any asserted value (audited).

## Public API impact

None — test-only. No `src/` changes, README unchanged, version stays `0.5.0`.

## Testing

- [x] `cargo test --test tests --all-features props_` — 14 passed, 0 failed
- [x] best_quote property run 3× — non-flaky
- [x] `cargo clippy --all-targets --all-features` clean
- [x] `make pre-push` clean (no `proptest-regressions/` produced — no invariant bug surfaced)
- [x] `proptest` confirmed dev-dependency only via `cargo metadata`

Closes #87