### PR TITLE
feat: surface evict_expired_orders through the hierarchy (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.1] - 2026-07-11
 
+### Added
+
+- Host-driven GTD/DAY expiry sweep surfaced through the whole hierarchy, wrapping
+  `orderbook-rs` 0.10's `OrderBook::evict_expired_orders(now_ms)`. `now_ms` is a
+  caller-supplied Unix-milliseconds cutoff (the sweep reads no clock, so it is a
+  pure function of `now_ms` and the resting book and replays identically), the
+  boundary is inclusive (an order whose deadline equals `now_ms` is evicted), and
+  expiry is realized only when the sweep runs — an order past its deadline that
+  has not yet been swept still rests and remains matchable until the next call.
+  - `OptionOrderBook::evict_expired_orders(now_ms) -> Vec<OrderId>` on the leaf
+    book, returning the evicted ids in the engine's deterministic order (bids then
+    asks, ascending price, oldest first within a level) — matching the id-centric
+    shape of `expire()` and the mass-cancel pass-throughs.
+  - Aggregated variants mirroring the `*MassCancelResult` pattern:
+    `StrikeOrderBook::evict_expired_orders`,
+    `OptionChainOrderBook::evict_expired_orders`,
+    `ExpirationOrderBook::evict_expired_orders`,
+    `UnderlyingOrderBook::evict_expired_orders`, and
+    `UnderlyingOrderBookManager::evict_expired_across_underlyings`, returning the
+    new `StrikeEvictExpiredResult` / `ChainEvictExpiredResult` /
+    `ExpirationEvictExpiredResult` / `UnderlyingEvictExpiredResult` /
+    `GlobalEvictExpiredResult` types. Each exposes `books_affected()` (leaf
+    contract-book unit, identical semantics to the mass-cancel counterpart) and
+    `total_evicted()`, and walks the tree in each container's deterministic order
+    (expirations by key, strikes ascending, underlyings by symbol).
+  - Not journaled as a wrapper-level sequencer command: `OptionChainCommand` is
+    not `#[non_exhaustive]`, so adding a variant would be a breaking change
+    (rejected by `cargo-semver-checks` and incompatible with a patch release).
+    The engine journals the sweep at its own layer via
+    `SequencerCommand::EvictExpiredOrders` (`orderbook-rs`). (#141)
+
 ### Fixed
 
 - `OptionOrderBook`'s `*_full` submit methods (`add_limit_order_full`,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,10 +323,11 @@ pub use error::{Error, Result};
 // `Side`, `TimeInForce`, `Hash32`, `Price`, `Quantity`, `TimestampMs`) re-exported
 // from `orderbook_rs` / `pricelevel`.
 pub use orderbook::{
-    AggregatedGreeks, CancelReason, ChainMassCancelResult, CleanupResult, ContractSpecs,
-    ContractSpecsBuilder, CycleRule, ExerciseStyle, ExpirationCallback, ExpirationManagerStats,
-    ExpirationMassCancelResult, ExpirationOrderBook, ExpirationOrderBookManager, ExpiryCycleConfig,
-    ExpiryLifecycleManager, ExpiryScheduler, ExpiryType, FeeSchedule, FlatVolSurface,
+    AggregatedGreeks, CancelReason, ChainEvictExpiredResult, ChainMassCancelResult, CleanupResult,
+    ContractSpecs, ContractSpecsBuilder, CycleRule, ExerciseStyle, ExpirationCallback,
+    ExpirationEvictExpiredResult, ExpirationManagerStats, ExpirationMassCancelResult,
+    ExpirationOrderBook, ExpirationOrderBookManager, ExpiryCycleConfig, ExpiryLifecycleManager,
+    ExpiryScheduler, ExpiryType, FeeSchedule, FlatVolSurface, GlobalEvictExpiredResult,
     GlobalMassCancelResult, GlobalStats, GreeksAggregator, GreeksEngine, GreeksRecalcTrigger,
     GreeksUpdate, GreeksUpdateListener, Hash32, IndexPriceFeed, InstrumentInfo, InstrumentRegistry,
     InstrumentStatus, LifecycleConfig, LifecycleEvent, LifecycleListener, LifecycleResult,
@@ -334,11 +335,12 @@ pub use orderbook::{
     OptionChainOrderBook, OptionChainOrderBookManager, OptionChainStats, OptionOrderBook, OrderId,
     OrderStateTracker, OrderStatus, OrderType, Position, Price, PriceUpdate, PriceUpdateListener,
     Quantity, Quote, QuoteUpdate, RefreshResult, STPMode, SettlementType, Side, StaticPriceFeed,
-    StrikeGenerator, StrikeMassCancelResult, StrikeOrderBook, StrikeOrderBookManager,
-    StrikeRangeConfig, StrikeRangeConfigBuilder, SubscriptionId, SymbolIndex, SymbolRef,
-    TerminalOrderSummary, TimeInForce, TimestampMs, TradeResult, UnderlyingMassCancelResult,
-    UnderlyingOrderBook, UnderlyingOrderBookManager, UnderlyingStats, ValidationConfig, VolSurface,
-    calculate_tte_years, wire_feed_to_calculator,
+    StrikeEvictExpiredResult, StrikeGenerator, StrikeMassCancelResult, StrikeOrderBook,
+    StrikeOrderBookManager, StrikeRangeConfig, StrikeRangeConfigBuilder, SubscriptionId,
+    SymbolIndex, SymbolRef, TerminalOrderSummary, TimeInForce, TimestampMs, TradeResult,
+    UnderlyingEvictExpiredResult, UnderlyingMassCancelResult, UnderlyingOrderBook,
+    UnderlyingOrderBookManager, UnderlyingStats, ValidationConfig, VolSurface, calculate_tte_years,
+    wire_feed_to_calculator,
 };
 
 #[cfg(feature = "nats")]

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -1368,6 +1368,94 @@ impl OptionOrderBook {
         Ok(self.book.cancel_orders_by_user(user_id))
     }
 
+    /// Evicts resting `GTD` / `DAY` orders whose deadline has passed as of
+    /// `now_ms`.
+    ///
+    /// # Description
+    ///
+    /// Host-driven, deterministic expiry sweep. Pass-through to the engine's
+    /// [`OrderBook::evict_expired_orders`](orderbook_rs::OrderBook::evict_expired_orders):
+    /// every resting order whose time-in-force is expired at `now_ms` is
+    /// removed through the same single-order cancel path as an ordinary cancel
+    /// (so the price-level cache, depth statistics, order indices, risk state,
+    /// and the order-state tracker all stay consistent), tagged with
+    /// [`CancelReason::TimeInForceExpired`](orderbook_rs::CancelReason). The
+    /// engine returns the evicted orders as `Arc<OrderType>`; this wrapper
+    /// narrows them to their identifiers, matching the id-centric shape of
+    /// [`expire`](Self::expire) and the mass-cancel pass-throughs.
+    ///
+    /// Unlike [`expire`](Self::expire), this does **not** change the
+    /// instrument's lifecycle status and does not require the book to be
+    /// active: it is a routine maintenance sweep the host runs on its own
+    /// cadence, not a terminal transition.
+    ///
+    /// # Timestamp and determinism
+    ///
+    /// `now_ms` is a **caller-supplied Unix-milliseconds** timestamp — the
+    /// engine reads no clock, so the sweep is a pure function of `now_ms` and
+    /// the resting book, and replays identically. The boundary is inclusive:
+    /// an order with deadline exactly `now_ms` is evicted (the same
+    /// `tif_expired_at` definition admission uses, so a just-admitted order can
+    /// never be swept at the same instant it was accepted).
+    ///
+    /// Evicted ids are returned in the engine's fixed, replay-stable order:
+    /// bids first then asks, price levels ascending within a side, and
+    /// ascending insertion sequence (oldest first) within a level.
+    ///
+    /// # Caveat
+    ///
+    /// Expiry is realized **only when the sweep runs**. An order whose deadline
+    /// has passed but which has not yet been swept still rests and remains
+    /// matchable until the next `evict_expired_orders` call; driving the sweep
+    /// cadence is the host's responsibility.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ms` - Caller-supplied Unix-milliseconds cutoff. Orders expired at
+    ///   or before this instant are evicted.
+    ///
+    /// # Returns
+    ///
+    /// The identifiers of the evicted orders, in the deterministic order
+    /// described above. Empty when nothing was expired. A second sweep at the
+    /// same `now_ms` returns an empty vector (idempotent).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::{OptionOrderBook, OrderId, Side, TimeInForce, TimestampMs};
+    /// use optionstratlib::OptionStyle;
+    ///
+    /// let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+    /// let gtd = OrderId::new();
+    /// // A resting GTD order that expires at t = 10_000_000_000_000 ms.
+    /// if let Err(err) =
+    ///     book.add_limit_order_with_tif(gtd, Side::Buy, 100, 1, TimeInForce::Gtd(10_000_000_000_000))
+    /// {
+    ///     panic!("add order failed: {}", err);
+    /// }
+    /// // Nothing expired one millisecond before the deadline.
+    /// assert!(
+    ///     book.evict_expired_orders(TimestampMs::new(9_999_999_999_999))
+    ///         .is_empty()
+    /// );
+    /// // At the deadline the order is evicted.
+    /// let evicted = book.evict_expired_orders(TimestampMs::new(10_000_000_000_000));
+    /// assert_eq!(evicted, vec![gtd]);
+    /// ```
+    #[must_use]
+    pub fn evict_expired_orders(&self, now_ms: TimestampMs) -> Vec<OrderId> {
+        self.book
+            .evict_expired_orders(now_ms)
+            .into_iter()
+            .map(|order| order.id())
+            .collect()
+    }
+
     // ── Order Lifecycle Queries ────────────────────────────────────────────
 
     /// Returns the current lifecycle status of an order.
@@ -2218,6 +2306,118 @@ mod tests {
         assert_eq!(result.cancelled_count(), 1);
         assert_eq!(book.order_count(), 1);
         assert!(book.best_ask().is_some());
+    }
+
+    // Far-future GTD deadlines (Unix ms) so admission — which reads the real
+    // wall clock — accepts them, while the sweep, which is driven purely by the
+    // caller-supplied `now_ms`, controls whether they are treated as expired.
+    const GTD_EXPIRED: u64 = 10_000_000_000_000;
+    const GTD_LATER: u64 = 20_000_000_000_000;
+
+    #[test]
+    fn test_evict_expired_orders_evicts_gtd_and_leaves_unexpired_and_gtc() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let expired = OrderId::new();
+        let later = OrderId::new();
+        let gtc = OrderId::new();
+
+        if let Err(err) = book.add_limit_order_with_tif(
+            expired,
+            Side::Buy,
+            100,
+            10,
+            TimeInForce::Gtd(GTD_EXPIRED),
+        ) {
+            panic!("add order failed: {}", err);
+        }
+        if let Err(err) =
+            book.add_limit_order_with_tif(later, Side::Buy, 99, 5, TimeInForce::Gtd(GTD_LATER))
+        {
+            panic!("add order failed: {}", err);
+        }
+        if let Err(err) = book.add_limit_order_with_tif(gtc, Side::Sell, 105, 7, TimeInForce::Gtc) {
+            panic!("add order failed: {}", err);
+        }
+
+        // One millisecond before the earliest deadline nothing is expired.
+        assert!(
+            book.evict_expired_orders(TimestampMs::new(GTD_EXPIRED - 1))
+                .is_empty()
+        );
+        assert_eq!(book.order_count(), 3);
+
+        // At the deadline only the matching GTD order is swept (inclusive
+        // boundary); the later GTD and the GTC order are untouched.
+        let evicted = book.evict_expired_orders(TimestampMs::new(GTD_EXPIRED));
+        assert_eq!(evicted, vec![expired]);
+        assert_eq!(book.order_count(), 2);
+        assert_eq!(book.get_order_status(later), Some(OrderStatus::Open));
+        assert_eq!(book.get_order_status(gtc), Some(OrderStatus::Open));
+    }
+
+    #[test]
+    fn test_evict_expired_orders_is_idempotent() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let expired = OrderId::new();
+        if let Err(err) = book.add_limit_order_with_tif(
+            expired,
+            Side::Buy,
+            100,
+            10,
+            TimeInForce::Gtd(GTD_EXPIRED),
+        ) {
+            panic!("add order failed: {}", err);
+        }
+
+        let first = book.evict_expired_orders(TimestampMs::new(GTD_EXPIRED));
+        assert_eq!(first, vec![expired]);
+
+        // A second sweep at the same instant evicts nothing: the order is gone.
+        let second = book.evict_expired_orders(TimestampMs::new(GTD_EXPIRED));
+        assert!(second.is_empty());
+    }
+
+    #[test]
+    fn test_evict_expired_orders_empty_book() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        assert!(
+            book.evict_expired_orders(TimestampMs::new(GTD_EXPIRED))
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_evict_expired_orders_deterministic_order() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let bid_low = OrderId::new();
+        let bid_high = OrderId::new();
+        let ask = OrderId::new();
+
+        // Add out of the documented order to prove the sweep, not insertion,
+        // dictates the result order: bids ascending price, then asks.
+        if let Err(err) =
+            book.add_limit_order_with_tif(ask, Side::Sell, 105, 1, TimeInForce::Gtd(GTD_EXPIRED))
+        {
+            panic!("add order failed: {}", err);
+        }
+        if let Err(err) = book.add_limit_order_with_tif(
+            bid_high,
+            Side::Buy,
+            100,
+            1,
+            TimeInForce::Gtd(GTD_EXPIRED),
+        ) {
+            panic!("add order failed: {}", err);
+        }
+        if let Err(err) =
+            book.add_limit_order_with_tif(bid_low, Side::Buy, 99, 1, TimeInForce::Gtd(GTD_EXPIRED))
+        {
+            panic!("add order failed: {}", err);
+        }
+
+        let evicted = book.evict_expired_orders(TimestampMs::new(GTD_EXPIRED));
+        // Bids ascending price (99 then 100), then asks.
+        assert_eq!(evicted, vec![bid_low, bid_high, ask]);
     }
 
     #[test]

