### PR TITLE
Serialize sequencer submissions and thread an injectable clock (#147)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,17 @@ matching engine itself is `orderbook-rs`. On top of that engine it provides:
 - **Mark price is a derived, non-journaled value.** It is computed from
   current inputs and is not part of the `sequencer` journal; replay
   reconstructs order-book state, not historical mark prices.
+- **Trade IDs are not replay-stable.** The upstream engine mints each
+  book's trade-ID namespace with a random `Uuid::new_v4()` and exposes no
+  injection seam, so trade IDs differ between a live run and its replay
+  even on identical command streams; the replay oracle compares book
+  state and excludes trade IDs (tracked upstream as OrderBook-rs#199).
+- **Time-in-force replay determinism requires an injected clock.** `GTD` /
+  `Day` admission is decided by each leaf's engine clock. Inject a
+  deterministic clock (e.g. [`orderbook::StubClock`]) via the hierarchy's
+  `set_clock` before the first order, and configure the replaying instance
+  with an identically-behaving clock; otherwise leaves stamp and admit
+  against the wall clock.
 - **Pricing inputs are supplied by the integrator.** The crate ships only a
   trivial [`orderbook::FlatVolSurface`] and mock / static index feeds
   ([`orderbook::MockPriceFeed`], [`orderbook::StaticPriceFeed`]); a

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -324,7 +324,7 @@ pub use error::{Error, Result};
 // from `orderbook_rs` / `pricelevel`.
 pub use orderbook::{
     AggregatedGreeks, CancelReason, ChainEvictExpiredResult, ChainMassCancelResult, CleanupResult,
-    ContractSpecs, ContractSpecsBuilder, CycleRule, ExerciseStyle, ExpirationCallback,
+    Clock, ContractSpecs, ContractSpecsBuilder, CycleRule, ExerciseStyle, ExpirationCallback,
     ExpirationEvictExpiredResult, ExpirationManagerStats, ExpirationMassCancelResult,
     ExpirationOrderBook, ExpirationOrderBookManager, ExpiryCycleConfig, ExpiryLifecycleManager,
     ExpiryScheduler, ExpiryType, FeeSchedule, FlatVolSurface, GlobalEvictExpiredResult,
@@ -332,15 +332,15 @@ pub use orderbook::{
     GreeksUpdate, GreeksUpdateListener, Hash32, IndexPriceFeed, InstrumentInfo, InstrumentRegistry,
     InstrumentStatus, LifecycleConfig, LifecycleEvent, LifecycleListener, LifecycleResult,
     MarkPriceCalculator, MarkPriceConfig, MarkPriceConfigBuilder, MassCancelResult, MockPriceFeed,
-    OptionChainOrderBook, OptionChainOrderBookManager, OptionChainStats, OptionOrderBook, OrderId,
-    OrderStateTracker, OrderStatus, OrderType, Position, Price, PriceUpdate, PriceUpdateListener,
-    Quantity, Quote, QuoteUpdate, RefreshResult, STPMode, SettlementType, Side, StaticPriceFeed,
-    StrikeEvictExpiredResult, StrikeGenerator, StrikeMassCancelResult, StrikeOrderBook,
-    StrikeOrderBookManager, StrikeRangeConfig, StrikeRangeConfigBuilder, SubscriptionId,
-    SymbolIndex, SymbolRef, TerminalOrderSummary, TimeInForce, TimestampMs, TradeResult,
-    UnderlyingEvictExpiredResult, UnderlyingMassCancelResult, UnderlyingOrderBook,
-    UnderlyingOrderBookManager, UnderlyingStats, ValidationConfig, VolSurface, calculate_tte_years,
-    wire_feed_to_calculator,
+    MonotonicClock, OptionChainOrderBook, OptionChainOrderBookManager, OptionChainStats,
+    OptionOrderBook, OrderId, OrderStateTracker, OrderStatus, OrderType, Position, Price,
+    PriceUpdate, PriceUpdateListener, Quantity, Quote, QuoteUpdate, RefreshResult, STPMode,
+    SettlementType, Side, StaticPriceFeed, StrikeEvictExpiredResult, StrikeGenerator,
+    StrikeMassCancelResult, StrikeOrderBook, StrikeOrderBookManager, StrikeRangeConfig,
+    StrikeRangeConfigBuilder, StubClock, SubscriptionId, SymbolIndex, SymbolRef,
+    TerminalOrderSummary, TimeInForce, TimestampMs, TradeResult, UnderlyingEvictExpiredResult,
+    UnderlyingMassCancelResult, UnderlyingOrderBook, UnderlyingOrderBookManager, UnderlyingStats,
+    ValidationConfig, VolSurface, calculate_tte_years, wire_feed_to_calculator,
 };
 
 #[cfg(feature = "nats")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,6 +152,17 @@
 //! - **Mark price is a derived, non-journaled value.** It is computed from
 //!   current inputs and is not part of the `sequencer` journal; replay
 //!   reconstructs order-book state, not historical mark prices.
+//! - **Trade IDs are not replay-stable.** The upstream engine mints each
+//!   book's trade-ID namespace with a random `Uuid::new_v4()` and exposes no
+//!   injection seam, so trade IDs differ between a live run and its replay
+//!   even on identical command streams; the replay oracle compares book
+//!   state and excludes trade IDs (tracked upstream as OrderBook-rs#199).
+//! - **Time-in-force replay determinism requires an injected clock.** `GTD` /
+//!   `Day` admission is decided by each leaf's engine clock. Inject a
+//!   deterministic clock (e.g. [`orderbook::StubClock`]) via the hierarchy's
+//!   `set_clock` before the first order, and configure the replaying instance
+//!   with an identically-behaving clock; otherwise leaves stamp and admit
+//!   against the wall clock.
 //! - **Pricing inputs are supplied by the integrator.** The crate ships only a
 //!   trivial [`orderbook::FlatVolSurface`] and mock / static index feeds
 //!   ([`orderbook::MockPriceFeed`], [`orderbook::StaticPriceFeed`]); a

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -12,8 +12,8 @@ use optionstratlib::OptionStyle;
 #[cfg(feature = "nats")]
 use orderbook_rs::PriceLevelChangedListener;
 use orderbook_rs::{
-    DefaultOrderBook, FeeSchedule, MassCancelResult, OrderBookSnapshot, OrderId, OrderStateTracker,
-    OrderStatus, STPMode, Side, TimeInForce, TradeListener, TradeResult,
+    Clock, DefaultOrderBook, FeeSchedule, MassCancelResult, OrderBookSnapshot, OrderId,
+    OrderStateTracker, OrderStatus, STPMode, Side, TimeInForce, TradeListener, TradeResult,
 };
 use pricelevel::{Hash32, MatchResult, Price, Quantity, TimestampMs};
 use std::collections::hash_map::DefaultHasher;
@@ -146,6 +146,12 @@ pub(crate) struct BookConfig {
     /// due to status recording. For extreme low-latency scenarios where every
     /// microsecond matters, set this to `false` to disable tracking entirely.
     pub enable_state_tracking: bool,
+    /// Engine clock installed on the inner book before it is frozen in `Arc`.
+    ///
+    /// `None` keeps the upstream default `MonotonicClock` (wall-clock time).
+    /// Inject a deterministic clock (e.g. `StubClock`) to make time-in-force
+    /// admission (`GTD`/`Day`) reproducible for sequencer replay.
+    pub clock: Option<Arc<dyn Clock>>,
     /// Pre-built NATS publisher listeners installed before the inner book is
     /// wrapped in `Arc` (feature `nats`). `None` for every non-NATS path.
     #[cfg(feature = "nats")]
@@ -159,7 +165,8 @@ impl std::fmt::Debug for BookConfig {
             .field("validation", &self.validation)
             .field("stp_mode", &self.stp_mode)
             .field("fee_schedule", &self.fee_schedule)
-            .field("enable_state_tracking", &self.enable_state_tracking);
+            .field("enable_state_tracking", &self.enable_state_tracking)
+            .field("clock", &self.clock);
         // The NATS listeners are boxed closures and carry no `Debug`; surface
         // only whether they are present so the impl stays informative.
         #[cfg(feature = "nats")]
@@ -176,6 +183,7 @@ impl Default for BookConfig {
             stp_mode: STPMode::None,
             fee_schedule: None,
             enable_state_tracking: true,
+            clock: None,
             #[cfg(feature = "nats")]
             nats_listeners: None,
         }
@@ -361,6 +369,13 @@ impl OptionOrderBook {
         }
         if let Some(schedule) = config.fee_schedule {
             book.set_fee_schedule(Some(schedule));
+        }
+        // Install the injected engine clock (if any) while the book is still
+        // owned mutably, before it is frozen in `Arc`. This works for both
+        // constructor branches above (STP and non-STP). `None` keeps the
+        // upstream default `MonotonicClock`.
+        if let Some(clock) = config.clock.clone() {
+            book.set_clock(clock);
         }
 
         // Install the continuous-capture listener backing the opt-in
@@ -3385,6 +3400,70 @@ mod tests {
         );
     }
 
+    // A GTD deadline (Unix ms) that a fresh `StubClock` near 0 sees as still in
+    // the future (admitted), while the wall-clock `MonotonicClock` — in the year
+    // 2026, ~1.7e12 ms — sees as long expired (rejected on admission).
+    const GTD_ADMIT_DEADLINE: u64 = 10_000;
+
+    #[test]
+    fn test_book_config_clock_applies_to_both_ctor_branches() {
+        use orderbook_rs::StubClock;
+
+        // For each STP branch of `new_with_config` (None takes the plain `new`
+        // ctor, non-None takes `with_stp_mode`), an injected `StubClock` must
+        // admit a GTD order whose deadline is only "future" relative to the
+        // stub, and the control without a clock must reject it against the wall
+        // clock. A non-zero user id is supplied so the STP branch does not
+        // reject on `MissingUserId` before the TIF admission check runs.
+        let user = Hash32::from([9u8; 32]);
+        for stp in [STPMode::None, STPMode::CancelTaker] {
+            let with_clock = OptionOrderBook::new_with_config(
+                "BTC-20240329-50000-C",
+                OptionStyle::Call,
+                BookConfig {
+                    stp_mode: stp,
+                    clock: Some(Arc::new(StubClock::new()) as Arc<dyn Clock>),
+                    ..BookConfig::default()
+                },
+            );
+            let admitted = with_clock.add_limit_order_with_tif_and_user(
+                OrderId::new(),
+                Side::Buy,
+                100,
+                10,
+                TimeInForce::Gtd(GTD_ADMIT_DEADLINE),
+                user,
+            );
+            assert!(
+                admitted.is_ok(),
+                "GTD order should be admitted under the injected StubClock (stp={stp:?}): {admitted:?}"
+            );
+            assert_eq!(with_clock.order_count(), 1);
+
+            let without_clock = OptionOrderBook::new_with_config(
+                "BTC-20240329-50000-C",
+                OptionStyle::Call,
+                BookConfig {
+                    stp_mode: stp,
+                    ..BookConfig::default()
+                },
+            );
+            let rejected = without_clock.add_limit_order_with_tif_and_user(
+                OrderId::new(),
+                Side::Buy,
+                100,
+                10,
+                TimeInForce::Gtd(GTD_ADMIT_DEADLINE),
+                user,
+            );
+            assert!(
+                rejected.is_err(),
+                "GTD order should be rejected under the default wall clock (stp={stp:?})"
+            );
+            assert_eq!(without_clock.order_count(), 0);
+        }
+    }
+
     #[test]
     fn test_add_limit_order_with_user() {
         let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
@@ -3557,6 +3636,7 @@ mod tests {
                 stp_mode: STPMode::CancelTaker,
                 fee_schedule: Some(schedule),
                 enable_state_tracking: true,
+                clock: None,
                 #[cfg(feature = "nats")]
                 nats_listeners: None,
             },

--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -254,6 +254,16 @@ impl OptionChainOrderBook {
         self.strikes.set_clock(clock);
     }
 
+    /// Clears the injected engine clock, so future option books fall back to
+    /// the upstream default `MonotonicClock`.
+    ///
+    /// Delegates to the underlying [`StrikeOrderBookManager::clear_clock`].
+    /// Existing books are not affected.
+    #[inline]
+    pub fn clear_clock(&self) {
+        self.strikes.clear_clock();
+    }
+
     /// Returns the current engine clock, or `None` when future books use the
     /// upstream default `MonotonicClock`.
     #[must_use]

--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -15,7 +15,7 @@ use super::validation::ValidationConfig;
 use crate::error::{Error, Result};
 use crossbeam_skiplist::SkipMap;
 use optionstratlib::ExpirationDate;
-use orderbook_rs::{FeeSchedule, OrderId, OrderStatus, STPMode, Side};
+use orderbook_rs::{Clock, FeeSchedule, OrderId, OrderStatus, STPMode, Side};
 use pricelevel::{Hash32, TimestampMs};
 use std::sync::Arc;
 use std::time::Duration;
@@ -243,6 +243,23 @@ impl OptionChainOrderBook {
     #[inline]
     pub fn fee_schedule(&self) -> Option<FeeSchedule> {
         self.strikes.fee_schedule()
+    }
+
+    /// Sets the engine clock for all future option books created within this chain.
+    ///
+    /// Delegates to the underlying [`StrikeOrderBookManager::set_clock`].
+    /// Existing books are not affected.
+    #[inline]
+    pub fn set_clock(&self, clock: Arc<dyn Clock>) {
+        self.strikes.set_clock(clock);
+    }
+
+    /// Returns the current engine clock, or `None` when future books use the
+    /// upstream default `MonotonicClock`.
+    #[must_use]
+    #[inline]
+    pub fn clock(&self) -> Option<Arc<dyn Clock>> {
+        self.strikes.clock()
     }
 
     /// Propagates the per-contract NATS listener factory down to the strike
@@ -906,6 +923,10 @@ pub struct OptionChainOrderBookManager {
     stp_mode: Shared<STPMode>,
     /// Fee schedule propagated to newly created chains.
     fee_schedule: Shared<Option<FeeSchedule>>,
+    /// Engine clock propagated to newly created chains. `None` keeps the
+    /// upstream default `MonotonicClock`; a shared `Arc<dyn Clock>` makes
+    /// time-in-force admission deterministic for replay.
+    clock: Shared<Option<Arc<dyn Clock>>>,
 }
 
 impl OptionChainOrderBookManager {
@@ -925,6 +946,7 @@ impl OptionChainOrderBookManager {
             symbol_index: None,
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
         }
     }
 
@@ -952,6 +974,7 @@ impl OptionChainOrderBookManager {
             symbol_index: None,
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
         }
     }
 
@@ -988,6 +1011,7 @@ impl OptionChainOrderBookManager {
             symbol_index: Some(symbol_index),
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
         }
     }
 
@@ -1060,6 +1084,37 @@ impl OptionChainOrderBookManager {
         self.fee_schedule.get()
     }
 
+    /// Sets the engine clock for all future chains created by this manager.
+    ///
+    /// Existing chains are not affected. Only newly created chains via
+    /// [`get_or_create`](Self::get_or_create) will have this clock propagated
+    /// down to their strike manager. The `Arc<dyn Clock>` is shared, not
+    /// deep-cloned, so every future option book stamps orders from the same
+    /// clock — inject a `StubClock` to make time-in-force admission
+    /// deterministic for replay.
+    #[inline]
+    pub fn set_clock(&self, clock: Arc<dyn Clock>) {
+        self.clock.set(Some(clock));
+    }
+
+    /// Clears the engine clock so future chains use the upstream default
+    /// `MonotonicClock` (wall-clock time).
+    ///
+    /// Existing chains are not affected. Only newly created chains via
+    /// [`get_or_create`](Self::get_or_create) will be affected.
+    #[inline]
+    pub fn clear_clock(&self) {
+        self.clock.set(None);
+    }
+
+    /// Returns the current engine clock, or `None` when future chains use the
+    /// upstream default `MonotonicClock`.
+    #[must_use]
+    #[inline]
+    pub fn clock(&self) -> Option<Arc<dyn Clock>> {
+        self.clock.get()
+    }
+
     /// Returns the underlying asset symbol.
     #[must_use]
     pub fn underlying(&self) -> &str {
@@ -1128,6 +1183,9 @@ impl OptionChainOrderBookManager {
         }
         if let Some(schedule) = self.fee_schedule.get() {
             fresh.set_fee_schedule(schedule);
+        }
+        if let Some(clock) = self.clock.get() {
+            fresh.set_clock(clock);
         }
         // Atomic, idempotent publish: first inserter wins and is never evicted.
         let entry = self.chains.get_or_insert(key, fresh);

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -246,6 +246,16 @@ impl ExpirationOrderBook {
         self.chain.set_clock(clock);
     }
 
+    /// Clears the injected engine clock, so future option books fall back to
+    /// the upstream default `MonotonicClock`.
+    ///
+    /// Delegates to the underlying [`OptionChainOrderBook::clear_clock`].
+    /// Existing books are not affected.
+    #[inline]
+    pub fn clear_clock(&self) {
+        self.chain.clear_clock();
+    }
+
     /// Returns the current engine clock, or `None` when future books use the
     /// upstream default `MonotonicClock`.
     #[must_use]

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -15,7 +15,7 @@ use crate::error::{Error, Result};
 use crate::utils::checked_accumulate;
 use crossbeam_skiplist::SkipMap;
 use optionstratlib::ExpirationDate;
-use orderbook_rs::{FeeSchedule, OrderId, OrderStatus, STPMode, Side};
+use orderbook_rs::{Clock, FeeSchedule, OrderId, OrderStatus, STPMode, Side};
 use pricelevel::{Hash32, TimestampMs};
 use std::sync::Arc;
 use std::time::Duration;
@@ -235,6 +235,23 @@ impl ExpirationOrderBook {
     #[inline]
     pub fn fee_schedule(&self) -> Option<FeeSchedule> {
         self.chain.fee_schedule()
+    }
+
+    /// Sets the engine clock for all future option books created within this expiration.
+    ///
+    /// Delegates to the underlying [`OptionChainOrderBook::set_clock`].
+    /// Existing books are not affected.
+    #[inline]
+    pub fn set_clock(&self, clock: Arc<dyn Clock>) {
+        self.chain.set_clock(clock);
+    }
+
+    /// Returns the current engine clock, or `None` when future books use the
+    /// upstream default `MonotonicClock`.
+    #[must_use]
+    #[inline]
+    pub fn clock(&self) -> Option<Arc<dyn Clock>> {
+        self.chain.clock()
     }
 
     /// Propagates the per-contract NATS listener factory down to this
@@ -626,6 +643,10 @@ pub struct ExpirationOrderBookManager {
     stp_mode: Shared<STPMode>,
     /// Fee schedule propagated to newly created expiration books.
     fee_schedule: Shared<Option<FeeSchedule>>,
+    /// Engine clock propagated to newly created expiration books. `None` keeps
+    /// the upstream default `MonotonicClock`; a shared `Arc<dyn Clock>` makes
+    /// time-in-force admission deterministic for replay.
+    clock: Shared<Option<Arc<dyn Clock>>>,
     /// Per-contract NATS listener factory propagated to newly created
     /// expiration books (and onward to their strikes). `None` (the default)
     /// reproduces the non-NATS path exactly.
@@ -650,6 +671,7 @@ impl ExpirationOrderBookManager {
             symbol_index: None,
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -679,6 +701,7 @@ impl ExpirationOrderBookManager {
             symbol_index: None,
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -706,6 +729,7 @@ impl ExpirationOrderBookManager {
             symbol_index: Some(symbol_index),
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -778,6 +802,37 @@ impl ExpirationOrderBookManager {
     #[inline]
     pub fn fee_schedule(&self) -> Option<FeeSchedule> {
         self.fee_schedule.get()
+    }
+
+    /// Sets the engine clock for all future expiration books created by this manager.
+    ///
+    /// Existing books are not affected. Only newly created books via
+    /// [`get_or_create`](Self::get_or_create) will have this clock propagated
+    /// down to their chains and strikes. The `Arc<dyn Clock>` is shared, not
+    /// deep-cloned, so every future option book stamps orders from the same
+    /// clock — inject a `StubClock` to make time-in-force admission
+    /// deterministic for replay.
+    #[inline]
+    pub fn set_clock(&self, clock: Arc<dyn Clock>) {
+        self.clock.set(Some(clock));
+    }
+
+    /// Clears the engine clock so future expiration books use the upstream
+    /// default `MonotonicClock` (wall-clock time).
+    ///
+    /// Existing books are not affected. Only newly created books via
+    /// [`get_or_create`](Self::get_or_create) will be affected.
+    #[inline]
+    pub fn clear_clock(&self) {
+        self.clock.set(None);
+    }
+
+    /// Returns the current engine clock, or `None` when future books use the
+    /// upstream default `MonotonicClock`.
+    #[must_use]
+    #[inline]
+    pub fn clock(&self) -> Option<Arc<dyn Clock>> {
+        self.clock.get()
     }
 
     /// Stores the per-contract NATS listener factory propagated from the top of
@@ -891,6 +946,9 @@ impl ExpirationOrderBookManager {
         }
         if let Some(schedule) = self.fee_schedule.get() {
             fresh.set_fee_schedule(schedule);
+        }
+        if let Some(clock) = self.clock.get() {
+            fresh.set_clock(clock);
         }
         // Propagate the per-contract NATS factory down to the fresh chain/strike
         // manager BEFORE publishing, so the configured-before-visible invariant

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -150,7 +150,7 @@ pub use sequencer::{
 // are re-exported here so downstream consumers need no direct `orderbook_rs` /
 // `pricelevel` dependency to use this crate's public surface.
 pub use orderbook_rs::{
-    CancelReason, FeeSchedule, MassCancelResult, OrderId, OrderStateTracker, OrderStatus,
-    OrderType, STPMode, Side, TimeInForce, TradeResult,
+    CancelReason, Clock, FeeSchedule, MassCancelResult, MonotonicClock, OrderId, OrderStateTracker,
+    OrderStatus, OrderType, STPMode, Side, StubClock, TimeInForce, TradeResult,
 };
 pub use pricelevel::{Hash32, Price, Quantity, TimestampMs};

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -835,8 +835,21 @@ impl SequencedUnderlyingOrderBook {
     /// [`StubClock`](orderbook_rs::StubClock) constructed with the same
     /// start and step as the live instance — before its journal prefix is
     /// replayed. The `Arc<dyn Clock>` is shared, not deep-cloned.
+    ///
+    /// This call takes the same serialization gate as
+    /// [`submit`](Self::submit), so it is linearized against the sequenced
+    /// command stream: every command either fully precedes or fully follows
+    /// the clock change, and which clock a lazily vivified leaf receives is
+    /// well-defined relative to the journal order. Note that until the
+    /// journaled `AddOrder` command carries a time-in-force (tracked in
+    /// issue #148), `Gtc` is hardcoded on the sequenced add path and the
+    /// injected clock affects only order timestamps — not admission — for
+    /// commands flowing through `submit`.
     #[inline]
     pub fn set_clock(&self, clock: Arc<dyn Clock>) {
+        // Linearize the config change against submit/replay so a racing
+        // command deterministically sees either the old or the new clock.
+        let _serialized = self.sequencer.acquire_gate();
         self.inner.set_clock(clock);
     }
 
@@ -1582,6 +1595,14 @@ impl SequencedUnderlyingOrderBook {
     /// section. A submit therefore never observes a half-rebuilt hierarchy, and
     /// replay never races the sequence advance. Never call `submit` from within
     /// `replay` or vice versa (both take the same gate, which would deadlock).
+    ///
+    /// The gate guarantees safety, not reproducibility, for replays on a live
+    /// instance: replaying into a book that already holds state or is
+    /// concurrently receiving submits is well-formed but yields an outcome
+    /// that depends on where the replay lands in the submit stream. The
+    /// deterministic contract — the one the replay-equals-live oracle tests —
+    /// is replaying a journal prefix into a *fresh*, identically-configured
+    /// (and identically-clocked) instance.
     ///
     /// Each event's command is re-executed against the underlying order book.
     /// Replay re-runs the `AddOrder` / `CancelOrder` / `MassCancel` stream

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -13,6 +13,26 @@
 //! - Parallel operation across different underlyings
 //! - Isolated failure domains
 //!
+//! # Ordering & atomicity
+//!
+//! Within a single [`SequencedUnderlyingOrderBook`], submissions are internally
+//! serialized. Each [`submit`](SequencedUnderlyingOrderBook::submit) holds a
+//! per-sequencer gate across the whole assign→execute→journal-append sequence,
+//! so concurrent callers are safe but serialized: sequence assignment, book
+//! mutation, and journal append happen as one indivisible step. This is what
+//! makes journal insertion order equal to sequence order equal to book-mutation
+//! order — a property replay relies on. Because the journal append happens
+//! *inside* the critical section, the [`OptionChainJournal`] contract is that
+//! `append` must be fast: a slow or blocking journal serializes every
+//! submission on that underlying.
+//!
+//! [`replay`](SequencedUnderlyingOrderBook::replay) takes the same gate, so a
+//! rebuild cannot interleave with a live submit. Deadlock analysis: there is no
+//! `submit`↔`replay` nesting (neither calls the other), and the lock order is
+//! always gate → journal-internal lock (never the reverse), so the gate cannot
+//! deadlock against the journal. `execute_command` must never acquire the gate,
+//! since it runs while the gate is already held.
+//!
 //! # Feature Gate
 //!
 //! This module is only available when the `sequencer` feature is enabled:
@@ -33,8 +53,8 @@ use optionstratlib::{ExpirationDate, OptionStyle};
 use orderbook_rs::{OrderId, Side};
 use pricelevel::{Hash32, TimestampMs};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 /// Scope for mass cancel operations in the option chain hierarchy.
 ///
@@ -484,6 +504,8 @@ pub(crate) struct OptionChainSequencer {
     success_count: AtomicU64,
     /// Count of rejected commands.
     reject_count: AtomicU64,
+    /// Serializes the assign→execute→journal-append critical section.
+    gate: Mutex<()>,
 }
 
 impl OptionChainSequencer {
@@ -494,6 +516,7 @@ impl OptionChainSequencer {
             sequence: AtomicU64::new(0),
             success_count: AtomicU64::new(0),
             reject_count: AtomicU64::new(0),
+            gate: Mutex::new(()),
         }
     }
 
@@ -507,6 +530,7 @@ impl OptionChainSequencer {
             sequence: AtomicU64::new(start),
             success_count: AtomicU64::new(0),
             reject_count: AtomicU64::new(0),
+            gate: Mutex::new(()),
         }
     }
 
@@ -551,6 +575,35 @@ impl OptionChainSequencer {
     #[inline]
     pub fn record_reject(&self) {
         self.reject_count.fetch_add(1, Ordering::Release);
+    }
+
+    /// Acquires the serialization gate for the assign→execute→journal-append
+    /// critical section.
+    ///
+    /// The returned guard serializes concurrent submissions so that sequence
+    /// assignment, book mutation, and journal append happen as one indivisible
+    /// step; releasing the guard (dropping it) ends the critical section.
+    /// Recovers from a poisoned lock via
+    /// `unwrap_or_else(|poisoned| poisoned.into_inner())`, matching the
+    /// poison-recovery policy used across the hierarchy (see
+    /// [`Shared`](crate::orderbook::shared)), so a panic while another thread
+    /// held the gate never wedges the sequencer.
+    pub fn acquire_gate(&self) -> MutexGuard<'_, ()> {
+        self.gate
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
+    /// Advances the sequence counter so the next assigned number is at least
+    /// `next`, without ever moving it backwards.
+    ///
+    /// Encapsulates the `fetch_max` used on the replay-resume path so callers
+    /// (e.g. [`SequencedUnderlyingOrderBook::replay`]) do not reach into the
+    /// private `sequence` field directly. Advancing past the highest replayed
+    /// sequence number keeps subsequently assigned ids non-conflicting.
+    #[inline]
+    pub fn advance_to(&self, next: u64) {
+        self.sequence.fetch_max(next, Ordering::Release);
     }
 }
 
@@ -790,10 +843,26 @@ impl SequencedUnderlyingOrderBook {
     /// against the underlying order book, and optionally persisted to the
     /// journal.
     ///
+    /// # Ordering & atomicity
+    ///
+    /// Submissions are internally serialized: sequence assignment, book
+    /// mutation, and journal append run inside a single critical section held
+    /// for the duration of this call. Concurrent callers are therefore safe but
+    /// serialized — one submission completes fully before the next begins. As a
+    /// result, journal insertion order equals sequence order equals
+    /// book-mutation order: the event journaled at sequence `n` was applied to
+    /// the books strictly before the event at sequence `n + 1`.
+    ///
     /// # Errors
     ///
     /// Returns an error if journaling fails.
     pub fn submit(&self, command: OptionChainCommand) -> Result<OptionChainReceipt, Error> {
+        // Hold the gate for the whole assign→execute→journal-append sequence so
+        // concurrent submissions cannot interleave and so the journal is
+        // appended in sequence order. Released when `_serialized` drops on
+        // return.
+        let _serialized = self.sequencer.acquire_gate();
+
         let (seq, ts) = self.sequencer.assign();
         let result = self.execute_command(&command);
 
@@ -1471,6 +1540,16 @@ impl SequencedUnderlyingOrderBook {
     /// Replays events from the journal starting at `from_sequence`, rebuilding
     /// the hierarchy state deterministically.
     ///
+    /// # Ordering & atomicity
+    ///
+    /// Replay acquires the same serialization gate that
+    /// [`submit`](Self::submit) holds, so a replay and a concurrent live
+    /// submission cannot interleave: the whole rebuild — re-executing every
+    /// command and advancing the sequence counter — runs as one critical
+    /// section. A submit therefore never observes a half-rebuilt hierarchy, and
+    /// replay never races the sequence advance. Never call `submit` from within
+    /// `replay` or vice versa (both take the same gate, which would deadlock).
+    ///
     /// Each event's command is re-executed against the underlying order book.
     /// Replay re-runs the `AddOrder` / `CancelOrder` / `MassCancel` stream
     /// exactly as it was recorded: every `AddOrder` deterministically vivifies
@@ -1539,6 +1618,13 @@ impl SequencedUnderlyingOrderBook {
             .as_ref()
             .ok_or_else(|| Error::journal_error("replay requires a journal"))?;
 
+        // Hold the same gate `submit` uses so a replay cannot interleave with a
+        // concurrent live submission: the rebuild runs as one critical section
+        // and no submit can observe a half-rebuilt hierarchy or race the
+        // sequence advance. Acquired after the journal-presence check so a
+        // journal-less book fails fast without taking the gate.
+        let _serialized = self.sequencer.acquire_gate();
+
         let events = journal.read_from(from_sequence)?;
         let count = events.len();
 
@@ -1563,9 +1649,7 @@ impl SequencedUnderlyingOrderBook {
         // Advance sequencer past the replayed range in a single atomic
         // operation instead of one fetch_max per event.
         if max_next > 0 {
-            self.sequencer
-                .sequence
-                .fetch_max(max_next, Ordering::Release);
+            self.sequencer.advance_to(max_next);
         }
 
         Ok(count)
@@ -3554,5 +3638,92 @@ mod tests {
 
         assert!(book.registry().is_some());
         assert!(book.symbol_index().is_some());
+    }
+
+    #[test]
+    fn test_replay_serialized_against_concurrent_submits_no_deadlock() {
+        use std::sync::Barrier;
+        use std::thread;
+
+        // A journal pre-populated by a first live run: replaying it must be
+        // able to run concurrently with fresh submits on a second book without
+        // deadlocking, because submit and replay share the same gate but never
+        // nest.
+        let seed_journal: Arc<dyn OptionChainJournal> = Arc::new(InMemoryOptionChainJournal::new());
+        let seed = SequencedUnderlyingOrderBook::with_journal("BTC", Arc::clone(&seed_journal));
+        for i in 0..20u64 {
+            seed.submit_add_order(
+                "BTC-20240329-50000-C",
+                OrderId::from_u64(1 + i),
+                Side::Buy,
+                100 + u128::from(i),
+                10,
+            )
+            .expect("seed submit");
+        }
+        let seed_events = seed_journal.read_from(0).expect("read seed");
+        assert_eq!(seed_events.len(), 20);
+
+        // The book under test carries the seeded events in a fresh journal so
+        // the replaying thread has something to rebuild while the other thread
+        // submits new commands.
+        let replay_journal: Arc<dyn OptionChainJournal> =
+            Arc::new(InMemoryOptionChainJournal::new());
+        for event in &seed_events {
+            replay_journal.append(event).expect("append seed");
+        }
+        let book = Arc::new(SequencedUnderlyingOrderBook::with_journal(
+            "BTC",
+            Arc::clone(&replay_journal),
+        ));
+
+        // Lockstep start so the replay and the submits genuinely contend for
+        // the gate rather than running one-after-the-other.
+        let barrier = Arc::new(Barrier::new(2));
+
+        let replay_book = Arc::clone(&book);
+        let replay_barrier = Arc::clone(&barrier);
+        let replayer = thread::spawn(move || {
+            replay_barrier.wait();
+            replay_book.replay(0).expect("replay")
+        });
+
+        let submit_book = Arc::clone(&book);
+        let submit_barrier = Arc::clone(&barrier);
+        let submitter = thread::spawn(move || {
+            submit_barrier.wait();
+            for i in 0..20u64 {
+                submit_book
+                    .submit_add_order(
+                        "BTC-20240329-55000-C",
+                        OrderId::from_u64(1_000 + i),
+                        Side::Sell,
+                        200 + u128::from(i),
+                        5,
+                    )
+                    .expect("live submit");
+            }
+        });
+
+        // Both threads must complete; a deadlock would hang the join forever.
+        let replayed = replayer.join().expect("replayer thread");
+        submitter.join().expect("submitter thread");
+
+        // Replay and submit share one journal, and replay reads it atomically
+        // under the gate: it sees the 20 seeded events plus however many of the
+        // 20 live submits had already been appended when it acquired the gate.
+        // So the replayed count lands in [20, 40] depending on interleaving.
+        assert!(
+            (20..=40).contains(&replayed),
+            "replay must return between the seeded count and seeded+submits, got {replayed}"
+        );
+        // The 20 live submits each `fetch_add(1)` unconditionally, so the
+        // sequence has advanced by at least 20 regardless of how replay's
+        // `fetch_max` interleaves with them (which can only raise it).
+        assert!(
+            book.current_sequence() >= 20,
+            "sequence must advance past the live submits, got {}",
+            book.current_sequence()
+        );
     }
 }

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -50,7 +50,7 @@ use crate::orderbook::symbol_index::SymbolIndex;
 use crate::orderbook::underlying::UnderlyingOrderBook;
 use crate::utils::{SymbolParser, nanos_since_epoch};
 use optionstratlib::{ExpirationDate, OptionStyle};
-use orderbook_rs::{OrderId, Side};
+use orderbook_rs::{Clock, OrderId, Side};
 use pricelevel::{Hash32, TimestampMs};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -805,6 +805,26 @@ impl SequencedUnderlyingOrderBook {
     #[inline]
     pub fn symbol_index(&self) -> Option<&Arc<SymbolIndex>> {
         self.inner.symbol_index()
+    }
+
+    /// Injects the engine clock used to stamp orders on every leaf book the
+    /// hierarchy vivifies from later commands.
+    ///
+    /// Delegates to [`UnderlyingOrderBook::set_clock`], so the clock is
+    /// propagated to expirations, chains, and strikes created *after* this
+    /// call. Set it BEFORE the first [`submit`](Self::submit) for full
+    /// determinism: leaves vivified by earlier commands keep whatever clock
+    /// they were built with (the upstream default `MonotonicClock` when none
+    /// was injected).
+    ///
+    /// For byte-identical replay, the replaying instance must be configured
+    /// with an identically-behaving clock — e.g. a fresh
+    /// [`StubClock`](orderbook_rs::StubClock) constructed with the same
+    /// start and step as the live instance — before its journal prefix is
+    /// replayed. The `Arc<dyn Clock>` is shared, not deep-cloned.
+    #[inline]
+    pub fn set_clock(&self, clock: Arc<dyn Clock>) {
+        self.inner.set_clock(clock);
     }
 
     /// Returns the current sequence number.

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -33,6 +33,19 @@
 //! deadlock against the journal. `execute_command` must never acquire the gate,
 //! since it runs while the gate is already held.
 //!
+//! # Known limitation — trade-ID determinism
+//!
+//! The upstream `orderbook_rs::OrderBook` mints its trade/transaction-ID
+//! namespace internally with a random `Uuid::new_v4()` at construction, and
+//! offers no injection seam. Trade IDs therefore differ between a live run and
+//! its replay even when the command stream, the injected
+//! [`Clock`](orderbook_rs::Clock), and the matching are identical. The replay
+//! oracle intentionally compares order-book *state* (resting orders,
+//! top-of-book, instrument status) and excludes trade IDs. Tracked upstream as
+//! [OrderBook-rs#199](https://github.com/joaquinbejar/OrderBook-rs/issues/199);
+//! once a namespace seam ships, the hierarchy will thread a deterministic
+//! namespace alongside the clock.
+//!
 //! # Feature Gate
 //!
 //! This module is only available when the `sequencer` feature is enabled:

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -17,7 +17,7 @@ use crate::utils::{checked_accumulate, format_expiration_yyyymmdd};
 use crossbeam_skiplist::SkipMap;
 use optionstratlib::greeks::Greek;
 use optionstratlib::{ExpirationDate, OptionStyle};
-use orderbook_rs::{FeeSchedule, MassCancelResult, OrderId, OrderStatus, STPMode, Side};
+use orderbook_rs::{Clock, FeeSchedule, MassCancelResult, OrderId, OrderStatus, STPMode, Side};
 use pricelevel::{Hash32, TimestampMs};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -923,6 +923,10 @@ pub struct StrikeOrderBookManager {
     stp_mode: Shared<STPMode>,
     /// Fee schedule applied to newly created option books.
     fee_schedule: Shared<Option<FeeSchedule>>,
+    /// Engine clock applied to newly created option books. `None` keeps the
+    /// upstream default `MonotonicClock`; a shared `Arc<dyn Clock>` (e.g.
+    /// `StubClock`) makes time-in-force admission deterministic for replay.
+    clock: Shared<Option<Arc<dyn Clock>>>,
     /// Per-contract NATS listener factory propagated from the top of the
     /// hierarchy. When present, each lazily created call/put book installs its
     /// own publishers pre-`Arc` in the [`get_or_create`](Self::get_or_create)
@@ -950,6 +954,7 @@ impl StrikeOrderBookManager {
             symbol_index: None,
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -981,6 +986,7 @@ impl StrikeOrderBookManager {
             symbol_index: None,
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -1011,6 +1017,7 @@ impl StrikeOrderBookManager {
             symbol_index: Some(symbol_index),
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -1091,6 +1098,37 @@ impl StrikeOrderBookManager {
     #[inline]
     pub fn fee_schedule(&self) -> Option<FeeSchedule> {
         self.fee_schedule.get()
+    }
+
+    /// Sets the engine clock for all future option books created by this manager.
+    ///
+    /// Applies to option books created *after* this call via
+    /// [`get_or_create`](Self::get_or_create); existing books are unaffected
+    /// (same semantics as fees / STP). The `Arc<dyn Clock>` is shared, not
+    /// deep-cloned, so every future book stamps orders from the same clock —
+    /// inject a `StubClock` to make time-in-force admission deterministic for
+    /// replay.
+    #[inline]
+    pub fn set_clock(&self, clock: Arc<dyn Clock>) {
+        self.clock.set(Some(clock));
+    }
+
+    /// Clears the engine clock so future option books use the upstream default
+    /// `MonotonicClock` (wall-clock time).
+    ///
+    /// Existing books are not affected. Only newly created books via
+    /// [`get_or_create`](Self::get_or_create) will be affected.
+    #[inline]
+    pub fn clear_clock(&self) {
+        self.clock.set(None);
+    }
+
+    /// Returns the current engine clock, or `None` when future books use the
+    /// upstream default `MonotonicClock`.
+    #[must_use]
+    #[inline]
+    pub fn clock(&self) -> Option<Arc<dyn Clock>> {
+        self.clock.get()
     }
 
     /// Stores the per-contract NATS listener factory propagated from the top of
@@ -1241,6 +1279,7 @@ impl StrikeOrderBookManager {
             validation: self.validation_config.get(),
             stp_mode: self.stp_mode.get(),
             fee_schedule: self.fee_schedule.get(),
+            clock: self.clock.get(),
             ..BookConfig::default()
         };
 
@@ -1368,6 +1407,7 @@ impl StrikeOrderBookManager {
             validation: self.validation_config.get(),
             stp_mode: self.stp_mode.get(),
             fee_schedule: self.fee_schedule.get(),
+            clock: self.clock.get(),
             nats_listeners: listeners,
             ..BookConfig::default()
         }
@@ -2610,5 +2650,73 @@ mod tests {
         // GTC survivor untouched; expired GTDs gone.
         assert_eq!(strike.call().order_count(), 1);
         assert_eq!(strike.put().order_count(), 0);
+    }
+
+    // A GTD deadline (Unix ms) a fresh `StubClock` near 0 admits, but the
+    // wall-clock default rejects on admission.
+    const GTD_ADMIT_DEADLINE: u64 = 10_000;
+
+    #[test]
+    fn test_strike_manager_set_clock_gtd_admission_uses_injected_clock() {
+        use orderbook_rs::{StubClock, TimeInForce};
+
+        let manager = StrikeOrderBookManager::new("BTC", test_expiration());
+        manager.set_clock(Arc::new(StubClock::new()) as Arc<dyn Clock>);
+
+        let strike = manager.get_or_create(50000);
+        let admitted = strike.call().add_limit_order_with_tif(
+            OrderId::new(),
+            Side::Buy,
+            100,
+            10,
+            TimeInForce::Gtd(GTD_ADMIT_DEADLINE),
+        );
+        assert!(
+            admitted.is_ok(),
+            "GTD order should be admitted under the injected StubClock: {admitted:?}"
+        );
+        assert_eq!(strike.call().order_count(), 1);
+    }
+
+    #[test]
+    fn test_strike_manager_set_clock_applies_only_to_future_books() {
+        use orderbook_rs::{StubClock, TimeInForce};
+
+        let manager = StrikeOrderBookManager::new("BTC", test_expiration());
+        // Book A is vivified BEFORE the clock is injected: it keeps the default
+        // wall clock and must reject the already-expired GTD.
+        let strike_a = manager.get_or_create(50000);
+
+        manager.set_clock(Arc::new(StubClock::new()) as Arc<dyn Clock>);
+
+        // Book B is vivified AFTER the injection: it stamps orders from the stub
+        // and must admit the same GTD.
+        let strike_b = manager.get_or_create(51000);
+
+        let rejected = strike_a.call().add_limit_order_with_tif(
+            OrderId::new(),
+            Side::Buy,
+            100,
+            10,
+            TimeInForce::Gtd(GTD_ADMIT_DEADLINE),
+        );
+        assert!(
+            rejected.is_err(),
+            "book created before set_clock keeps the wall clock and rejects the GTD"
+        );
+        assert_eq!(strike_a.call().order_count(), 0);
+
+        let admitted = strike_b.call().add_limit_order_with_tif(
+            OrderId::new(),
+            Side::Buy,
+            100,
+            10,
+            TimeInForce::Gtd(GTD_ADMIT_DEADLINE),
+        );
+        assert!(
+            admitted.is_ok(),
+            "book created after set_clock uses the stub and admits the GTD: {admitted:?}"
+        );
+        assert_eq!(strike_b.call().order_count(), 1);
     }
 }

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -19,7 +19,7 @@ use crate::error::{Error, Result};
 use crate::utils::checked_accumulate;
 use crossbeam_skiplist::SkipMap;
 use optionstratlib::ExpirationDate;
-use orderbook_rs::{FeeSchedule, OrderId, OrderStatus, STPMode, Side};
+use orderbook_rs::{Clock, FeeSchedule, OrderId, OrderStatus, STPMode, Side};
 use pricelevel::{Hash32, TimestampMs};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -455,6 +455,24 @@ impl UnderlyingOrderBook {
     #[inline]
     pub fn fee_schedule(&self) -> Option<FeeSchedule> {
         self.expirations.fee_schedule()
+    }
+
+    /// Sets the engine clock for future expirations created within this underlying.
+    ///
+    /// Delegates to [`ExpirationOrderBookManager::set_clock`]. Only expirations
+    /// created after this call inherit the clock; existing expirations and
+    /// their strikes are not affected.
+    #[inline]
+    pub fn set_clock(&self, clock: Arc<dyn Clock>) {
+        self.expirations.set_clock(clock);
+    }
+
+    /// Returns the current engine clock, or `None` when future books use the
+    /// upstream default `MonotonicClock`.
+    #[must_use]
+    #[inline]
+    pub fn clock(&self) -> Option<Arc<dyn Clock>> {
+        self.expirations.clock()
     }
 
     /// Propagates the per-contract NATS listener factory down to this
@@ -1106,6 +1124,10 @@ pub struct UnderlyingOrderBookManager {
     stp_mode: Shared<STPMode>,
     /// Fee schedule propagated to newly created underlying books.
     fee_schedule: Shared<Option<FeeSchedule>>,
+    /// Engine clock propagated to newly created underlying books. `None` keeps
+    /// the upstream default `MonotonicClock`; a shared `Arc<dyn Clock>` makes
+    /// time-in-force admission deterministic for replay.
+    clock: Shared<Option<Arc<dyn Clock>>>,
     /// Per-contract NATS listener factory propagated to every underlying book
     /// (and onward to its expirations and strikes). Configured via
     /// [`with_nats_factory`](UnderlyingOrderBookManager::with_nats_factory);
@@ -1134,6 +1156,7 @@ impl UnderlyingOrderBookManager {
             symbol_index: Arc::new(SymbolIndex::new()),
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -1156,6 +1179,7 @@ impl UnderlyingOrderBookManager {
             symbol_index: Arc::new(SymbolIndex::new()),
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
+            clock: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -1231,6 +1255,9 @@ impl UnderlyingOrderBookManager {
         if let Some(schedule) = self.fee_schedule.get() {
             fresh.set_fee_schedule(schedule);
         }
+        if let Some(clock) = self.clock.get() {
+            fresh.set_clock(clock);
+        }
         // Propagate the per-contract NATS factory down the fresh subtree BEFORE
         // publishing so it is configured-before-visible. Only when a factory is
         // configured, keeping the no-factory path identical.
@@ -1282,6 +1309,37 @@ impl UnderlyingOrderBookManager {
     #[inline]
     pub fn fee_schedule(&self) -> Option<FeeSchedule> {
         self.fee_schedule.get()
+    }
+
+    /// Sets the engine clock for all future underlying books created by this manager.
+    ///
+    /// Existing books are not affected. Only newly created books via
+    /// [`get_or_create`](Self::get_or_create) will have this clock propagated
+    /// down to their expirations, chains, and strikes. The `Arc<dyn Clock>` is
+    /// shared, not deep-cloned, so every future option book stamps orders from
+    /// the same clock — inject a `StubClock` to make time-in-force admission
+    /// deterministic for replay.
+    #[inline]
+    pub fn set_clock(&self, clock: Arc<dyn Clock>) {
+        self.clock.set(Some(clock));
+    }
+
+    /// Clears the engine clock so future underlying books use the upstream
+    /// default `MonotonicClock` (wall-clock time).
+    ///
+    /// Existing books are not affected. Only newly created books via
+    /// [`get_or_create`](Self::get_or_create) will be affected.
+    #[inline]
+    pub fn clear_clock(&self) {
+        self.clock.set(None);
+    }
+
+    /// Returns the current engine clock, or `None` when future books use the
+    /// upstream default `MonotonicClock`.
+    #[must_use]
+    #[inline]
+    pub fn clock(&self) -> Option<Arc<dyn Clock>> {
+        self.clock.get()
     }
 
     /// Returns a reference to the symbol index.
@@ -2134,6 +2192,38 @@ mod tests {
             .cancel_all_across_underlyings()
             .expect("global cancel");
         assert_eq!(global_result.books_affected(), expected);
+    }
+
+    #[test]
+    fn test_underlying_manager_set_clock_propagates_to_vivified_leaf() {
+        use orderbook_rs::{StubClock, TimeInForce};
+
+        // A GTD deadline (Unix ms) a fresh `StubClock` near 0 admits, but the
+        // wall-clock default rejects on admission.
+        const GTD_ADMIT_DEADLINE: u64 = 10_000;
+
+        let manager = UnderlyingOrderBookManager::new();
+        manager.set_clock(Arc::new(StubClock::new()) as Arc<dyn Clock>);
+
+        // Walk the full hierarchy the manager vivifies after the clock is set:
+        // underlying -> expiration -> chain -> strike -> leaf.
+        let leaf = manager
+            .get_or_create("BTC")
+            .get_or_create_expiration(test_expiration())
+            .get_or_create_strike(50000);
+
+        let admitted = leaf.call().add_limit_order_with_tif(
+            OrderId::new(),
+            Side::Buy,
+            100,
+            10,
+            TimeInForce::Gtd(GTD_ADMIT_DEADLINE),
+        );
+        assert!(
+            admitted.is_ok(),
+            "leaf vivified after manager.set_clock stamps orders from the stub and admits the GTD: {admitted:?}"
+        );
+        assert_eq!(leaf.call().order_count(), 1);
     }
 
     #[test]

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -467,6 +467,16 @@ impl UnderlyingOrderBook {
         self.expirations.set_clock(clock);
     }
 
+    /// Clears the injected engine clock, so future option books fall back to
+    /// the upstream default `MonotonicClock`.
+    ///
+    /// Delegates to [`ExpirationOrderBookManager::clear_clock`]. Existing
+    /// books are not affected.
+    #[inline]
+    pub fn clear_clock(&self) {
+        self.expirations.clear_clock();
+    }
+
     /// Returns the current engine clock, or `None` when future books use the
     /// upstream default `MonotonicClock`.
     #[must_use]

--- a/tests/unit/sequencer_tests.rs
+++ b/tests/unit/sequencer_tests.rs
@@ -551,3 +551,123 @@ fn test_replay_into_empty_book_then_resume_is_consistent() {
     // 10 rebuilt resting orders + 1 new.
     assert_eq!(resumed.total_order_count(), 11);
 }
+
+// ── Concurrent submit: gate ordering + replay-under-load oracle ─────────────
+
+/// Number of worker threads used by the concurrent-load helper.
+const CONCURRENT_THREADS: u64 = 8;
+/// Number of `AddOrder` commands each worker submits.
+const CONCURRENT_PER_THREAD: u64 = 25;
+
+/// Drives a concurrent `AddOrder` load through the sequencer.
+///
+/// Spawns [`CONCURRENT_THREADS`] workers that each submit
+/// [`CONCURRENT_PER_THREAD`] orders to a per-thread-distinct symbol, released in
+/// lockstep by a [`Barrier`](std::sync::Barrier) so the submissions genuinely
+/// contend for the sequencer gate rather than running one after another.
+/// Distinct strikes keep the workers from matching against each other, and the
+/// absolute `YYYYMMDD` date makes every derived symbol replay-stable. Returns
+/// the total number of commands submitted.
+fn drive_concurrent_add_load(book: &Arc<SequencedUnderlyingOrderBook>) -> usize {
+    use std::sync::Barrier;
+    use std::thread;
+
+    let barrier = Arc::new(Barrier::new(CONCURRENT_THREADS as usize));
+    let mut handles = Vec::with_capacity(CONCURRENT_THREADS as usize);
+    for t in 0..CONCURRENT_THREADS {
+        let book = Arc::clone(book);
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            let symbol = format!("BTC-20240329-{}-C", 50000 + t * 1000);
+            barrier.wait();
+            for i in 0..CONCURRENT_PER_THREAD {
+                // Order ids are offset by 1 so no worker ever submits id 0, and
+                // the per-thread 1000-stride keeps them globally distinct.
+                book.submit_add_order(
+                    &symbol,
+                    oid(1 + t * 1000 + i),
+                    Side::Buy,
+                    100 + u128::from(i),
+                    10,
+                )
+                .expect("concurrent add must succeed");
+            }
+        }));
+    }
+    for handle in handles {
+        handle.join().expect("worker thread must not panic");
+    }
+    (CONCURRENT_THREADS * CONCURRENT_PER_THREAD) as usize
+}
+
+#[test]
+fn test_submit_concurrent_journal_order_matches_sequence_order() {
+    // The submit gate serializes assign→execute→journal-append, so even under a
+    // concurrent load the journal is appended in sequence order.
+    let journal: Arc<dyn OptionChainJournal> = Arc::new(InMemoryOptionChainJournal::new());
+    let book = Arc::new(SequencedUnderlyingOrderBook::with_journal(
+        "BTC",
+        Arc::clone(&journal),
+    ));
+
+    let total = drive_concurrent_add_load(&book);
+    assert_eq!(total, 200);
+
+    // Journal insertion order equals sequence order: reading from 0 yields
+    // sequence numbers 0..200, strictly ascending by exactly +1, in the order
+    // they were appended.
+    let events = journal.read_from(0).expect("read journal");
+    assert_eq!(
+        events.len(),
+        200,
+        "every concurrent submit must be journaled exactly once"
+    );
+    for (index, event) in events.iter().enumerate() {
+        assert_eq!(
+            event.sequence_num, index as u64,
+            "journal entry at position {index} must carry sequence {index} \
+             (insertion order == sequence order)"
+        );
+    }
+
+    // Each submit records exactly one outcome (success or reject).
+    assert_eq!(
+        book.success_count() + book.reject_count(),
+        200,
+        "each of the 200 submits records exactly one outcome"
+    );
+}
+
+#[test]
+fn test_submit_concurrent_replay_equals_live_full_state_oracle() {
+    // Under a concurrent load the gate makes strike creation — and therefore
+    // registry-id allocation — happen in sequence order across threads, so
+    // replay (which re-runs the journal in that same order into a fresh book)
+    // rebuilds an identical hierarchy AND identical registry ids. This exercises
+    // the full-state oracle against a concurrently-produced journal.
+    let journal = Arc::new(InMemoryOptionChainJournal::new());
+
+    let live = Arc::new(fresh_book(&journal));
+    let submitted = drive_concurrent_add_load(&live);
+    assert_eq!(
+        journal.len(),
+        submitted,
+        "every concurrent command must be journaled"
+    );
+
+    let live_snapshot = snapshot(&live);
+
+    // Replay into a fresh, identically-configured book and compare.
+    let replay = fresh_book(&journal);
+    let replayed = replay.replay(0).expect("replay");
+    assert_eq!(
+        replayed, submitted,
+        "replay must re-run every journaled command"
+    );
+
+    assert_eq!(
+        live_snapshot,
+        snapshot(&replay),
+        "replayed state must equal live state after a concurrent load"
+    );
+}

--- a/tests/unit/sequencer_tests.rs
+++ b/tests/unit/sequencer_tests.rs
@@ -39,7 +39,7 @@ use option_chain_orderbook::orderbook::{
     MassCancelType, OptionChainJournal, OptionOrderBook, SequencedUnderlyingOrderBook, SymbolIndex,
 };
 use optionstratlib::OptionStyle;
-use orderbook_rs::{OrderId, Side};
+use orderbook_rs::{Clock, OrderId, Side, StubClock, TimeInForce};
 use std::sync::Arc;
 
 // ── Deterministic test inputs ──────────────────────────────────────────────
@@ -669,5 +669,98 @@ fn test_submit_concurrent_replay_equals_live_full_state_oracle() {
         live_snapshot,
         snapshot(&replay),
         "replayed state must equal live state after a concurrent load"
+    );
+}
+
+// ── Injected clock: leaf vivification + replay determinism ──────────────────
+
+// A GTD deadline (Unix ms) a fresh `StubClock` near 0 admits, but the wall-clock
+// default rejects on admission.
+const GTD_ADMIT_DEADLINE: u64 = 10_000;
+
+/// Resolves the call leaf for `symbol` inside a sequenced book, or `None` if the
+/// hierarchy has not vivified it yet.
+fn call_leaf(
+    book: &SequencedUnderlyingOrderBook,
+    symbol: &str,
+) -> Option<Arc<option_chain_orderbook::orderbook::StrikeOrderBook>> {
+    let parsed = SymbolParser::parse(symbol).expect("parse symbol");
+    let exp = book.underlying().get_expiration(parsed.expiration()).ok()?;
+    exp.get_strike(parsed.strike()).ok()
+}
+
+#[test]
+fn test_sequenced_set_clock_applies_to_leaves_vivified_by_submit() {
+    // The sequencer's `AddOrder` is Gtc-hardcoded today, so the injected clock is
+    // observable through TIF admission on a leaf vivified BY a submit: set the
+    // stub clock, submit a (Gtc) order that vivifies the leaf, then add a GTD
+    // directly on the leaf handle. Under the stub the GTD is admitted; the
+    // control without an injected clock rejects it against the wall clock.
+    let symbol = "BTC-20240329-50000-C";
+
+    let with_clock = SequencedUnderlyingOrderBook::new("BTC");
+    with_clock.set_clock(Arc::new(StubClock::new()) as Arc<dyn Clock>);
+    with_clock
+        .submit_add_order(symbol, oid(1), Side::Buy, 100, 10)
+        .expect("submit vivifies the leaf under the stub clock");
+
+    let leaf = call_leaf(&with_clock, symbol).expect("leaf vivified by submit");
+    let admitted = leaf.call().add_limit_order_with_tif(
+        oid(2),
+        Side::Buy,
+        99,
+        5,
+        TimeInForce::Gtd(GTD_ADMIT_DEADLINE),
+    );
+    assert!(
+        admitted.is_ok(),
+        "GTD admitted on a leaf vivified after set_clock: {admitted:?}"
+    );
+
+    // Control: no injected clock, so the leaf keeps the wall clock and rejects.
+    let without_clock = SequencedUnderlyingOrderBook::new("BTC");
+    without_clock
+        .submit_add_order(symbol, oid(1), Side::Buy, 100, 10)
+        .expect("submit vivifies the leaf under the default clock");
+    let control_leaf = call_leaf(&without_clock, symbol).expect("control leaf vivified");
+    let rejected = control_leaf.call().add_limit_order_with_tif(
+        oid(2),
+        Side::Buy,
+        99,
+        5,
+        TimeInForce::Gtd(GTD_ADMIT_DEADLINE),
+    );
+    assert!(
+        rejected.is_err(),
+        "GTD rejected on a leaf using the default wall clock"
+    );
+}
+
+#[test]
+fn test_replay_with_injected_stub_clock_equals_live() {
+    // Injecting a fresh `StubClock` into BOTH the live and the replay instance
+    // before driving / replaying must preserve the full-state oracle equality:
+    // a deterministic clock keeps replay byte-identical to live. Each instance
+    // gets its OWN fresh `StubClock` with the same start/step so their logical
+    // time streams behave identically.
+    let journal = Arc::new(InMemoryOptionChainJournal::new());
+
+    let live = fresh_book(&journal);
+    live.set_clock(Arc::new(StubClock::new()) as Arc<dyn Clock>);
+    let submitted = drive_command_prefix(&live);
+    let live_snapshot = snapshot(&live);
+
+    let replay = fresh_book(&journal);
+    replay.set_clock(Arc::new(StubClock::new()) as Arc<dyn Clock>);
+    let replayed = replay.replay(0).expect("replay under injected stub clock");
+    assert_eq!(
+        replayed, submitted,
+        "replay must re-run every journaled command"
+    );
+
+    assert_eq!(
+        live_snapshot,
+        snapshot(&replay),
+        "replayed state under a fresh StubClock must equal live state under its own fresh StubClock"
     );
 }


### PR DESCRIPTION
## Stack

- **Stack: #147 → #148 (this PR is 1 of 2, the bottom of the stack).**
- Base branch: `main`.
- Blocks: the upcoming #148 PR (`stack/2-148-lossless-venue`), which is branched off this PR's HEAD.
- Merge bottom-up: this PR first; after it merges (squash), the upper branch is rebased onto the new `main`.

## Summary

A venue or backtester wrapping the sequenced hierarchy (fauxchange, IronCondor) cannot get deterministic, replayable behavior without forking: concurrent `submit()` calls could journal out of sequence order, and every lazily vivified leaf book silently installed the wall clock, making GTD/Day admission non-replayable. This PR closes both seams and documents the one that remains upstream-blocked.

## Changes

- **Sequencer atomicity**: `SequencedUnderlyingOrderBook::submit()` now holds a per-sequencer gate across the whole assign→execute→journal-append sequence, so journal insertion order == sequence order == book-mutation order. `replay()` takes the same gate (a rebuild cannot interleave with live submits) and advances the counter through the new `advance_to()` instead of poking the private field.
- **Clock threading**: every manager level carries a `Shared<Option<Arc<dyn Clock>>>` with `set_clock`/`clear_clock`/`clock()` (mirroring the fee-schedule rails); the clock rides `get_or_create` into `BookConfig` (plain and NATS paths) and is installed on the inner `orderbook_rs` book before it is frozen in `Arc`. `SequencedUnderlyingOrderBook::set_clock` is linearized against the command stream via the same gate. `Clock`, `MonotonicClock`, `StubClock` are re-exported.
- **Trade-ID determinism**: documented as a known limitation — upstream `orderbook-rs` mints each book's trade-ID namespace with a random `Uuid::new_v4()` and exposes no injection seam; tracked as [OrderBook-rs#199](https://github.com/joaquinbejar/OrderBook-rs/issues/199). The hierarchy will thread a deterministic namespace alongside the clock once the seam ships.

## Technical decisions

- Internal serialization (a `Mutex<()>` gate) instead of a public assign/commit API: the sequenced path is opt-in and not the lock-free hot path; the gate makes the ordering guarantee unconditional rather than contractual. The direct (non-sequenced) hierarchy stays lock-free — verified by the hot-path review.
- Journal `append` now runs inside the critical section; the `OptionChainJournal` contract states appends must be fast (a blocking journal serializes that underlying's submissions).
- Clock semantics match every other `Shared` config: applies to leaves vivified after it is set; set it before the first `submit` for full determinism. The replaying instance must be configured with an identically-behaving clock (e.g. a fresh `StubClock`).
- Until the journaled `AddOrder` carries a time-in-force (issue #148, next PR in this stack), the sequenced add path hardcodes `Gtc`, so the injected clock affects order timestamps but not admission through `submit` — stated in the docs and exercised end-to-end in the stacked follow-up.

## Public API impact

- New: `set_clock` / `clear_clock` / `clock()` on `UnderlyingOrderBookManager`, `UnderlyingOrderBook`, `ExpirationOrderBookManager`, `ExpirationOrderBook`, `OptionChainOrderBookManager`, `OptionChainOrderBook`, `StrikeOrderBookManager`; `set_clock` on `SequencedUnderlyingOrderBook` (feature `sequencer`).
- New re-exports: `Clock`, `MonotonicClock`, `StubClock` (from `orderbook_rs`) in `src/orderbook/mod.rs` and the crate root.
- `src/lib.rs` Limitations updated (trade-ID replay stability, injected-clock requirement for GTD/Day determinism); `README.md` regenerated via `make readme`.

## Testing

- [x] Unit tests added or updated
- [x] Integration tests under `tests/unit/` added or updated (if applicable)
- [x] Replay determinism covered for sequencer changes (replayed state == live)
- [x] `make pre-push` run locally and clean

New coverage: concurrent-load journal-order test (8 threads × 25 commands, gapless strictly-ascending sequence), concurrent-load replay-equals-live full-state oracle, replay-vs-submit no-deadlock test, GTD admission via injected `StubClock` at leaf/strike/underlying levels, vivified-after semantics pin, replay-equals-live under an injected clock. Totals: 826 lib + 31 sequencer integration + 110 doctests, 0 failures; concurrency tests ran 5× with no flakes.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic on protocol counters — no `saturating_*` / `wrapping_*`
- [x] No `unsafe` introduced
- [x] Layering respected (one-way leaf-up; Greeks / eventing not depended on by the core hierarchy)
- [x] Matching delegated to `orderbook-rs`; Greeks delegated to `optionstratlib`
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) updated if the public surface changed

Closes #147
