### PR TITLE
chore(deps)!: bump orderbook-rs 0.9 → 0.10 (public dependency) — 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.4`. A full upgrade walkthrough lives in
 > [`MIGRATING-0.5.0.md`](./MIGRATING-0.5.0.md).
 
+## [0.6.0] - 2026-07-10
+
+### ⚠️ Breaking Changes
+
+- **`orderbook-rs` dependency bumped `0.9` → `0.10`.** `orderbook-rs` is a
+  *public* dependency: types re-exported at this crate's root (`TradeResult`,
+  `MassCancelResult`, `OrderStatus`, `OrderStateTracker`, `FeeSchedule`,
+  `STPMode`, `CancelReason`, the boundary newtypes, …) now come from
+  `orderbook-rs 0.10`, so downstream crates that also depend on `orderbook-rs`
+  directly must move their own pin to `0.10` in the same update or the two
+  copies' types will not unify. No code changes are required in this crate's
+  own API — signatures and behavior are unchanged.
+- Migration notes for direct `orderbook-rs` users: `SequencerCommand` /
+  `SequencerResult` are `#[non_exhaustive]` in 0.10 (exhaustive `match`es need
+  a wildcard arm). 0.10 also adds `OrderBook::evict_expired_orders(now_ms)`
+  (host-driven GTD/DAY expiry sweep) — not yet surfaced through this wrapper;
+  tracked in #141.
+
+### Changed
+
+- `pricelevel` floor raised to `0.8.4` (GTD deadline documented as Unix
+  milliseconds + pinning test).
+
 ## [0.5.0] - 2026-06-27
 
 ### ⚠️ Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "option-chain-orderbook"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance Rust library for options market making infrastructure, providing a complete Option Chain Order Book system built on top of OrderBook-rs, PriceLevel, and OptionStratLib."
@@ -69,7 +69,7 @@ crate-type = ["rlib"]
 
 [workspace.dependencies]
 optionstratlib = { version = "0.17", default-features = false }
-orderbook-rs = { version = "0.9", features = ["special_orders"] }
+orderbook-rs = { version = "0.10", features = ["special_orders"] }
 async-nats = "0.49"
 bytes = "1.12"
 tokio = { version = "1.52", features = ["rt", "sync"] }
@@ -81,4 +81,4 @@ rust_decimal_macros = "1.40"
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2.0"
 crossbeam-skiplist = "0.1"
-pricelevel = "0.8"
+pricelevel = "0.8.4"


### PR DESCRIPTION
## Summary

Moves the `orderbook-rs` pin from `0.9` to `0.10` and releases **0.6.0**.

### Why 0.6.0 (breaking)
`orderbook-rs` is a **public** dependency — `TradeResult`, `MassCancelResult`, `OrderStatus`, `OrderStateTracker`, `FeeSchedule`, `STPMode`, `CancelReason` and the boundary newtypes are re-exported at the crate root. Bumping to 0.10 changes those types' identity, so downstream crates that also depend on `orderbook-rs` directly must move their pin in the same update (the backend PR does exactly that).

### Impact in this crate
- **Zero code changes**: 926 tests green + clippy `-D warnings` clean against 0.10.0. The 0.10 `#[non_exhaustive]` on `SequencerCommand`/`SequencerResult` doesn't bite here — this crate defines its own `OptionChainCommand` layer.
- `pricelevel` floor raised to `0.8.4`.
- `cargo semver-checks`: pass (0.5.0 → 0.6.0 major slot).

### Follow-ups
- #141 — surface `evict_expired_orders` (new in orderbook-rs 0.10) through the wrapper hierarchy.
- #140 — migrate `*_full` methods onto `add_order_with_result` (unblocked by this bump).