--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -7,14 +7,16 @@ use super::contract_specs::ContractSpecs;
 use super::expiration_key::ExpirationKey;
 use super::instrument_registry::InstrumentRegistry;
 use super::shared::Shared;
-use super::strike::{StrikeMassCancelResult, StrikeOrderBook, StrikeOrderBookManager};
+use super::strike::{
+    StrikeEvictExpiredResult, StrikeMassCancelResult, StrikeOrderBook, StrikeOrderBookManager,
+};
 use super::symbol_index::SymbolIndex;
 use super::validation::ValidationConfig;
 use crate::error::{Error, Result};
 use crossbeam_skiplist::SkipMap;
 use optionstratlib::ExpirationDate;
 use orderbook_rs::{FeeSchedule, OrderId, OrderStatus, STPMode, Side};
-use pricelevel::Hash32;
+use pricelevel::{Hash32, TimestampMs};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -442,6 +444,59 @@ impl OptionChainOrderBook {
         Ok(ChainMassCancelResult { per_child })
     }
 
+    /// Evicts expired `GTD` / `DAY` orders across every strike in the chain.
+    ///
+    /// # Description
+    ///
+    /// Runs the host-driven expiry sweep across all strikes and returns the
+    /// aggregated per-strike results. `now_ms` is a caller-supplied
+    /// Unix-milliseconds cutoff; the sweep reads no clock, so it is a pure
+    /// function of `now_ms` and the resting books and replays identically.
+    /// Strikes are walked in ascending strike-price order (the `SkipMap`'s
+    /// natural key order — the same order [`cancel_all`](Self::cancel_all)
+    /// uses), and within each leaf book the evicted ids follow the engine's
+    /// deterministic eviction order.
+    ///
+    /// Expiry is realized only when the sweep runs: an order past its deadline
+    /// that has not yet been swept still rests and remains matchable.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ms` - Caller-supplied Unix-milliseconds cutoff.
+    ///
+    /// # Returns
+    ///
+    /// A [`ChainEvictExpiredResult`] containing per-strike results plus
+    /// aggregated counts (books, orders).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::OptionChainOrderBook;
+    /// use option_chain_orderbook::TimestampMs;
+    /// use optionstratlib::ExpirationDate;
+    /// use optionstratlib::prelude::pos_or_panic;
+    ///
+    /// let chain = OptionChainOrderBook::new("BTC", ExpirationDate::Days(pos_or_panic!(30.0)));
+    /// let result = chain.evict_expired_orders(TimestampMs::new(10_000_000_000_000));
+    /// assert_eq!(result.total_evicted(), 0);
+    /// ```
+    pub fn evict_expired_orders(&self, now_ms: TimestampMs) -> ChainEvictExpiredResult {
+        let mut per_child = Vec::with_capacity(self.strikes.len());
+
+        for entry in self.strikes.iter() {
+            let strike_key = entry.key().to_string();
+            let result = entry.value().evict_expired_orders(now_ms);
+            per_child.push((strike_key, result));
+        }
+
+        ChainEvictExpiredResult { per_child }
+    }
+
     // ── Order Lifecycle Queries ────────────────────────────────────────────
 
     /// Finds an order anywhere in this chain's strikes.
@@ -723,6 +778,103 @@ impl ChainMassCancelResult {
         self.per_child
             .iter()
             .map(|(_, result)| result.total_cancelled())
+            .sum()
+    }
+}
+
+/// Aggregated result of an expiry sweep across every strike in a chain.
+///
+/// The eviction analogue of [`ChainMassCancelResult`]: `per_child` carries the
+/// per-strike [`StrikeEvictExpiredResult`] keyed by strike price, in ascending
+/// strike order. The aggregate accessors report the leaf-contract-book unit,
+/// identical to the mass-cancel counterpart.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use option_chain_orderbook::orderbook::ChainEvictExpiredResult;
+///
+/// let result = ChainEvictExpiredResult { per_child: Vec::new() };
+/// assert_eq!(result.total_evicted(), 0);
+/// ```
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct ChainEvictExpiredResult {
+    /// Per-strike eviction results keyed by strike price.
+    pub per_child: Vec<(String, StrikeEvictExpiredResult)>,
+}
+
+impl ChainEvictExpiredResult {
+    /// Returns the number of leaf option books with evicted orders.
+    ///
+    /// # Description
+    ///
+    /// Drills into each per-strike result and sums its affected leaf
+    /// [`OptionOrderBook`](super::book::OptionOrderBook)s (call/put contract
+    /// books). The unit is a leaf contract book — identical to the unit reported
+    /// at every other level — so results aggregate cleanly up the tree (a chain
+    /// spanning `N` strikes with both legs touched reports `2N`). This is NOT a
+    /// count of affected strikes.
+    ///
+    /// # Arguments
+    ///
+    /// None.
+    ///
+    /// # Returns
+    ///
+    /// Number of leaf option books affected (call/put contract books).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::ChainEvictExpiredResult;
+    ///
+    /// let result = ChainEvictExpiredResult { per_child: Vec::new() };
+    /// assert_eq!(result.books_affected(), 0);
+    /// ```
+    #[must_use]
+    pub fn books_affected(&self) -> usize {
+        self.per_child
+            .iter()
+            .map(|(_, result)| result.books_affected())
+            .sum()
+    }
+
+    /// Returns the total number of evicted orders across the chain.
+    ///
+    /// # Description
+    ///
+    /// Sums evicted orders across every strike in the chain.
+    ///
+    /// # Arguments
+    ///
+    /// None.
+    ///
+    /// # Returns
+    ///
+    /// Total evicted orders (orders).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::ChainEvictExpiredResult;
+    ///
+    /// let result = ChainEvictExpiredResult { per_child: Vec::new() };
+    /// assert_eq!(result.total_evicted(), 0);
+    /// ```
+    #[must_use]
+    pub fn total_evicted(&self) -> usize {
+        self.per_child
+            .iter()
+            .map(|(_, result)| result.total_evicted())
             .sum()
     }
 }
@@ -1666,6 +1818,50 @@ mod tests {
         thread::sleep(Duration::from_millis(10));
         let purged = chain.purge_terminal_states(Duration::from_millis(1));
         assert_eq!(purged, 2);
+    }
+
+    #[test]
+    fn test_chain_evict_expired_orders_walks_strikes_ascending() {
+        use orderbook_rs::TimeInForce;
+        // Far-future GTD deadline so admission (wall clock) accepts it while the
+        // caller-driven sweep controls expiry.
+        const GTD_EXPIRED: u64 = 10_000_000_000_000;
+        let chain = OptionChainOrderBook::new("BTC", test_expiration());
+
+        // Create strikes out of order to prove the sweep walks them ascending.
+        let id_high = OrderId::new();
+        chain
+            .get_or_create_strike(51000)
+            .call()
+            .add_limit_order_with_tif(id_high, Side::Buy, 100, 1, TimeInForce::Gtd(GTD_EXPIRED))
+            .expect("add high strike gtd");
+        let id_low = OrderId::new();
+        chain
+            .get_or_create_strike(50000)
+            .put()
+            .add_limit_order_with_tif(id_low, Side::Buy, 90, 1, TimeInForce::Gtd(GTD_EXPIRED))
+            .expect("add low strike gtd");
+        // A GTC survivor the sweep must not touch.
+        chain
+            .get_or_create_strike(50000)
+            .put()
+            .add_limit_order(OrderId::new(), Side::Sell, 130, 2)
+            .expect("add gtc survivor");
+
+        let result = chain.evict_expired_orders(TimestampMs::new(GTD_EXPIRED));
+
+        assert_eq!(result.books_affected(), 2);
+        assert_eq!(result.total_evicted(), 2);
+
+        // Strikes are keyed and walked in ascending price order (50000 then
+        // 51000), so the low-strike put eviction precedes the high-strike call.
+        let flat: Vec<OrderId> = result
+            .per_child
+            .iter()
+            .flat_map(|(_, strike)| strike.per_book.iter())
+            .flat_map(|(_, ids)| ids.iter().copied())
+            .collect();
+        assert_eq!(flat, vec![id_low, id_high]);
     }
 
     // ── OptionChainOrderBook accessor coverage ───────────────────────────

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -3,7 +3,7 @@
 //! This module provides the [`ExpirationOrderBook`] and [`ExpirationOrderBookManager`]
 //! for managing all expirations for a single underlying asset.
 
-use super::chain::{ChainMassCancelResult, OptionChainOrderBook};
+use super::chain::{ChainEvictExpiredResult, ChainMassCancelResult, OptionChainOrderBook};
 use super::contract_specs::ContractSpecs;
 use super::expiration_key::ExpirationKey;
 use super::instrument_registry::InstrumentRegistry;
@@ -16,7 +16,7 @@ use crate::utils::checked_accumulate;
 use crossbeam_skiplist::SkipMap;
 use optionstratlib::ExpirationDate;
 use orderbook_rs::{FeeSchedule, OrderId, OrderStatus, STPMode, Side};
-use pricelevel::Hash32;
+use pricelevel::{Hash32, TimestampMs};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -375,6 +375,54 @@ impl ExpirationOrderBook {
         Ok(ExpirationMassCancelResult {
             per_child: vec![(self.expiration.to_string(), result)],
         })
+    }
+
+    /// Evicts expired `GTD` / `DAY` orders across this expiration's chain.
+    ///
+    /// # Description
+    ///
+    /// Runs the host-driven expiry sweep across the expiration's chain and
+    /// returns the aggregated result. `now_ms` is a caller-supplied
+    /// Unix-milliseconds cutoff; the sweep reads no clock, so it is a pure
+    /// function of `now_ms` and the resting books and replays identically. The
+    /// chain is walked in ascending strike order and each leaf book in the
+    /// engine's deterministic eviction order — the same traversal
+    /// [`cancel_all`](Self::cancel_all) uses.
+    ///
+    /// Expiry is realized only when the sweep runs: an order past its deadline
+    /// that has not yet been swept still rests and remains matchable.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ms` - Caller-supplied Unix-milliseconds cutoff.
+    ///
+    /// # Returns
+    ///
+    /// An [`ExpirationEvictExpiredResult`] containing per-chain results plus
+    /// aggregated counts (books, orders).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::ExpirationOrderBook;
+    /// use option_chain_orderbook::TimestampMs;
+    /// use optionstratlib::ExpirationDate;
+    /// use optionstratlib::prelude::pos_or_panic;
+    ///
+    /// let book = ExpirationOrderBook::new("BTC", ExpirationDate::Days(pos_or_panic!(30.0)));
+    /// let result = book.evict_expired_orders(TimestampMs::new(10_000_000_000_000));
+    /// assert_eq!(result.total_evicted(), 0);
+    /// ```
+    pub fn evict_expired_orders(&self, now_ms: TimestampMs) -> ExpirationEvictExpiredResult {
+        let result = self.chain.evict_expired_orders(now_ms);
+
+        ExpirationEvictExpiredResult {
+            per_child: vec![(self.expiration.to_string(), result)],
+        }
     }
 
     // ── Order Lifecycle Queries ────────────────────────────────────────────
@@ -1135,6 +1183,102 @@ impl ExpirationMassCancelResult {
         self.per_child
             .iter()
             .map(|(_, result)| result.total_cancelled())
+            .sum()
+    }
+}
+
+/// Aggregated result of an expiry sweep across an expiration's chain.
+///
+/// The eviction analogue of [`ExpirationMassCancelResult`]: `per_child` carries
+/// the single per-chain [`ChainEvictExpiredResult`] keyed by expiration. The
+/// aggregate accessors report the leaf-contract-book unit, identical to the
+/// mass-cancel counterpart.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use option_chain_orderbook::orderbook::ExpirationEvictExpiredResult;
+///
+/// let result = ExpirationEvictExpiredResult { per_child: Vec::new() };
+/// assert_eq!(result.total_evicted(), 0);
+/// ```
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct ExpirationEvictExpiredResult {
+    /// Per-chain eviction results keyed by expiration.
+    pub per_child: Vec<(String, ChainEvictExpiredResult)>,
+}
+
+impl ExpirationEvictExpiredResult {
+    /// Returns the number of leaf option books with evicted orders.
+    ///
+    /// # Description
+    ///
+    /// Drills into each per-chain result and sums its affected leaf
+    /// [`OptionOrderBook`](super::book::OptionOrderBook)s (call/put contract
+    /// books). The unit is a leaf contract book — identical to the unit reported
+    /// at every other level — so results aggregate cleanly up the tree. This is
+    /// NOT a count of affected chains.
+    ///
+    /// # Arguments
+    ///
+    /// None.
+    ///
+    /// # Returns
+    ///
+    /// Number of leaf option books affected (call/put contract books).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::ExpirationEvictExpiredResult;
+    ///
+    /// let result = ExpirationEvictExpiredResult { per_child: Vec::new() };
+    /// assert_eq!(result.books_affected(), 0);
+    /// ```
+    #[must_use]
+    pub fn books_affected(&self) -> usize {
+        self.per_child
+            .iter()
+            .map(|(_, result)| result.books_affected())
+            .sum()
+    }
+
+    /// Returns the total number of evicted orders across the expiration.
+    ///
+    /// # Description
+    ///
+    /// Sums evicted orders across the expiration's chain.
+    ///
+    /// # Arguments
+    ///
+    /// None.
+    ///
+    /// # Returns
+    ///
+    /// Total evicted orders (orders).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::ExpirationEvictExpiredResult;
+    ///
+    /// let result = ExpirationEvictExpiredResult { per_child: Vec::new() };
+    /// assert_eq!(result.total_evicted(), 0);
+    /// ```
+    #[must_use]
+    pub fn total_evicted(&self) -> usize {
+        self.per_child
+            .iter()
+            .map(|(_, result)| result.total_evicted())
             .sum()
     }
 }

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -89,12 +89,13 @@ pub mod sequencer;
 // Re-export all public types
 pub use book::{OptionOrderBook, TerminalOrderSummary};
 pub use chain::{
-    ChainMassCancelResult, OptionChainOrderBook, OptionChainOrderBookManager, OptionChainStats,
+    ChainEvictExpiredResult, ChainMassCancelResult, OptionChainOrderBook,
+    OptionChainOrderBookManager, OptionChainStats,
 };
 pub use contract_specs::{ContractSpecs, ContractSpecsBuilder, ExerciseStyle, SettlementType};
 pub use expiration::{
-    ExpirationManagerStats, ExpirationMassCancelResult, ExpirationOrderBook,
-    ExpirationOrderBookManager,
+    ExpirationEvictExpiredResult, ExpirationManagerStats, ExpirationMassCancelResult,
+    ExpirationOrderBook, ExpirationOrderBookManager,
 };
 pub use expiry_cycle::{CycleRule, ExpiryCycleConfig};
 pub use expiry_lifecycle::{
@@ -118,13 +119,15 @@ pub use instrument_registry::{InstrumentInfo, InstrumentRegistry};
 pub use instrument_status::InstrumentStatus;
 pub use mark_price::{MarkPriceCalculator, MarkPriceConfig, MarkPriceConfigBuilder};
 pub use quote::{Quote, QuoteUpdate};
-pub use strike::{StrikeMassCancelResult, StrikeOrderBook, StrikeOrderBookManager};
+pub use strike::{
+    StrikeEvictExpiredResult, StrikeMassCancelResult, StrikeOrderBook, StrikeOrderBookManager,
+};
 pub use strike_generator::{CleanupResult, StrikeGenerator};
 pub use strike_range::{ExpiryType, StrikeRangeConfig, StrikeRangeConfigBuilder};
 pub use symbol_index::{SymbolIndex, SymbolRef};
 pub use underlying::{
-    GlobalMassCancelResult, GlobalStats, UnderlyingMassCancelResult, UnderlyingOrderBook,
-    UnderlyingOrderBookManager, UnderlyingStats,
+    GlobalEvictExpiredResult, GlobalMassCancelResult, GlobalStats, UnderlyingEvictExpiredResult,
+    UnderlyingMassCancelResult, UnderlyingOrderBook, UnderlyingOrderBookManager, UnderlyingStats,
 };
 pub use validation::ValidationConfig;
 

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -18,7 +18,7 @@ use crossbeam_skiplist::SkipMap;
 use optionstratlib::greeks::Greek;
 use optionstratlib::{ExpirationDate, OptionStyle};
 use orderbook_rs::{FeeSchedule, MassCancelResult, OrderId, OrderStatus, STPMode, Side};
-use pricelevel::Hash32;
+use pricelevel::{Hash32, TimestampMs};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
@@ -457,6 +457,64 @@ impl StrikeOrderBook {
         })
     }
 
+    /// Evicts expired `GTD` / `DAY` orders across the call and put books.
+    ///
+    /// # Description
+    ///
+    /// Runs the host-driven expiry sweep
+    /// ([`OptionOrderBook::evict_expired_orders`](super::book::OptionOrderBook::evict_expired_orders))
+    /// on the call book, then the put book, and returns the aggregated
+    /// per-book evicted identifiers. `now_ms` is a caller-supplied
+    /// Unix-milliseconds cutoff; the sweep reads no clock, so it is a pure
+    /// function of `now_ms` and the resting books and replays identically.
+    /// Within each leaf book the evicted ids follow the engine's deterministic
+    /// order (bids then asks, ascending price, oldest first within a level);
+    /// the two books are walked call-first, then put — the same order
+    /// [`cancel_all`](Self::cancel_all) uses.
+    ///
+    /// Expiry is realized only when the sweep runs: an order past its deadline
+    /// that has not yet been swept still rests and remains matchable.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ms` - Caller-supplied Unix-milliseconds cutoff.
+    ///
+    /// # Returns
+    ///
+    /// A [`StrikeEvictExpiredResult`] containing per-book evicted ids plus
+    /// aggregated counts (books, orders).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::StrikeOrderBook;
+    /// use option_chain_orderbook::TimestampMs;
+    /// use optionstratlib::ExpirationDate;
+    /// use optionstratlib::prelude::pos_or_panic;
+    ///
+    /// let strike = StrikeOrderBook::new("BTC", ExpirationDate::Days(pos_or_panic!(30.0)), 50000);
+    /// let result = strike.evict_expired_orders(TimestampMs::new(10_000_000_000_000));
+    /// assert_eq!(result.total_evicted(), 0);
+    /// ```
+    pub fn evict_expired_orders(&self, now_ms: TimestampMs) -> StrikeEvictExpiredResult {
+        StrikeEvictExpiredResult {
+            per_book: vec![
+                (
+                    self.call.symbol().to_string(),
+                    self.call.evict_expired_orders(now_ms),
+                ),
+                (
+                    self.put.symbol().to_string(),
+                    self.put.evict_expired_orders(now_ms),
+                ),
+            ],
+        }
+    }
+
     // ── Order Lifecycle Queries ────────────────────────────────────────────
 
     /// Finds an order anywhere in this strike's call or put book.
@@ -745,6 +803,100 @@ impl StrikeMassCancelResult {
             .iter()
             .map(|(_, result)| result.cancelled_count())
             .sum()
+    }
+}
+
+/// Aggregated result of an expiry sweep across a strike's call and put books.
+///
+/// The eviction analogue of [`StrikeMassCancelResult`]: `per_book` carries the
+/// evicted order identifiers for each leaf option book (in the engine's
+/// deterministic eviction order), and the aggregate accessors report the same
+/// leaf-contract-book unit used everywhere else in the hierarchy.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use option_chain_orderbook::orderbook::StrikeEvictExpiredResult;
+///
+/// let result = StrikeEvictExpiredResult { per_book: Vec::new() };
+/// assert_eq!(result.total_evicted(), 0);
+/// ```
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct StrikeEvictExpiredResult {
+    /// Per-option-book evicted order identifiers keyed by option symbol.
+    pub per_book: Vec<(String, Vec<OrderId>)>,
+}
+
+impl StrikeEvictExpiredResult {
+    /// Returns the number of leaf option books with evicted orders.
+    ///
+    /// # Description
+    ///
+    /// Counts how many leaf [`OptionOrderBook`]s
+    /// (call/put contract books) evicted at least one order. This is the leaf
+    /// base case of `books_affected`: every higher level drills down and sums
+    /// these, so the unit is a leaf contract book at every level and the counts
+    /// aggregate cleanly up the tree — identical semantics to
+    /// [`StrikeMassCancelResult::books_affected`].
+    ///
+    /// # Arguments
+    ///
+    /// None.
+    ///
+    /// # Returns
+    ///
+    /// Number of leaf option books affected (call/put contract books).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::StrikeEvictExpiredResult;
+    ///
+    /// let result = StrikeEvictExpiredResult { per_book: Vec::new() };
+    /// assert_eq!(result.books_affected(), 0);
+    /// ```
+    #[must_use]
+    pub fn books_affected(&self) -> usize {
+        self.per_book
+            .iter()
+            .filter(|(_, ids)| !ids.is_empty())
+            .count()
+    }
+
+    /// Returns the total number of evicted orders across call and put books.
+    ///
+    /// # Description
+    ///
+    /// Sums evicted orders across every option book for this strike.
+    ///
+    /// # Arguments
+    ///
+    /// None.
+    ///
+    /// # Returns
+    ///
+    /// Total evicted orders (orders).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::StrikeEvictExpiredResult;
+    ///
+    /// let result = StrikeEvictExpiredResult { per_book: Vec::new() };
+    /// assert_eq!(result.total_evicted(), 0);
+    /// ```
+    #[must_use]
+    pub fn total_evicted(&self) -> usize {
+        self.per_book.iter().map(|(_, ids)| ids.len()).sum()
     }
 }
 
@@ -2414,5 +2566,49 @@ mod tests {
         thread::sleep(Duration::from_millis(10));
         let purged = strike.purge_terminal_states(Duration::from_millis(1));
         assert_eq!(purged, 2);
+    }
+
+    #[test]
+    fn test_strike_evict_expired_orders_aggregates_call_and_put() {
+        use orderbook_rs::TimeInForce;
+        // Far-future GTD deadline so admission (wall clock) accepts it while the
+        // caller-driven sweep controls expiry.
+        const GTD_EXPIRED: u64 = 10_000_000_000_000;
+        let strike = StrikeOrderBook::new("BTC", test_expiration(), 50000);
+
+        let call_gtd = OrderId::new();
+        let put_gtd = OrderId::new();
+        // A GTC survivor on the call leg that the sweep must not touch.
+        strike
+            .call()
+            .add_limit_order(OrderId::new(), Side::Sell, 105, 3)
+            .expect("add call gtc");
+        strike
+            .call()
+            .add_limit_order_with_tif(call_gtd, Side::Buy, 100, 10, TimeInForce::Gtd(GTD_EXPIRED))
+            .expect("add call gtd");
+        strike
+            .put()
+            .add_limit_order_with_tif(put_gtd, Side::Buy, 90, 5, TimeInForce::Gtd(GTD_EXPIRED))
+            .expect("add put gtd");
+
+        let result = strike.evict_expired_orders(TimestampMs::new(GTD_EXPIRED));
+
+        // Both leaf books contributed one eviction each; the unit is the leaf
+        // contract book.
+        assert_eq!(result.per_book.len(), 2);
+        assert_eq!(result.books_affected(), 2);
+        assert_eq!(result.total_evicted(), 2);
+
+        // per_book is call-first then put, keyed by option symbol, and each
+        // leaf's ids come back in the engine's deterministic order.
+        assert_eq!(result.per_book[0].0, strike.call().symbol());
+        assert_eq!(result.per_book[0].1, vec![call_gtd]);
+        assert_eq!(result.per_book[1].0, strike.put().symbol());
+        assert_eq!(result.per_book[1].1, vec![put_gtd]);
+
+        // GTC survivor untouched; expired GTDs gone.
+        assert_eq!(strike.call().order_count(), 1);
+        assert_eq!(strike.put().order_count(), 0);
     }
 }

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -5,7 +5,8 @@
 
 use super::contract_specs::ContractSpecs;
 use super::expiration::{
-    ExpirationMassCancelResult, ExpirationOrderBook, ExpirationOrderBookManager, SubtreeStats,
+    ExpirationEvictExpiredResult, ExpirationMassCancelResult, ExpirationOrderBook,
+    ExpirationOrderBookManager, SubtreeStats,
 };
 use super::expiry_cycle::ExpiryCycleConfig;
 use super::index_feed::IndexPriceFeed;
@@ -19,7 +20,7 @@ use crate::utils::checked_accumulate;
 use crossbeam_skiplist::SkipMap;
 use optionstratlib::ExpirationDate;
 use orderbook_rs::{FeeSchedule, OrderId, OrderStatus, STPMode, Side};
-use pricelevel::Hash32;
+use pricelevel::{Hash32, TimestampMs};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -169,6 +170,103 @@ impl UnderlyingMassCancelResult {
         self.per_child
             .iter()
             .map(|(_, result)| result.total_cancelled())
+            .sum()
+    }
+}
+
+/// Aggregated result of an expiry sweep across an underlying's expirations.
+///
+/// The eviction analogue of [`UnderlyingMassCancelResult`]: `per_child` carries
+/// the per-expiration [`ExpirationEvictExpiredResult`] keyed by expiration, in
+/// the manager's deterministic order. The aggregate accessors report the
+/// leaf-contract-book unit, identical to the mass-cancel counterpart.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use option_chain_orderbook::orderbook::UnderlyingEvictExpiredResult;
+///
+/// let result = UnderlyingEvictExpiredResult { per_child: Vec::new() };
+/// assert_eq!(result.total_evicted(), 0);
+/// ```
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct UnderlyingEvictExpiredResult {
+    /// Per-expiration eviction results keyed by expiration.
+    pub per_child: Vec<(String, ExpirationEvictExpiredResult)>,
+}
+
+impl UnderlyingEvictExpiredResult {
+    /// Returns the number of leaf option books with evicted orders.
+    ///
+    /// # Description
+    ///
+    /// Drills into each per-expiration result and sums its affected leaf
+    /// [`OptionOrderBook`](super::book::OptionOrderBook)s (call/put contract
+    /// books). The unit is a leaf contract book — identical to the unit reported
+    /// at every other level — so results aggregate cleanly up the tree and match
+    /// the same count read at the expiration / global levels. This is NOT a count
+    /// of affected expirations.
+    ///
+    /// # Arguments
+    ///
+    /// None.
+    ///
+    /// # Returns
+    ///
+    /// Number of leaf option books affected (call/put contract books).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::UnderlyingEvictExpiredResult;
+    ///
+    /// let result = UnderlyingEvictExpiredResult { per_child: Vec::new() };
+    /// assert_eq!(result.books_affected(), 0);
+    /// ```
+    #[must_use]
+    pub fn books_affected(&self) -> usize {
+        self.per_child
+            .iter()
+            .map(|(_, result)| result.books_affected())
+            .sum()
+    }
+
+    /// Returns the total number of evicted orders across the underlying.
+    ///
+    /// # Description
+    ///
+    /// Sums evicted orders across every expiration for this underlying.
+    ///
+    /// # Arguments
+    ///
+    /// None.
+    ///
+    /// # Returns
+    ///
+    /// Total evicted orders (orders).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::UnderlyingEvictExpiredResult;
+    ///
+    /// let result = UnderlyingEvictExpiredResult { per_child: Vec::new() };
+    /// assert_eq!(result.total_evicted(), 0);
+    /// ```
+    #[must_use]
+    pub fn total_evicted(&self) -> usize {
+        self.per_child
+            .iter()
+            .map(|(_, result)| result.total_evicted())
             .sum()
     }
 }
@@ -734,6 +832,58 @@ impl UnderlyingOrderBook {
         }
 
         Ok(UnderlyingMassCancelResult { per_child })
+    }
+
+    /// Evicts expired `GTD` / `DAY` orders across every expiration.
+    ///
+    /// # Description
+    ///
+    /// Runs the host-driven expiry sweep across all expirations for this
+    /// underlying and returns the aggregated per-expiration results. `now_ms`
+    /// is a caller-supplied Unix-milliseconds cutoff; the sweep reads no clock,
+    /// so it is a pure function of `now_ms` and the resting books and replays
+    /// identically. Expirations are walked in the manager's deterministic
+    /// expiration-key order (the same order
+    /// [`cancel_all`](Self::cancel_all) uses), each chain in ascending
+    /// strike order, and each leaf book in the engine's deterministic eviction
+    /// order.
+    ///
+    /// Expiry is realized only when the sweep runs: an order past its deadline
+    /// that has not yet been swept still rests and remains matchable.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ms` - Caller-supplied Unix-milliseconds cutoff.
+    ///
+    /// # Returns
+    ///
+    /// An [`UnderlyingEvictExpiredResult`] containing per-expiration results
+    /// plus aggregated counts (books, orders).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::UnderlyingOrderBook;
+    /// use option_chain_orderbook::TimestampMs;
+    ///
+    /// let book = UnderlyingOrderBook::new("BTC");
+    /// let result = book.evict_expired_orders(TimestampMs::new(10_000_000_000_000));
+    /// assert_eq!(result.total_evicted(), 0);
+    /// ```
+    pub fn evict_expired_orders(&self, now_ms: TimestampMs) -> UnderlyingEvictExpiredResult {
+        let mut per_child = Vec::with_capacity(self.expirations.len());
+
+        for (expiration, book) in self.expirations.iter() {
+            let expiration_key = expiration.to_string();
+            let result = book.evict_expired_orders(now_ms);
+            per_child.push((expiration_key, result));
+        }
+
+        UnderlyingEvictExpiredResult { per_child }
     }
 
     // ── Order Lifecycle Queries ────────────────────────────────────────────
@@ -1365,6 +1515,66 @@ impl UnderlyingOrderBookManager {
         Ok(GlobalMassCancelResult { per_child })
     }
 
+    /// Evicts expired `GTD` / `DAY` orders across every underlying.
+    ///
+    /// # Description
+    ///
+    /// Runs the host-driven expiry sweep across the entire hierarchy — every
+    /// underlying, expiration, strike, and leaf book — and returns the
+    /// aggregated per-underlying results. This is the wrapper analogue of the
+    /// engine's manager-level
+    /// [`BookManagerStd::evict_expired_across_books`](orderbook_rs::orderbook::manager::BookManagerStd::evict_expired_across_books),
+    /// projected onto the option hierarchy. `now_ms` is a caller-supplied
+    /// Unix-milliseconds cutoff; the sweep reads no clock, so it is a pure
+    /// function of `now_ms` and the resting books and replays identically.
+    /// Underlyings are walked in ascending symbol order (the `SkipMap`'s natural
+    /// key order — the same order
+    /// [`cancel_all_across_underlyings`](Self::cancel_all_across_underlyings)
+    /// uses); each subtree is walked in its own documented deterministic order.
+    /// Complexity is O(U × E × S) where U is the number of underlyings, E
+    /// expirations per underlying, and S strikes per expiration.
+    ///
+    /// Expiry is realized only when the sweep runs: an order past its deadline
+    /// that has not yet been swept still rests and remains matchable.
+    ///
+    /// # Arguments
+    ///
+    /// * `now_ms` - Caller-supplied Unix-milliseconds cutoff.
+    ///
+    /// # Returns
+    ///
+    /// A [`GlobalEvictExpiredResult`] containing per-underlying results plus
+    /// aggregated counts (books, orders).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::UnderlyingOrderBookManager;
+    /// use option_chain_orderbook::TimestampMs;
+    ///
+    /// let manager = UnderlyingOrderBookManager::new();
+    /// let result = manager.evict_expired_across_underlyings(TimestampMs::new(10_000_000_000_000));
+    /// assert_eq!(result.total_evicted(), 0);
+    /// ```
+    pub fn evict_expired_across_underlyings(
+        &self,
+        now_ms: TimestampMs,
+    ) -> GlobalEvictExpiredResult {
+        let mut per_child = Vec::with_capacity(self.underlyings.len());
+
+        for entry in self.underlyings.iter() {
+            let underlying_key = entry.key().clone();
+            let result = entry.value().evict_expired_orders(now_ms);
+            per_child.push((underlying_key, result));
+        }
+
+        GlobalEvictExpiredResult { per_child }
+    }
+
     // ── Order Lifecycle Queries ────────────────────────────────────────────
 
     /// Finds an order anywhere across all underlyings.
@@ -1718,6 +1928,103 @@ impl GlobalMassCancelResult {
     }
 }
 
+/// Aggregated result of an expiry sweep across every underlying in the system.
+///
+/// The eviction analogue of [`GlobalMassCancelResult`]: `per_child` carries the
+/// per-underlying [`UnderlyingEvictExpiredResult`] keyed by underlying symbol,
+/// in ascending symbol order. The aggregate accessors report the
+/// leaf-contract-book unit, identical to the mass-cancel counterpart.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use option_chain_orderbook::orderbook::GlobalEvictExpiredResult;
+///
+/// let result = GlobalEvictExpiredResult { per_child: Vec::new() };
+/// assert_eq!(result.total_evicted(), 0);
+/// ```
+#[derive(Debug, Clone)]
+#[must_use]
+pub struct GlobalEvictExpiredResult {
+    /// Per-underlying eviction results keyed by underlying symbol.
+    pub per_child: Vec<(String, UnderlyingEvictExpiredResult)>,
+}
+
+impl GlobalEvictExpiredResult {
+    /// Returns the number of leaf option books with evicted orders.
+    ///
+    /// # Description
+    ///
+    /// Drills into each per-underlying result and sums its affected leaf
+    /// [`OptionOrderBook`](super::book::OptionOrderBook)s (call/put contract
+    /// books). The unit is a leaf contract book — identical to the unit reported
+    /// at every other level — so the global total equals the sum of the
+    /// per-underlying / per-expiration / per-chain leaf counts. This is NOT a
+    /// count of affected underlyings.
+    ///
+    /// # Arguments
+    ///
+    /// None.
+    ///
+    /// # Returns
+    ///
+    /// Number of leaf option books affected (call/put contract books).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::GlobalEvictExpiredResult;
+    ///
+    /// let result = GlobalEvictExpiredResult { per_child: Vec::new() };
+    /// assert_eq!(result.books_affected(), 0);
+    /// ```
+    #[must_use]
+    pub fn books_affected(&self) -> usize {
+        self.per_child
+            .iter()
+            .map(|(_, result)| result.books_affected())
+            .sum()
+    }
+
+    /// Returns the total number of evicted orders across all underlyings.
+    ///
+    /// # Description
+    ///
+    /// Sums evicted orders across every underlying in the hierarchy.
+    ///
+    /// # Arguments
+    ///
+    /// None.
+    ///
+    /// # Returns
+    ///
+    /// Total evicted orders (orders).
+    ///
+    /// # Errors
+    ///
+    /// None.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use option_chain_orderbook::orderbook::GlobalEvictExpiredResult;
+    ///
+    /// let result = GlobalEvictExpiredResult { per_child: Vec::new() };
+    /// assert_eq!(result.total_evicted(), 0);
+    /// ```
+    #[must_use]
+    pub fn total_evicted(&self) -> usize {
+        self.per_child
+            .iter()
+            .map(|(_, result)| result.total_evicted())
+            .sum()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1827,6 +2134,139 @@ mod tests {
             .cancel_all_across_underlyings()
             .expect("global cancel");
         assert_eq!(global_result.books_affected(), expected);
+    }
+
+    #[test]
+    fn test_evict_expired_orders_aggregates_across_the_tree() {
+        use orderbook_rs::TimeInForce;
+        // Far-future GTD deadlines so admission (wall clock) accepts them while
+        // the caller-driven sweep controls expiry.
+        const GTD_EXPIRED: u64 = 10_000_000_000_000;
+        const GTD_LATER: u64 = 20_000_000_000_000;
+        let exp_a = test_expiration();
+        let exp_b = ExpirationDate::Days(pos_or_panic!(60.0));
+
+        let book = UnderlyingOrderBook::new("BTC");
+
+        // exp_a / strike 50000: call GTD (evicts) + a GTC survivor on the call.
+        let a_call = book
+            .get_or_create_expiration(exp_a)
+            .get_or_create_strike(50000);
+        let id_a_call = OrderId::new();
+        a_call
+            .call()
+            .add_limit_order_with_tif(id_a_call, Side::Buy, 100, 10, TimeInForce::Gtd(GTD_EXPIRED))
+            .expect("add a call gtd");
+        a_call
+            .call()
+            .add_limit_order(OrderId::new(), Side::Sell, 120, 3)
+            .expect("add a call gtc");
+
+        // exp_a / strike 51000: put GTD (evicts) + a later GTD survivor on the put.
+        let a_put = book
+            .get_or_create_expiration(exp_a)
+            .get_or_create_strike(51000);
+        let id_a_put = OrderId::new();
+        a_put
+            .put()
+            .add_limit_order_with_tif(id_a_put, Side::Buy, 90, 5, TimeInForce::Gtd(GTD_EXPIRED))
+            .expect("add a put gtd");
+        a_put
+            .put()
+            .add_limit_order_with_tif(
+                OrderId::new(),
+                Side::Buy,
+                80,
+                2,
+                TimeInForce::Gtd(GTD_LATER),
+            )
+            .expect("add a put later gtd");
+
+        // exp_b / strike 52000: call GTD (evicts).
+        let b_call = book
+            .get_or_create_expiration(exp_b)
+            .get_or_create_strike(52000);
+        let id_b_call = OrderId::new();
+        b_call
+            .call()
+            .add_limit_order_with_tif(id_b_call, Side::Buy, 70, 1, TimeInForce::Gtd(GTD_EXPIRED))
+            .expect("add b call gtd");
+
+        assert_eq!(book.total_order_count(), 5);
+
+        // Sweep the whole underlying at the cutoff.
+        let result = book.evict_expired_orders(TimestampMs::new(GTD_EXPIRED));
+
+        // Three leaf books contributed one eviction each; the later GTD and the
+        // GTC survivor are untouched.
+        assert_eq!(result.books_affected(), 3);
+        assert_eq!(result.total_evicted(), 3);
+        assert_eq!(book.total_order_count(), 2);
+
+        // Flattening the tree in walk order yields the evicted ids in the fixed
+        // deterministic order: expirations ascending (exp_a before exp_b),
+        // strikes ascending within a chain (50000 before 51000), call-before-put
+        // within a strike.
+        let flat: Vec<OrderId> = result
+            .per_child
+            .iter()
+            .flat_map(|(_, exp)| exp.per_child.iter())
+            .flat_map(|(_, chain)| chain.per_child.iter())
+            .flat_map(|(_, strike)| strike.per_book.iter())
+            .flat_map(|(_, ids)| ids.iter().copied())
+            .collect();
+        assert_eq!(flat, vec![id_a_call, id_a_put, id_b_call]);
+
+        // Idempotent: a second sweep at the same instant evicts nothing.
+        let again = book.evict_expired_orders(TimestampMs::new(GTD_EXPIRED));
+        assert_eq!(again.total_evicted(), 0);
+        assert_eq!(again.books_affected(), 0);
+    }
+
+    #[test]
+    fn test_evict_expired_across_underlyings_aggregates_and_is_deterministic() {
+        use orderbook_rs::TimeInForce;
+        const GTD_EXPIRED: u64 = 10_000_000_000_000;
+
+        let manager = UnderlyingOrderBookManager::new();
+
+        // Two underlyings, each with one expiring GTD on a leaf book. Insert ETH
+        // before BTC to prove the walk order is by symbol, not insertion.
+        let eth = manager.get_or_create("ETH");
+        let id_eth = OrderId::new();
+        eth.get_or_create_expiration(test_expiration())
+            .get_or_create_strike(3000)
+            .call()
+            .add_limit_order_with_tif(id_eth, Side::Buy, 100, 1, TimeInForce::Gtd(GTD_EXPIRED))
+            .expect("add eth gtd");
+
+        let btc = manager.get_or_create("BTC");
+        let id_btc = OrderId::new();
+        btc.get_or_create_expiration(test_expiration())
+            .get_or_create_strike(50000)
+            .put()
+            .add_limit_order_with_tif(id_btc, Side::Buy, 90, 1, TimeInForce::Gtd(GTD_EXPIRED))
+            .expect("add btc gtd");
+
+        let result = manager.evict_expired_across_underlyings(TimestampMs::new(GTD_EXPIRED));
+
+        assert_eq!(result.books_affected(), 2);
+        assert_eq!(result.total_evicted(), 2);
+
+        // Underlyings are keyed and ordered by symbol (BTC before ETH).
+        let keys: Vec<&str> = result.per_child.iter().map(|(k, _)| k.as_str()).collect();
+        assert_eq!(keys, vec!["BTC", "ETH"]);
+
+        let flat: Vec<OrderId> = result
+            .per_child
+            .iter()
+            .flat_map(|(_, u)| u.per_child.iter())
+            .flat_map(|(_, exp)| exp.per_child.iter())
+            .flat_map(|(_, chain)| chain.per_child.iter())
+            .flat_map(|(_, strike)| strike.per_book.iter())
+            .flat_map(|(_, ids)| ids.iter().copied())
+            .collect();
+        assert_eq!(flat, vec![id_btc, id_eth]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #141. Surfaces the engine's host-driven GTD/DAY expiry sweep (orderbook-rs 0.10) at every wrapper level. Additive-only; version stays **0.6.1** (ships together with #140's fix in one release).

### API
- Leaf: `OptionOrderBook::evict_expired_orders(now_ms: TimestampMs) -> Vec<OrderId>` — narrows the engine's `Vec<Arc<OrderType>>` to ids, mirroring `expire()`'s id-centric shape.
- Aggregations mirror `*MassCancelResult` exactly: `Strike/Chain/Expiration/Underlying EvictExpiredResult` + `evict_expired_across_underlyings -> GlobalEvictExpiredResult`, each with `books_affected()` / `total_evicted()`, deterministic tree walk (call-then-put, strikes ascending, expirations by key, underlyings by symbol).
- Infallible (the upstream sweep never errors — the `Result` wrapper of mass-cancel aggregations is not needed).

### Sequencer decision
NOT journaled in `OptionChainCommand`: it's exhaustive + `#[serde(deny_unknown_fields)]` — a new variant is a breaking change that fails this release's additive-only gate. Deferred to 0.7.0 as #144. The engine journals sweeps at its own layer (`SequencerCommand::EvictExpiredOrders`).

### Docs
Every new pub item: caller-supplied Unix-ms cutoff (no clock read), inclusive boundary, deterministic order, honest caveat (expired-but-unswept orders remain matchable until the sweep).

### Tests
8 new: leaf inclusive-boundary/idempotency/deterministic order/empty book; strike call+put aggregation; chain ascending-strike walk; underlying + global multi-book sweeps with per-child ordering.

## Gates
`cargo test --all-features`: 818 lib + 27 integration + 110 doctests, 0 failed. clippy `-D warnings` clean. `make pre-push` pass. `cargo semver-checks`: 196 pass — additive-only, no breaking findings.

Closes #141.