### PR TITLE
Lossless venue integration: fills, TIF/identity, atomic replace, max price (#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enums were already `#[non_exhaustive]`, so wildcard `match`es keep compiling,
   but literal constructors and full field patterns need the new fields (or
   `..`). `TimeInForce::Gtc` + `Hash32::zero()` reproduce the old semantics
-  exactly. The journal wire format is backward-compatible: the fields carry
-  `#[serde(default)]`, so every pre-0.8.0 journal decodes and replays
-  identically (pinned by the frozen v0.5.0 fixture test). Walkthrough:
+  exactly. The journal wire format is backward-compatible **for self-describing
+  encodings (JSON)**: the fields carry `#[serde(default)]`, so every pre-0.8.0
+  JSON journal decodes and replays identically (pinned by the frozen v0.5.0
+  fixture test). Positional codecs such as bincode cannot apply a
+  missing-field default, so pre-0.8.0 *binary* journal records do not decode
+  against the new shape — re-journal or migrate them. (Appending the new
+  `ReplaceOrder` / `OrderReplaced` *variants* is bincode-safe either way:
+  earlier variant indices never shift.) Walkthrough:
   [`MIGRATING-0.8.0.md`](./MIGRATING-0.8.0.md). (#148)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,74 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.4`. A full upgrade walkthrough lives in
 > [`MIGRATING-0.5.0.md`](./MIGRATING-0.5.0.md).
 
+## [0.8.0] - 2026-07-12
+
+### ⚠️ Breaking Changes
+
+- **`OptionChainCommand::AddOrder` gained `tif: TimeInForce` + `user_id: Hash32`;
+  `OptionChainResult::OrderAdded` gained `trade: Option<TradeResult>`.** Both
+  enums were already `#[non_exhaustive]`, so wildcard `match`es keep compiling,
+  but literal constructors and full field patterns need the new fields (or
+  `..`). `TimeInForce::Gtc` + `Hash32::zero()` reproduce the old semantics
+  exactly. The journal wire format is backward-compatible: the fields carry
+  `#[serde(default)]`, so every pre-0.8.0 journal decodes and replays
+  identically (pinned by the frozen v0.5.0 fixture test). Walkthrough:
+  [`MIGRATING-0.8.0.md`](./MIGRATING-0.8.0.md). (#148)
+
+### Added
+
+- **Deterministic venue seams (#147).**
+  - `SequencedUnderlyingOrderBook::submit` now serializes the whole
+    assign→execute→journal-append sequence in one critical section: journal
+    insertion order == sequence order == book-mutation order. `replay` takes
+    the same gate, so a rebuild cannot interleave with live submits.
+  - An injectable engine clock threads from every manager level into lazily
+    vivified leaf books (`set_clock` / `clear_clock` / `clock()` on managers
+    and books; `SequencedUnderlyingOrderBook::set_clock` is linearized against
+    the command stream). `Clock`, `MonotonicClock`, `StubClock` re-exported.
+    GTD/Day admission becomes replay-deterministic under an injected clock.
+  - Known limitation documented: trade IDs are not replay-stable — upstream
+    `orderbook-rs` mints each book's trade-ID namespace with a random
+    `Uuid::new_v4()` (tracked as OrderBook-rs#199); the replay oracle compares
+    book state and excludes trade IDs.
+- **Lossless venue integration (#148).**
+  - `OrderAdded` carries the fills: `trade: Option<TradeResult>`, `Some` iff
+    the add crossed, attributed per-call (never the shared capture slot). A
+    journaled `Rejected` after real fills (unfillable IOC remainder, STP
+    taker-cancel) is deterministic and documented; those fills stay
+    listener-visible.
+  - `submit_add_order_with(...)` journals TIF variety and account/STP
+    identity; `submit_add_order` delegates unchanged (Gtc + zero user).
+  - `OptionChainCommand::ReplaceOrder` / `OptionChainResult::OrderReplaced` +
+    `submit_replace_order(...)`: atomic validate-first replace through the
+    sequencer, resolved via the non-creating lookup (a replace never vivifies
+    expirations/strikes); the original order survives any rejection.
+  - `OptionOrderBook::replace_order(order_id, price, quantity, side)` — leaf
+    primitive over the engine's validate-first `OrderUpdate::Replace` (queue
+    priority lost; rematch fills reach the trade listener only).
+  - `OptionOrderBook::take_trade_result()` / `clear_trade_capture()` — atomic
+    consuming read and explicit reset for the single-slot trade capture.
+  - `ValidationConfig::with_max_price(u128)` — crate-side maximum price bound
+    enforced on every add and replace path (the upstream engine has no
+    price-bound hook); `validation_config()` readback merges the leaf-held
+    bound. A finite bound lets venues prove upstream fee saturation
+    unreachable (`FeeSchedule::max_guaranteed_exact_notional_for_bps`,
+    orderbook-rs ≥ 0.10.4).
+- New strict wire fixture `tests/fixtures/journal_event_v0.8.0.json` freezing
+  the current schema (deterministic `Some(trade)` payload built via serde, no
+  wall-clock/random-id construction); wire pins for the enriched `AddOrder`,
+  `OrderAdded`-with-trade and `ReplaceOrder`, deny-unknown-fields probes, and
+  an old-binary-rejects-new-variant simulation.
+
+### Tests
+
+Concurrent-load journal-order and replay-equals-live oracles under the new
+gate; GTD admission via injected `StubClock` at leaf/strike/underlying levels;
+replay-equals-live under an injected clock; crossing/IOC/nonzero-user adds,
+replace-that-rematches and unknown-id replace pinned by the full-state replay
+oracle; max-price enforcement across all eight add paths plus replace;
+capture take/clear including poisoned-lock recovery.
+
 ## [0.7.0] - 2026-07-11
 
 ### ⚠️ Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "option-chain-orderbook"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 authors = ["Joaquin Bejar <jb@taunais.com>"]
 description = "A high-performance Rust library for options market making infrastructure, providing a complete Option Chain Order Book system built on top of OrderBook-rs, PriceLevel, and OptionStratLib."

--- a/MIGRATING-0.8.0.md
+++ b/MIGRATING-0.8.0.md
@@ -1,0 +1,86 @@
+# Migrating `option-chain-orderbook` 0.7.0 → 0.8.0
+
+`0.8.0` delivers the deterministic venue seams (#147) and the lossless venue
+integration surface (#148). The journal wire format is backward-compatible —
+a 0.8.0 binary reads every 0.5.0+ journal unchanged. The only source breaks
+are in code that constructs or exhaustively destructures two sequencer enum
+variants by literal.
+
+---
+
+## `AddOrder` and `OrderAdded` variants gained fields
+
+`OptionChainCommand::AddOrder` gained `tif: TimeInForce` and
+`user_id: Hash32`; `OptionChainResult::OrderAdded` gained
+`trade: Option<TradeResult>`. Both enums were already `#[non_exhaustive]`
+(0.7.0), so `match`es with a wildcard arm keep compiling — but a **literal
+constructor** or a **pattern that names every field without `..`** does not.
+
+**Before (0.7.0)**
+
+```rust
+let cmd = OptionChainCommand::AddOrder { symbol, order_id, side, price, quantity };
+
+if let OptionChainResult::OrderAdded { order_id } = receipt.result { /* … */ }
+```
+
+**After (0.8.0)**
+
+```rust
+use option_chain_orderbook::TimeInForce;
+use pricelevel::Hash32;
+
+let cmd = OptionChainCommand::AddOrder {
+    symbol,
+    order_id,
+    side,
+    price,
+    quantity,
+    tif: TimeInForce::Gtc,      // pre-0.8.0 behavior
+    user_id: Hash32::zero(),    // pre-0.8.0 behavior
+};
+
+if let OptionChainResult::OrderAdded { order_id, .. } = receipt.result { /* … */ }
+```
+
+**What to do:** add the two fields to `AddOrder` literals (`TimeInForce::Gtc`
++ `Hash32::zero()` reproduce the old semantics exactly), and add `..` to
+field patterns. Prefer the `submit_add_order` / `submit_add_order_with`
+helpers over hand-built command literals — the former is signature-unchanged.
+
+**Wire format:** unaffected in the backward direction. The new fields carry
+`#[serde(default)]`, so old journals decode to `Gtc` / zero-user / no-trade
+and replay identically (pinned by the frozen v0.5.0 fixture test). An *old*
+binary reading a journal produced by 0.8.0 fails loudly on the unknown fields
+or the new `ReplaceOrder` variant tag — the established, intentional
+asymmetry.
+
+---
+
+## Everything else is additive
+
+- `submit_add_order_with(symbol, order_id, side, price, quantity, tif, user_id)`
+  — full-fidelity journaled add (TIF variety + account/STP identity).
+- `OrderAdded.trade: Option<TradeResult>` — `Some` iff the add produced
+  fills, attributed per-call (never the shared capture slot). Trade IDs,
+  timestamps and `engine_seq` inside the payload are not replay-stable until
+  OrderBook-rs#199 ships; the replay oracle compares book state and ignores
+  journaled results.
+- `OptionChainCommand::ReplaceOrder` / `OptionChainResult::OrderReplaced` +
+  `submit_replace_order(...)` — atomic validate-first replace through the
+  sequencer; the original order survives any rejection; a replace never
+  vivifies expirations/strikes.
+- `OptionOrderBook::replace_order(order_id, price, quantity, side)` — the
+  leaf primitive (queue priority is lost; rematch fills reach the trade
+  listener only).
+- `OptionOrderBook::take_trade_result()` / `clear_trade_capture()` — atomic
+  consuming read / explicit reset for the single-slot trade capture.
+- `ValidationConfig::with_max_price(u128)` — crate-side maximum price bound,
+  enforced on every add and replace path (the upstream engine has no
+  price-bound hook). A finite bound lets venues prove upstream fee
+  saturation unreachable.
+- Deterministic seams from #147: internal serialization of the sequencer's
+  assign→execute→journal-append critical section, `set_clock` /
+  `clear_clock` / `clock()` at every hierarchy level (plus
+  `SequencedUnderlyingOrderBook::set_clock`, linearized against the command
+  stream), and re-exported `Clock` / `MonotonicClock` / `StubClock`.

--- a/MIGRATING-0.8.0.md
+++ b/MIGRATING-0.8.0.md
@@ -1,10 +1,12 @@
 # Migrating `option-chain-orderbook` 0.7.0 → 0.8.0
 
 `0.8.0` delivers the deterministic venue seams (#147) and the lossless venue
-integration surface (#148). The journal wire format is backward-compatible —
-a 0.8.0 binary reads every 0.5.0+ journal unchanged. The only source breaks
-are in code that constructs or exhaustively destructures two sequencer enum
-variants by literal.
+integration surface (#148). The journal wire format is backward-compatible for
+self-describing encodings — a 0.8.0 binary reads every 0.5.0+ **JSON** journal
+unchanged (positional codecs such as bincode cannot apply missing-field
+defaults; see the wire-format note below). The only source breaks are in code
+that constructs or exhaustively destructures two sequencer enum variants by
+literal.
 
 ---
 
@@ -27,8 +29,7 @@ if let OptionChainResult::OrderAdded { order_id } = receipt.result { /* … */ }
 **After (0.8.0)**
 
 ```rust
-use option_chain_orderbook::TimeInForce;
-use pricelevel::Hash32;
+use option_chain_orderbook::{Hash32, TimeInForce};
 
 let cmd = OptionChainCommand::AddOrder {
     symbol,
@@ -48,12 +49,18 @@ if let OptionChainResult::OrderAdded { order_id, .. } = receipt.result { /* … 
 field patterns. Prefer the `submit_add_order` / `submit_add_order_with`
 helpers over hand-built command literals — the former is signature-unchanged.
 
-**Wire format:** unaffected in the backward direction. The new fields carry
-`#[serde(default)]`, so old journals decode to `Gtc` / zero-user / no-trade
-and replay identically (pinned by the frozen v0.5.0 fixture test). An *old*
-binary reading a journal produced by 0.8.0 fails loudly on the unknown fields
-or the new `ReplaceOrder` variant tag — the established, intentional
-asymmetry.
+**Wire format:** unaffected in the backward direction **for self-describing
+encodings (JSON)**. The new fields carry `#[serde(default)]`, so old JSON
+journals decode to `Gtc` / zero-user / no-trade and replay identically
+(pinned by the frozen v0.5.0 fixture test). Serde's missing-field default
+does not exist in positional codecs: a bincode-style journal cannot detect
+an absent trailing field, so pre-0.8.0 *binary* records fail to decode
+against the new `AddOrder` / `OrderAdded` shape — re-journal or migrate
+them before upgrading. (Appending the `ReplaceOrder` / `OrderReplaced`
+*variants* is safe in every codec — earlier variant indices never shift.)
+An *old* binary reading a journal produced by 0.8.0 fails loudly on the
+unknown fields or the new `ReplaceOrder` variant tag — the established,
+intentional asymmetry.
 
 ---
 

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -15,7 +15,7 @@ use orderbook_rs::{
     Clock, DefaultOrderBook, FeeSchedule, MassCancelResult, OrderBookSnapshot, OrderId,
     OrderStateTracker, OrderStatus, STPMode, Side, TimeInForce, TradeListener, TradeResult,
 };
-use pricelevel::{Hash32, MatchResult, Price, Quantity, TimestampMs};
+use pricelevel::{Hash32, MatchResult, OrderUpdate, Price, Quantity, TimestampMs};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicUsize, Ordering};
@@ -338,6 +338,11 @@ pub struct OptionOrderBook {
     ///
     /// `None` when state tracking is disabled via `BookConfig`.
     terminal_counters: Option<Arc<TerminalCounters>>,
+    /// Crate-side maximum order price (smallest price units); orders priced
+    /// above are rejected before reaching the engine. The upstream engine has
+    /// no price-bound hook, so this bound cannot be delegated and is enforced
+    /// here. `None` disables the bound.
+    max_price: Option<u128>,
 }
 
 impl OptionOrderBook {
@@ -367,6 +372,12 @@ impl OptionOrderBook {
         if let Some(ref validation) = config.validation {
             Self::apply_validation(&mut book, validation);
         }
+        // The max-price bound is enforced crate-side (no engine hook), so keep a
+        // copy on the book rather than delegating it to the inner order book.
+        let max_price = config
+            .validation
+            .as_ref()
+            .and_then(ValidationConfig::max_price);
         if let Some(schedule) = config.fee_schedule {
             book.set_fee_schedule(Some(schedule));
         }
@@ -452,6 +463,7 @@ impl OptionOrderBook {
             last_trade_result: capture,
             trade_capture_armed: armed,
             terminal_counters,
+            max_price,
         }
     }
 
@@ -559,6 +571,9 @@ impl OptionOrderBook {
         if let Some(max) = config.max_order_size() {
             book.set_max_order_size(max);
         }
+        // `max_price` is intentionally NOT delegated to the engine: `orderbook_rs`
+        // exposes no price-bound setter, so the bound is stored on the leaf and
+        // enforced crate-side in `check_max_price`.
     }
 
     /// Returns the current validation configuration read back from the underlying book,
@@ -577,6 +592,12 @@ impl OptionOrderBook {
         }
         if let Some(max) = self.book.max_order_size() {
             config = config.with_max_order_size(max);
+        }
+        // The price bound lives on the leaf, not the engine, so merge it back in
+        // before the emptiness check so a book configured with only a max_price
+        // still reports its config.
+        if let Some(bound) = self.max_price {
+            config = config.with_max_price(bound);
         }
         if config.is_empty() {
             None
@@ -729,6 +750,39 @@ impl OptionOrderBook {
     #[inline]
     pub fn is_trade_capture_armed(&self) -> bool {
         self.trade_capture_armed.load(Ordering::Relaxed)
+    }
+
+    /// Consumes and returns the captured trade result, emptying the slot.
+    ///
+    /// Unlike [`last_trade_result`](Self::last_trade_result), which clones and
+    /// leaves the value in place, this is a read-once venue-poll primitive: it
+    /// takes the captured [`TradeResult`] out and leaves the slot empty, so a
+    /// subsequent call returns `None` until the next armed match writes a new
+    /// value. The slot is single-value and last-write-wins (see
+    /// [`last_trade_result`](Self::last_trade_result) for the concurrency
+    /// caveats); this take does not disarm capture.
+    #[must_use]
+    pub fn take_trade_result(&self) -> Option<TradeResult> {
+        self.last_trade_result
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+    }
+
+    /// Empties the trade-capture slot without disarming capture.
+    ///
+    /// Clears any value left by an earlier armed match so the next
+    /// [`last_trade_result`](Self::last_trade_result) /
+    /// [`take_trade_result`](Self::take_trade_result) reflects only matches that
+    /// occur after this call. Capture stays armed if it was armed — this is
+    /// distinct from [`arm_trade_capture(false)`](Self::arm_trade_capture), which
+    /// disarms future capture but does NOT clear the slot.
+    pub fn clear_trade_capture(&self) {
+        let mut guard = self
+            .last_trade_result
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *guard = None;
     }
 
     /// Returns the current lifecycle status of this instrument.
@@ -953,6 +1007,32 @@ impl OptionOrderBook {
         }
     }
 
+    /// Rejects an order priced above the crate-side `max_price` bound.
+    ///
+    /// The happy path (no bound, or price within the bound) is allocation-free;
+    /// the error construction is offloaded to a `#[cold]` helper so the check
+    /// stays branch-predictable on the submission hot path.
+    #[inline]
+    fn check_max_price(&self, price: u128) -> Result<()> {
+        if let Some(bound) = self.max_price
+            && price > bound
+        {
+            return Err(self.max_price_exceeded(price, bound));
+        }
+        Ok(())
+    }
+
+    /// Builds the `max_price` violation error. Cold + un-inlined so the common
+    /// in-bounds path carries none of the formatting code.
+    #[cold]
+    #[inline(never)]
+    fn max_price_exceeded(&self, price: u128, bound: u128) -> Error {
+        Error::validation(format!(
+            "price {price} exceeds max_price {bound} for {}",
+            self.symbol
+        ))
+    }
+
     /// Adds a limit order to the book.
     ///
     /// # Arguments
@@ -964,8 +1044,10 @@ impl OptionOrderBook {
     ///
     /// # Errors
     ///
-    /// Returns [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
-    /// [`Active`](InstrumentStatus::Active).
+    /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
+    ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
+    ///   configured `max_price` bound.
     pub fn add_limit_order(
         &self,
         order_id: OrderId,
@@ -974,6 +1056,7 @@ impl OptionOrderBook {
         quantity: u64,
     ) -> Result<()> {
         self.check_active()?;
+        self.check_max_price(price)?;
         self.book
             .add_limit_order(order_id, price, quantity, side, TimeInForce::Gtc, None)?;
         Ok(())
@@ -991,8 +1074,10 @@ impl OptionOrderBook {
     ///
     /// # Errors
     ///
-    /// Returns [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
-    /// [`Active`](InstrumentStatus::Active).
+    /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
+    ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
+    ///   configured `max_price` bound.
     pub fn add_limit_order_with_tif(
         &self,
         order_id: OrderId,
@@ -1002,6 +1087,7 @@ impl OptionOrderBook {
         tif: TimeInForce,
     ) -> Result<()> {
         self.check_active()?;
+        self.check_max_price(price)?;
         self.book
             .add_limit_order(order_id, price, quantity, side, tif, None)?;
         Ok(())
@@ -1024,6 +1110,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
+    ///   configured `max_price` bound.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order
     ///   (e.g., `MissingUserId` when STP is enabled and `user_id` is zero).
     pub fn add_limit_order_with_user(
@@ -1035,6 +1123,7 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<()> {
         self.check_active()?;
+        self.check_max_price(price)?;
         self.book.add_limit_order_with_user(
             order_id,
             price,
@@ -1064,6 +1153,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
+    ///   configured `max_price` bound.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order.
     pub fn add_limit_order_with_tif_and_user(
         &self,
@@ -1075,6 +1166,7 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<()> {
         self.check_active()?;
+        self.check_max_price(price)?;
         self.book
             .add_limit_order_with_user(order_id, price, quantity, side, tif, user_id, None)?;
         Ok(())
@@ -1117,6 +1209,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
+    ///   configured `max_price` bound.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order.
     ///
     /// On an error-after-fills path (an unfillable IOC remainder, or a
@@ -1132,6 +1226,7 @@ impl OptionOrderBook {
         quantity: u64,
     ) -> Result<TradeResult> {
         self.check_active()?;
+        self.check_max_price(price)?;
         let (_order, trade) = self.book.add_limit_order_with_result(
             order_id,
             price,
@@ -1153,6 +1248,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
+    ///   configured `max_price` bound.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order
     ///   (including error-after-fills paths, where executed fills reach only the trade listener).
     pub fn add_limit_order_with_tif_full(
@@ -1164,6 +1261,7 @@ impl OptionOrderBook {
         tif: TimeInForce,
     ) -> Result<TradeResult> {
         self.check_active()?;
+        self.check_max_price(price)?;
         let (_order, trade) = self
             .book
             .add_limit_order_with_result(order_id, price, quantity, side, tif, None)?;
@@ -1180,6 +1278,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
+    ///   configured `max_price` bound.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order
     ///   (including error-after-fills paths, where executed fills reach only the trade listener).
     pub fn add_limit_order_with_user_full(
@@ -1191,6 +1291,7 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<TradeResult> {
         self.check_active()?;
+        self.check_max_price(price)?;
         let (_order, trade) = self.book.add_limit_order_with_user_and_result(
             order_id,
             price,
@@ -1214,6 +1315,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
+    ///   configured `max_price` bound.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order
     ///   (including error-after-fills paths, where executed fills reach only the trade listener).
     pub fn add_limit_order_with_tif_and_user_full(
@@ -1226,6 +1329,7 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<TradeResult> {
         self.check_active()?;
+        self.check_max_price(price)?;
         let (_order, trade) = self.book.add_limit_order_with_user_and_result(
             order_id, price, quantity, side, tif, user_id, None,
         )?;
@@ -1255,6 +1359,67 @@ impl OptionOrderBook {
         // `false` (not a false success), and a real error must surface (not be
         // swallowed as a benign not-found).
         match self.book.cancel_order(order_id) {
+            Ok(Some(_)) => Ok(true),
+            Ok(None) => Ok(false),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Atomically replaces a resting order's price, quantity, and side.
+    ///
+    /// Delegates to the engine's validate-first [`OrderUpdate::Replace`]: the
+    /// replacement's shape, the modify-aware risk check, and the self-trade
+    /// self-cross check all run **before** the original is cancelled, so on any
+    /// rejection the original order stays resting untouched (no book mutation,
+    /// no events, no trades). Only after both checks pass is the original
+    /// cancelled and the replacement added.
+    ///
+    /// The replacement is a brand-new order: **queue priority is lost** (the
+    /// replacement goes to the back of its price level). If the new price
+    /// crosses the book, the replacement may rematch and fill immediately;
+    /// those fills reach only the installed trade listener (and thus the NATS
+    /// publisher / order-state tracker), **never this return value** — this call
+    /// reports placement, not fills.
+    ///
+    /// # Arguments
+    ///
+    /// * `order_id` - The ID of the resting order to replace
+    /// * `price` - New limit price in smallest units (u128)
+    /// * `quantity` - New quantity in smallest units (u64)
+    /// * `side` - New side (Buy or Sell); a flip moves the order across the book
+    ///
+    /// # Returns
+    ///
+    /// `Ok(true)` if the order was found and replaced, `Ok(false)` if no order
+    /// with that ID was resting on the book.
+    ///
+    /// # Errors
+    ///
+    /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
+    ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
+    ///   configured `max_price` bound.
+    /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream engine rejects the
+    ///   replacement (e.g. a tick/lot shape violation or a risk/STP rejection);
+    ///   on any such rejection the original order survives.
+    pub fn replace_order(
+        &self,
+        order_id: OrderId,
+        price: u128,
+        quantity: u64,
+        side: Side,
+    ) -> Result<bool> {
+        self.check_active()?;
+        self.check_max_price(price)?;
+        // Map the engine's validate-first replace like `cancel_order`: Some =>
+        // replaced, None => the order was not resting, Err => a real engine
+        // rejection (with the original left untouched).
+        match self.book.update_order(OrderUpdate::Replace {
+            order_id,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
+            side,
+        }) {
             Ok(Some(_)) => Ok(true),
             Ok(None) => Ok(false),
             Err(e) => Err(e.into()),
@@ -4074,5 +4239,338 @@ mod tests {
             book_change_count.load(Ordering::Relaxed) >= 1,
             "book-change listener must fire on price-level changes"
         );
+    }
+
+    // ── max_price leaf enforcement ──────────────────────────────────────
+
+    /// Builds a book whose only validation rule is a `max_price` bound.
+    fn max_price_book(bound: u128) -> OptionOrderBook {
+        OptionOrderBook::new_with_config(
+            "BTC-20240329-50000-C",
+            OptionStyle::Call,
+            BookConfig {
+                validation: Some(ValidationConfig::new().with_max_price(bound)),
+                ..BookConfig::default()
+            },
+        )
+    }
+
+    #[test]
+    fn test_max_price_add_above_bound_rejected_all_eight_paths() {
+        const BOUND: u128 = 1_000;
+        const ABOVE: u128 = 1_001;
+        let user = Hash32::from([3u8; 32]);
+        let book = max_price_book(BOUND);
+
+        // Every add entry point must apply the crate-side bound. Normalize each
+        // return type to `Result<()>` so the eight paths can be checked uniformly.
+        let results: Vec<Result<()>> = vec![
+            book.add_limit_order(OrderId::new(), Side::Buy, ABOVE, 10),
+            book.add_limit_order_with_tif(OrderId::new(), Side::Buy, ABOVE, 10, TimeInForce::Gtc),
+            book.add_limit_order_with_user(OrderId::new(), Side::Buy, ABOVE, 10, user),
+            book.add_limit_order_with_tif_and_user(
+                OrderId::new(),
+                Side::Buy,
+                ABOVE,
+                10,
+                TimeInForce::Gtc,
+                user,
+            ),
+            book.add_limit_order_full(OrderId::new(), Side::Buy, ABOVE, 10)
+                .map(|_| ()),
+            book.add_limit_order_with_tif_full(
+                OrderId::new(),
+                Side::Buy,
+                ABOVE,
+                10,
+                TimeInForce::Gtc,
+            )
+            .map(|_| ()),
+            book.add_limit_order_with_user_full(OrderId::new(), Side::Buy, ABOVE, 10, user)
+                .map(|_| ()),
+            book.add_limit_order_with_tif_and_user_full(
+                OrderId::new(),
+                Side::Buy,
+                ABOVE,
+                10,
+                TimeInForce::Gtc,
+                user,
+            )
+            .map(|_| ()),
+        ];
+
+        assert_eq!(results.len(), 8);
+        for (i, res) in results.into_iter().enumerate() {
+            assert!(
+                matches!(res, Err(Error::ValidationError { .. })),
+                "add path {i} must reject an above-bound price with ValidationError"
+            );
+        }
+        // No above-bound order ever reached the engine.
+        assert_eq!(book.order_count(), 0);
+    }
+
+    #[test]
+    fn test_max_price_add_at_bound_accepted() {
+        const BOUND: u128 = 1_000;
+        let book = max_price_book(BOUND);
+        // The bound is inclusive: a price exactly at the bound is accepted.
+        let res = book.add_limit_order(OrderId::new(), Side::Buy, BOUND, 10);
+        assert!(res.is_ok(), "price at the bound must be accepted: {res:?}");
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_max_price_unset_never_rejects() {
+        // No max_price configured: even an extreme price is admitted (subject to
+        // the engine's own checks, of which there are none here).
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let res = book.add_limit_order(OrderId::new(), Side::Buy, u128::MAX, 10);
+        assert!(
+            res.is_ok(),
+            "no bound means no crate-side price rejection: {res:?}"
+        );
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_validation_config_readback_merges_max_price() {
+        let book = OptionOrderBook::new_with_config(
+            "BTC-20240329-50000-C",
+            OptionStyle::Call,
+            BookConfig {
+                validation: Some(
+                    ValidationConfig::new()
+                        .with_tick_size(1)
+                        .with_max_price(5_000),
+                ),
+                ..BookConfig::default()
+            },
+        );
+        let config = book.validation_config().expect("config present");
+        assert_eq!(config.max_price(), Some(5_000));
+        assert_eq!(config.tick_size(), Some(1));
+    }
+
+    #[test]
+    fn test_validation_config_readback_only_max_price_is_some() {
+        // A book configured with ONLY a max_price still reports a non-empty
+        // config, because the readback merges the leaf-held bound before the
+        // emptiness check.
+        let book = max_price_book(2_000);
+        let config = book
+            .validation_config()
+            .expect("config present with only max_price");
+        assert_eq!(config.max_price(), Some(2_000));
+        assert_eq!(config.tick_size(), None);
+    }
+
+    // ── trade-capture take / clear ──────────────────────────────────────
+
+    #[test]
+    fn test_take_trade_result_returns_captured_and_empties_slot() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.arm_trade_capture(true);
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 10)
+            .expect("rest sell");
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 5)
+            .expect("cross buy");
+
+        let first = book.take_trade_result();
+        assert!(
+            first.is_some(),
+            "the crossing match must have been captured"
+        );
+        // The take consumed the slot: a second read is empty until the next match.
+        assert!(book.take_trade_result().is_none());
+    }
+
+    #[test]
+    fn test_take_trade_result_none_when_never_armed() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        // A match occurs, but capture was never armed, so nothing is recorded.
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 10)
+            .expect("rest sell");
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 5)
+            .expect("cross buy");
+        assert!(book.take_trade_result().is_none());
+    }
+
+    #[test]
+    fn test_clear_trade_capture_empties_slot_without_disarming() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.arm_trade_capture(true);
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 10)
+            .expect("rest sell");
+        book.add_limit_order(OrderId::new(), Side::Buy, 100, 5)
+            .expect("cross buy");
+        assert!(book.last_trade_result().is_some());
+
+        book.clear_trade_capture();
+        assert!(book.last_trade_result().is_none(), "clear empties the slot");
+        // Clearing does NOT disarm: capture stays on for future matches.
+        assert!(book.is_trade_capture_armed());
+    }
+
+    #[test]
+    fn test_take_trade_result_recovers_from_poisoned_lock() {
+        let book = Arc::new(OptionOrderBook::new(
+            "BTC-20240329-50000-C",
+            OptionStyle::Call,
+        ));
+        // Seed the slot directly with an empty trade result.
+        {
+            let mut guard = book
+                .last_trade_result
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *guard = Some(book.empty_trade_result(OrderId::new(), 5));
+        }
+
+        // Poison the capture lock by panicking while holding the guard.
+        let clone = Arc::clone(&book);
+        let handle = std::thread::spawn(move || {
+            let _guard = clone
+                .last_trade_result
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            panic!("poison the trade-capture lock");
+        });
+        assert!(handle.join().is_err());
+
+        // The take still recovers the seeded value and empties the slot.
+        assert!(book.take_trade_result().is_some());
+        assert!(book.take_trade_result().is_none());
+    }
+
+    // ── replace_order ───────────────────────────────────────────────────
+
+    #[test]
+    fn test_replace_order_moves_price_and_quantity_returns_true() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 100, 10).expect("add");
+
+        let res = book.replace_order(id, 105, 20, Side::Buy);
+        assert!(
+            matches!(res, Ok(true)),
+            "replace should report a hit: {res:?}"
+        );
+        assert_eq!(book.best_bid(), Some(105));
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_replace_order_unknown_id_returns_false() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let res = book.replace_order(OrderId::new(), 100, 10, Side::Buy);
+        assert!(
+            matches!(res, Ok(false)),
+            "unknown id must be a miss: {res:?}"
+        );
+    }
+
+    #[test]
+    fn test_replace_order_rejected_when_halted_original_untouched() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 100, 10).expect("add");
+        book.halt().expect("halt");
+
+        let res = book.replace_order(id, 105, 20, Side::Buy);
+        assert!(
+            matches!(res, Err(Error::InstrumentNotActive { .. })),
+            "replace on a halted book must be rejected: {res:?}"
+        );
+        // The original is untouched (inspectable while halted).
+        assert_eq!(book.best_bid(), Some(100));
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_replace_order_validate_first_rejection_leaves_original_resting() {
+        // Tick size 10: the original rests at a valid multiple, then the replace
+        // targets a non-multiple price. The engine validates the new shape BEFORE
+        // cancelling, so the original stays resting on the rejection.
+        let book = OptionOrderBook::new_with_config(
+            "BTC-20240329-50000-C",
+            OptionStyle::Call,
+            BookConfig {
+                validation: Some(ValidationConfig::new().with_tick_size(10)),
+                ..BookConfig::default()
+            },
+        );
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 100, 10)
+            .expect("add at valid tick");
+
+        let res = book.replace_order(id, 105, 10, Side::Buy);
+        assert!(
+            matches!(res, Err(Error::OrderBookEngine(_))),
+            "a tick-size violation must be rejected by the engine: {res:?}"
+        );
+        // Validate-first: the original survives the rejection untouched.
+        assert_eq!(book.best_bid(), Some(100));
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_replace_order_to_crossing_price_rematches_and_fills_reach_listener() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        // Resting sell to cross into, and a resting buy well below it.
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 10)
+            .expect("rest sell");
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 90, 5)
+            .expect("rest buy");
+
+        book.arm_trade_capture(true);
+        // Reprice the buy up to the sell: the replacement rematches and fills.
+        let res = book.replace_order(id, 100, 5, Side::Buy);
+        assert!(
+            matches!(res, Ok(true)),
+            "crossing replace reports a hit: {res:?}"
+        );
+
+        // The fills reached the trade listener (capture slot), NOT this return.
+        let captured = book.take_trade_result();
+        assert!(
+            captured.is_some(),
+            "a crossing replace's fills must reach the trade listener"
+        );
+    }
+
+    #[test]
+    fn test_replace_order_side_flip_moves_order_across_book() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 100, 10)
+            .expect("add buy");
+        assert_eq!(book.best_bid(), Some(100));
+        assert!(book.best_ask().is_none());
+
+        // Flip the resting buy into a sell on the other side of the book.
+        let res = book.replace_order(id, 120, 10, Side::Sell);
+        assert!(matches!(res, Ok(true)), "side flip reports a hit: {res:?}");
+        assert!(book.best_bid().is_none());
+        assert_eq!(book.best_ask(), Some(120));
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_max_price_enforced_on_replace_order() {
+        let book = max_price_book(1_000);
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 500, 10)
+            .expect("add within bound");
+
+        let res = book.replace_order(id, 1_001, 10, Side::Buy);
+        assert!(
+            matches!(res, Err(Error::ValidationError { .. })),
+            "replace above the bound must be rejected crate-side: {res:?}"
+        );
+        // The bound is checked before the engine, so the original is untouched.
+        assert_eq!(book.best_bid(), Some(500));
+        assert_eq!(book.order_count(), 1);
     }
 }

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -183,7 +183,11 @@ pub enum OptionChainCommand {
         ///
         /// Defaults to [`TimeInForce::Gtc`] (via a serde default) when absent, so
         /// a journal written before #148 decodes and replays exactly
-        /// as it did then (every pre-#148 add was good-till-cancelled). The wire
+        /// as it did then (every pre-#148 add was good-till-cancelled). That
+        /// missing-field default only exists in self-describing encodings
+        /// (JSON): a positional codec such as bincode cannot detect an absent
+        /// trailing field, so pre-#148 *binary* records do not decode against
+        /// the new shape — re-journal or migrate them instead. The wire
         /// tags are pricelevel's casing — `"GTC" | "IOC" | "FOK" | {"GTD": ms} |
         /// "DAY"` — not the `snake_case` used for the other fields. The
         /// clock-relative variants (`Gtd`, `Day`) are replay-stable only because
@@ -324,7 +328,10 @@ pub enum OptionChainResult {
         /// `Some` iff the add crossed the book and executed at least one trade;
         /// `None` when the order rested unfilled — which is also what any
         /// pre-#148 journal (whose `OrderAdded` had no `trade` field) decodes to
-        /// via `#[serde(default)]`.
+        /// via `#[serde(default)]`. As with `AddOrder`'s appended fields, that
+        /// old-journal default applies only to self-describing encodings
+        /// (JSON); positional codecs such as bincode cannot decode pre-#148
+        /// binary records against the new shape.
         ///
         /// # Replay caveat
         ///
@@ -939,11 +946,11 @@ impl SequencedUnderlyingOrderBook {
     /// [`submit`](Self::submit), so it is linearized against the sequenced
     /// command stream: every command either fully precedes or fully follows
     /// the clock change, and which clock a lazily vivified leaf receives is
-    /// well-defined relative to the journal order. Note that until the
-    /// journaled `AddOrder` command carries a time-in-force (tracked in
-    /// issue #148), `Gtc` is hardcoded on the sequenced add path and the
-    /// injected clock affects only order timestamps — not admission — for
-    /// commands flowing through `submit`.
+    /// well-defined relative to the journal order. The journaled `AddOrder`
+    /// command carries a time-in-force (#148), so an injected deterministic
+    /// clock makes `Gtd` / `Day` admission — and the order timestamps the
+    /// engine stamps — replay-stable for commands flowing through
+    /// [`submit`](Self::submit).
     #[inline]
     pub fn set_clock(&self, clock: Arc<dyn Clock>) {
         // Linearize the config change against submit/replay so a racing
@@ -1041,6 +1048,9 @@ impl SequencedUnderlyingOrderBook {
     /// The order is good-till-cancelled ([`TimeInForce::Gtc`]) and attributed to
     /// the zero [`Hash32`] user. For a non-default time-in-force or user
     /// identity, use [`submit_add_order_with`](Self::submit_add_order_with).
+    /// On a book with self-trade prevention enabled the zero user is rejected
+    /// by the engine (`MissingUserId`) — STP-enabled sequenced books must
+    /// submit through `submit_add_order_with` with a non-zero identity.
     ///
     /// # Arguments
     ///

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -63,7 +63,7 @@ use crate::orderbook::symbol_index::SymbolIndex;
 use crate::orderbook::underlying::UnderlyingOrderBook;
 use crate::utils::{SymbolParser, nanos_since_epoch};
 use optionstratlib::{ExpirationDate, OptionStyle};
-use orderbook_rs::{Clock, OrderId, Side};
+use orderbook_rs::{Clock, OrderId, Side, TimeInForce, TradeResult};
 use pricelevel::{Hash32, TimestampMs};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -120,6 +120,20 @@ pub enum MassCancelType {
     ByUser(Hash32),
 }
 
+/// The default time-in-force for a journaled [`OptionChainCommand::AddOrder`]
+/// that predates the #148 `tif` field.
+///
+/// Serde uses this via `#[serde(default = "...")]` so an old journal — written
+/// before `AddOrder` carried a `tif` — decodes to [`TimeInForce::Gtc`], which is
+/// exactly the good-till-cancelled behavior every pre-#148 add had. Keeping the
+/// default here (rather than relying on a `Default` impl) is required because
+/// `TimeInForce` has no `Default`.
+#[must_use]
+#[inline]
+fn default_add_order_tif() -> TimeInForce {
+    TimeInForce::Gtc
+}
+
 /// Command for the option chain sequencer with hierarchy routing.
 ///
 /// Each variant represents an operation that can be sequenced through
@@ -165,6 +179,25 @@ pub enum OptionChainCommand {
         price: u128,
         /// Order quantity.
         quantity: u64,
+        /// Time-in-force policy for the order.
+        ///
+        /// Defaults to [`TimeInForce::Gtc`] (via a serde default) when absent, so
+        /// a journal written before #148 decodes and replays exactly
+        /// as it did then (every pre-#148 add was good-till-cancelled). The wire
+        /// tags are pricelevel's casing — `"GTC" | "IOC" | "FOK" | {"GTD": ms} |
+        /// "DAY"` — not the `snake_case` used for the other fields. The
+        /// clock-relative variants (`Gtd`, `Day`) are replay-stable only because
+        /// #147 injects the engine clock; without that the eviction cutoff would
+        /// read wall-clock and diverge.
+        #[serde(default = "default_add_order_tif")]
+        tif: TimeInForce,
+        /// Owning user identity, used for by-user mass cancel and STP grouping.
+        ///
+        /// Defaults to the zero [`Hash32`] (via `#[serde(default)]`, which
+        /// `Hash32` derives) when absent, reproducing the pre-#148 behavior where
+        /// every add was attributed to the zero user. Serializes as a hex string.
+        #[serde(default)]
+        user_id: Hash32,
     },
     /// Cancel an order in a specific option book.
     CancelOrder {
@@ -227,6 +260,41 @@ pub enum OptionChainCommand {
         /// market close.
         now_ms: TimestampMs,
     },
+    /// Atomically replace a resting order's price, quantity, and side.
+    ///
+    /// A replace names an order that already exists, so it resolves through the
+    /// NON-creating `find_book_by_symbol` path — it never vivifies an expiration
+    /// or strike. This is deterministic:
+    /// live execution and replay both use the same non-creating resolver, so a
+    /// replace against a book that was never created is rejected identically on
+    /// both. The replacement carries validate-first atomic semantics from the
+    /// leaf [`replace_order`](crate::orderbook::OptionOrderBook::replace_order):
+    /// if the replacement's shape, risk, or self-cross check fails, the original
+    /// order survives untouched.
+    ///
+    /// Replace fills are NOT carried in the v1 result. If the new price crosses
+    /// the book the replacement can rematch and fill immediately; those fills
+    /// reach only the trade listener (and the NATS publisher), not the journaled
+    /// [`OptionChainResult::OrderReplaced`] — a follow-up will surface them once
+    /// OrderBook-rs#199 ships replay-stable ids.
+    ///
+    /// Wire-compatible addition: appended after every prior variant, so existing
+    /// journals replay unchanged and their bincode variant indices are
+    /// unaffected. A journal carrying `ReplaceOrder` fails to decode against an
+    /// older binary that predates the variant — expected, and the same
+    /// forward-compat asymmetry documented on this enum.
+    ReplaceOrder {
+        /// Target option symbol (e.g., "BTC-20240329-50000-C").
+        symbol: String,
+        /// Identifier of the resting order to replace.
+        order_id: OrderId,
+        /// New limit price in smallest units.
+        price: u128,
+        /// New order quantity.
+        quantity: u64,
+        /// New side (Buy or Sell); a flip moves the order across the book.
+        side: Side,
+    },
 }
 
 /// Result of executing an option chain command.
@@ -251,6 +319,27 @@ pub enum OptionChainResult {
     OrderAdded {
         /// The identifier of the newly added order.
         order_id: OrderId,
+        /// The fills the add produced, if any.
+        ///
+        /// `Some` iff the add crossed the book and executed at least one trade;
+        /// `None` when the order rested unfilled — which is also what any
+        /// pre-#148 journal (whose `OrderAdded` had no `trade` field) decodes to
+        /// via `#[serde(default)]`.
+        ///
+        /// # Replay caveat
+        ///
+        /// The payload's [`TradeResult::engine_seq`], the individual trade ids,
+        /// and the trade timestamps are NOT replay-stable: a replay into a fresh
+        /// book mints a fresh engine-seq / trade-id namespace (pending
+        /// OrderBook-rs#199). Replay discards journaled results by design (it
+        /// re-executes commands and keeps the freshly produced state), so the
+        /// replay==live *state* oracle is unaffected — but a consumer must not
+        /// diff `trade` payloads across a live run and a replay run and expect
+        /// them to match. There is deliberately no `skip_serializing_if` here:
+        /// the field is always emitted (as `null` when `None`) so the JSON and
+        /// bincode encodings stay symmetric across decode/encode round-trips.
+        #[serde(default)]
+        trade: Option<TradeResult>,
     },
     /// An order was successfully cancelled.
     OrderCancelled {
@@ -293,6 +382,16 @@ pub enum OptionChainResult {
     ExpiredEvicted {
         /// Evicted order identifiers in the sweep's deterministic order.
         evicted_ids: Vec<OrderId>,
+    },
+    /// A resting order was atomically replaced.
+    ///
+    /// The successful outcome of an [`OptionChainCommand::ReplaceOrder`]. The
+    /// replacement's fills, if the new price crossed the book, are NOT carried
+    /// here in v1 — they reach only the trade listener / NATS publisher (see the
+    /// command's doc). This variant reports placement, not fills.
+    OrderReplaced {
+        /// The identifier of the replaced order.
+        order_id: OrderId,
     },
 }
 
@@ -939,6 +1038,10 @@ impl SequencedUnderlyingOrderBook {
 
     /// Submits an add order command to a specific option book.
     ///
+    /// The order is good-till-cancelled ([`TimeInForce::Gtc`]) and attributed to
+    /// the zero [`Hash32`] user. For a non-default time-in-force or user
+    /// identity, use [`submit_add_order_with`](Self::submit_add_order_with).
+    ///
     /// # Arguments
     ///
     /// * `symbol` - Target option symbol (e.g., "BTC-20240329-50000-C")
@@ -958,12 +1061,64 @@ impl SequencedUnderlyingOrderBook {
         price: u128,
         quantity: u64,
     ) -> Result<OptionChainReceipt, Error> {
+        // Delegate with the pre-#148 defaults so this signature stays a
+        // convenience wrapper and the two paths cannot drift.
+        self.submit_add_order_with(
+            symbol,
+            order_id,
+            side,
+            price,
+            quantity,
+            TimeInForce::Gtc,
+            Hash32::zero(),
+        )
+    }
+
+    /// Submits an add order command with an explicit time-in-force and user
+    /// identity.
+    ///
+    /// This is the full-fidelity add: it carries the `tif` and `user_id` into the
+    /// journaled [`OptionChainCommand::AddOrder`] so replay reproduces the same
+    /// eviction behavior (for `Gtd`/`Day`, in concert with the injected engine
+    /// clock) and the same by-user attribution. On success the receipt's
+    /// [`OptionChainResult::OrderAdded`] carries the fills the add produced (see
+    /// that variant's replay caveat).
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - Target option symbol (e.g., "BTC-20240329-50000-C")
+    /// * `order_id` - Unique order identifier
+    /// * `side` - Buy or Sell
+    /// * `price` - Limit price
+    /// * `quantity` - Order quantity
+    /// * `tif` - Time-in-force policy for the order
+    /// * `user_id` - Owning user identity
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if journaling fails.
+    // A full venue add is inherently 7 order attributes (symbol, id, side, price,
+    // quantity, tif, user) — bundling them into a struct would only obscure the
+    // call site, so the argument count is intrinsic here.
+    #[allow(clippy::too_many_arguments)]
+    pub fn submit_add_order_with(
+        &self,
+        symbol: &str,
+        order_id: OrderId,
+        side: Side,
+        price: u128,
+        quantity: u64,
+        tif: TimeInForce,
+        user_id: Hash32,
+    ) -> Result<OptionChainReceipt, Error> {
         let command = OptionChainCommand::AddOrder {
             symbol: symbol.to_string(),
             order_id,
             side,
             price,
             quantity,
+            tif,
+            user_id,
         };
         self.submit(command)
     }
@@ -1067,6 +1222,50 @@ impl SequencedUnderlyingOrderBook {
         self.submit(command)
     }
 
+    /// Submits an atomic replace command for a resting order.
+    ///
+    /// Journals the replace as an [`OptionChainCommand::ReplaceOrder`]. The
+    /// target order must already exist: the command resolves through the
+    /// non-creating book lookup and never vivifies an expiration or strike, so a
+    /// replace against a book that does not exist is rejected. Replace semantics
+    /// are validate-first and atomic — a rejected replacement leaves the original
+    /// order untouched (see the leaf
+    /// [`replace_order`](crate::orderbook::OptionOrderBook::replace_order)).
+    ///
+    /// The receipt is [`OptionChainResult::OrderReplaced`] on success,
+    /// [`OptionChainResult::BookNotFound`] when the symbol names no existing
+    /// book, or [`OptionChainResult::Rejected`] when the order is not resting,
+    /// the symbol crosses underlyings, or the engine rejects the replacement.
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - Target option symbol
+    /// * `order_id` - Identifier of the resting order to replace
+    /// * `price` - New limit price in smallest units
+    /// * `quantity` - New order quantity
+    /// * `side` - New side (Buy or Sell)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if journaling fails.
+    pub fn submit_replace_order(
+        &self,
+        symbol: &str,
+        order_id: OrderId,
+        price: u128,
+        quantity: u64,
+        side: Side,
+    ) -> Result<OptionChainReceipt, Error> {
+        let command = OptionChainCommand::ReplaceOrder {
+            symbol: symbol.to_string(),
+            order_id,
+            price,
+            quantity,
+            side,
+        };
+        self.submit(command)
+    }
+
     // ── Command Execution ────────────────────────────────────────────────
 
     /// Executes a command against the underlying order book.
@@ -1078,7 +1277,11 @@ impl SequencedUnderlyingOrderBook {
                 side,
                 price,
                 quantity,
-            } => self.execute_add_order(symbol, *order_id, *side, *price, *quantity),
+                tif,
+                user_id,
+            } => {
+                self.execute_add_order(symbol, *order_id, *side, *price, *quantity, *tif, *user_id)
+            }
             OptionChainCommand::CancelOrder { symbol, order_id } => {
                 self.execute_cancel_order(symbol, *order_id)
             }
@@ -1091,6 +1294,13 @@ impl SequencedUnderlyingOrderBook {
             OptionChainCommand::EvictExpiredOrders { now_ms } => {
                 self.execute_evict_expired_orders(*now_ms)
             }
+            OptionChainCommand::ReplaceOrder {
+                symbol,
+                order_id,
+                price,
+                quantity,
+                side,
+            } => self.execute_replace_order(symbol, *order_id, *price, *quantity, *side),
         }
     }
 
@@ -1103,6 +1313,21 @@ impl SequencedUnderlyingOrderBook {
     /// prefix rebuilds identical structural state in a fresh book. A malformed
     /// symbol still yields [`OptionChainResult::BookNotFound`]; a cross-underlying
     /// symbol is rejected before anything is created.
+    ///
+    /// # Fills and the error-after-fills caveat
+    ///
+    /// On success the result's `trade` is `Some` iff the add crossed and executed
+    /// at least one trade, `None` if it rested unfilled. The engine can also
+    /// return an error *after* executing real fills — an `Ioc`/`Fok` remainder
+    /// that cannot rest, or an STP taker-cancel — in which case the add is
+    /// journaled as [`OptionChainResult::Rejected`] even though fills reached the
+    /// trade listener (and the NATS publisher). Those fills are listener-visible
+    /// only; they are deterministic, so replay reproduces the same rejection and
+    /// the same fills, but a venue consumer must not read `Rejected` as "nothing
+    /// happened".
+    // Mirrors the full add attribute set (see `submit_add_order_with`); the count
+    // is intrinsic to a limit-order add, not accidental.
+    #[allow(clippy::too_many_arguments)]
     fn execute_add_order(
         &self,
         symbol: &str,
@@ -1110,6 +1335,8 @@ impl SequencedUnderlyingOrderBook {
         side: Side,
         price: u128,
         quantity: u64,
+        tif: TimeInForce,
+        user_id: Hash32,
     ) -> OptionChainResult {
         let book = match self.find_or_create_book_by_symbol(symbol) {
             Ok(book) => book,
@@ -1129,8 +1356,15 @@ impl SequencedUnderlyingOrderBook {
             }
         };
 
-        match book.add_limit_order(order_id, side, price, quantity) {
-            Ok(_) => OptionChainResult::OrderAdded { order_id },
+        match book
+            .add_limit_order_with_tif_and_user_full(order_id, side, price, quantity, tif, user_id)
+        {
+            Ok(trade) => OptionChainResult::OrderAdded {
+                order_id,
+                // Carry the fills only when the add actually crossed; an empty
+                // trade list means the order rested, which is `None`.
+                trade: (!trade.match_result.trades().is_empty()).then_some(trade),
+            },
             Err(e) => OptionChainResult::Rejected {
                 reason: e.to_string(),
             },
@@ -1208,6 +1442,56 @@ impl SequencedUnderlyingOrderBook {
 
         match book.cancel_order(order_id) {
             Ok(_) => OptionChainResult::OrderCancelled { order_id },
+            Err(e) => OptionChainResult::Rejected {
+                reason: e.to_string(),
+            },
+        }
+    }
+
+    /// Executes an atomic replace operation.
+    ///
+    /// Resolution goes through the NON-creating
+    /// [`find_book_by_symbol`](Self::find_book_by_symbol) — the same resolver as
+    /// [`execute_cancel_order`](Self::execute_cancel_order) — so a replace never
+    /// vivifies an expiration or strike. The error mapping mirrors the cancel
+    /// path: a cross-underlying symbol is [`Rejected`](OptionChainResult::Rejected)
+    /// with the typed reason, any other resolution failure (malformed symbol, or
+    /// a book that was never created) is
+    /// [`BookNotFound`](OptionChainResult::BookNotFound). The leaf replace then
+    /// distinguishes replaced (`Ok(true)`), order-not-resting (`Ok(false)`, a
+    /// deterministic rejection), and an engine rejection (`Err`, with the
+    /// original order left untouched).
+    fn execute_replace_order(
+        &self,
+        symbol: &str,
+        order_id: OrderId,
+        price: u128,
+        quantity: u64,
+        side: Side,
+    ) -> OptionChainResult {
+        let book = match self.find_book_by_symbol(symbol) {
+            Ok(book) => book,
+            // A cross-underlying command must be rejected with the typed reason,
+            // never silently routed or masked as a missing book.
+            Err(e @ Error::UnderlyingMismatch { .. }) => {
+                return OptionChainResult::Rejected {
+                    reason: e.to_string(),
+                };
+            }
+            Err(_) => {
+                return OptionChainResult::BookNotFound {
+                    symbol: symbol.to_string(),
+                };
+            }
+        };
+
+        match book.replace_order(order_id, price, quantity, side) {
+            Ok(true) => OptionChainResult::OrderReplaced { order_id },
+            // The book exists but no order with that id is resting: a
+            // deterministic rejection (not a book-not-found).
+            Ok(false) => OptionChainResult::Rejected {
+                reason: format!("order not found: {order_id}"),
+            },
             Err(e) => OptionChainResult::Rejected {
                 reason: e.to_string(),
             },
@@ -1661,6 +1945,20 @@ impl SequencedUnderlyingOrderBook {
     /// evicts exactly the orders it evicted live; the sweep is idempotent, so a
     /// duplicate replay is a no-op.
     ///
+    /// **Replaces are reconstructed when journaled.** An
+    /// [`OptionChainCommand::ReplaceOrder`] (via
+    /// [`submit_replace_order`](Self::submit_replace_order)) replays through the
+    /// SAME non-creating resolution and the same engine validate-first replace
+    /// path (the leaf
+    /// [`replace_order`](crate::orderbook::OptionOrderBook::replace_order)) as
+    /// live, so a replace that re-priced an order to a crossing level and
+    /// rematched live rematches identically on replay, rebuilding the same
+    /// resting book. Journaled `trade` payloads carried in
+    /// [`OptionChainResult::OrderAdded`] results are ignored by replay: replay
+    /// re-executes commands and keeps the freshly produced results, so the
+    /// non-replay-stable trade ids / engine-seqs in the journal never influence
+    /// the rebuilt state.
+    ///
     /// Returns the number of events replayed.
     ///
     /// # Errors
@@ -1794,6 +2092,7 @@ mod tests {
     fn test_option_chain_result_is_error() {
         let success = OptionChainResult::OrderAdded {
             order_id: OrderId::new(),
+            trade: None,
         };
         let rejected = OptionChainResult::Rejected {
             reason: "test".to_string(),
@@ -2421,9 +2720,12 @@ mod tests {
                 side: Side::Buy,
                 price: 100,
                 quantity: 10,
+                tif: TimeInForce::Gtc,
+                user_id: Hash32::zero(),
             },
             result: OptionChainResult::OrderAdded {
                 order_id: OrderId::new(),
+                trade: None,
             },
         };
 
@@ -2670,7 +2972,7 @@ mod tests {
             .expect("canonical expiry");
 
         vec![
-            // AddOrder + OrderAdded
+            // AddOrder + OrderAdded (default tif/user, rested unfilled → trade None)
             OptionChainEvent {
                 sequence_num: 1,
                 timestamp_ns: 1_700_000_000_000_000_000,
@@ -2680,8 +2982,13 @@ mod tests {
                     side: Side::Buy,
                     price: 100,
                     quantity: 10,
+                    tif: TimeInForce::Gtc,
+                    user_id: Hash32::zero(),
                 },
-                result: OptionChainResult::OrderAdded { order_id: oid },
+                result: OptionChainResult::OrderAdded {
+                    order_id: oid,
+                    trade: None,
+                },
             },
             // CancelOrder + OrderCancelled
             OptionChainEvent {
@@ -2766,7 +3073,71 @@ mod tests {
                     evicted_ids: vec![OrderId::sequential(42), OrderId::sequential(43)],
                 },
             },
+            // AddOrder with a NON-default tif (Gtd) + nonzero user_id, and an
+            // OrderAdded carrying deterministic fills (#148). Exercises the
+            // enriched wire shape end to end.
+            OptionChainEvent {
+                sequence_num: 9,
+                timestamp_ns: 1_700_000_000_000_000_008,
+                command: OptionChainCommand::AddOrder {
+                    symbol: "BTC-20240329-50000-C".to_string(),
+                    order_id: oid,
+                    side: Side::Buy,
+                    price: 100,
+                    quantity: 4,
+                    tif: TimeInForce::Gtd(1_700_000_000_000),
+                    user_id: user,
+                },
+                result: OptionChainResult::OrderAdded {
+                    order_id: oid,
+                    trade: Some(deterministic_trade_result()),
+                },
+            },
+            // ReplaceOrder + OrderReplaced (#148).
+            OptionChainEvent {
+                sequence_num: 10,
+                timestamp_ns: 1_700_000_000_000_000_009,
+                command: OptionChainCommand::ReplaceOrder {
+                    symbol: "BTC-20240329-50000-C".to_string(),
+                    order_id: oid,
+                    price: 105,
+                    quantity: 7,
+                    side: Side::Buy,
+                },
+                result: OptionChainResult::OrderReplaced { order_id: oid },
+            },
         ]
+    }
+
+    /// Builds a deterministic single-fill [`TradeResult`] for fixtures and wire
+    /// tests.
+    ///
+    /// The inner [`Trade`](pricelevel::Trade) is deserialized from a pinned JSON
+    /// literal — never `Trade::new`, which stamps a wall-clock timestamp and
+    /// would make the encoding non-reproducible — so the whole `TradeResult`, and
+    /// any journal event carrying it, is byte-stable across runs. Represents a
+    /// taker of 4 units fully filled at price 100 by maker order 43.
+    fn deterministic_trade_result() -> TradeResult {
+        // Pinned Trade wire form: `Id`s are strings, price/quantity/timestamp are
+        // transparent numbers, `taker_side` is "BUY"/"SELL". The fixed timestamp
+        // is what keeps this reproducible (Trade::new would read the clock).
+        const TRADE_JSON: &str = r#"{
+            "trade_id": "9001",
+            "taker_order_id": "42",
+            "maker_order_id": "43",
+            "price": 100,
+            "quantity": 4,
+            "taker_side": "BUY",
+            "timestamp": 1700000000000
+        }"#;
+        let trade: pricelevel::Trade =
+            serde_json::from_str(TRADE_JSON).expect("pinned trade json must decode");
+        let mut match_result =
+            pricelevel::MatchResult::new(OrderId::sequential(42), pricelevel::Quantity::new(4));
+        match_result
+            .add_trade(trade)
+            .expect("pinned trade must not overfill the match result");
+        TradeResult::new("BTC-20240329-50000-C".to_string(), match_result)
     }
 
     /// Back-compat / format-pin guard: a checked-in journal sample written under
@@ -2809,15 +3180,42 @@ mod tests {
             }
         ));
 
-        // Re-encoding is value-identical to the on-disk fixture: the wire format
-        // is unchanged by the serde attributes (key order / whitespace aside).
+        // Re-encoding: the #148 additive fields (`tif` / `user_id` on `AddOrder`,
+        // `trade` on `OrderAdded`) are absent from the frozen v0.5.0 fixture but
+        // are ALWAYS emitted by the current schema (no `skip_serializing_if`), so
+        // a naive `to_value(decoded) == fixture` comparison would fail purely on
+        // the new fields. That is expected and correct: the additive-field
+        // precedent is that an old journal decodes to the field DEFAULTS, and
+        // re-encoding then materializes those defaults. To keep this test a true
+        // wire-stability pin (nothing OTHER than the known additive fields
+        // changed), we patch the parsed fixture with exactly those defaults —
+        // `"tif":"GTC"`, the zero-hex `user_id`, `"trade":null` — and require the
+        // patched fixture to match the re-encode byte-for-byte. Any drift in a
+        // pre-existing field still fails loudly. The frozen fixture file itself
+        // is NOT edited.
         let reencoded: serde_json::Value =
             serde_json::to_value(&decoded).expect("re-encode decoded events");
-        let on_disk: serde_json::Value =
+        let mut on_disk: serde_json::Value =
             serde_json::from_str(FIXTURE).expect("parse fixture as value");
+
+        // Event 0 is the AddOrder + OrderAdded; inject the defaulted fields.
+        let add_cmd = on_disk[0]["command"]["AddOrder"]
+            .as_object_mut()
+            .expect("fixture event 0 command is AddOrder");
+        add_cmd.insert("tif".to_string(), serde_json::json!("GTC"));
+        add_cmd.insert(
+            "user_id".to_string(),
+            serde_json::json!(Hash32::zero().to_hex()),
+        );
+        let added_result = on_disk[0]["result"]["OrderAdded"]
+            .as_object_mut()
+            .expect("fixture event 0 result is OrderAdded");
+        added_result.insert("trade".to_string(), serde_json::Value::Null);
+
         assert_eq!(
             reencoded, on_disk,
-            "re-encoded journal diverged from the checked-in v0.5.0 wire format"
+            "re-encoded journal diverged from the checked-in v0.5.0 wire format \
+             (beyond the known #148 additive fields)"
         );
     }
 
@@ -2834,6 +3232,63 @@ mod tests {
             let json2 = serde_json::to_string(&back).expect("re-serialize");
             assert_eq!(json, json2, "round-trip changed the encoding for {event:?}");
         }
+    }
+
+    /// Format-pin guard for the CURRENT (#148) schema: a checked-in journal
+    /// sample written under the enriched schema MUST decode into
+    /// `OptionChainEvent` and re-encode value-identically. Unlike the v0.5.0
+    /// fixture (which predates the additive fields and therefore needs the
+    /// defaults patched in), this fixture already carries `tif` / `user_id` /
+    /// `trade` and the `ReplaceOrder` / `OrderReplaced` variants, so the
+    /// comparison is strict with no patching. It covers `AddOrder` with the
+    /// default and with a non-default `Gtd` tif + nonzero user, `OrderAdded` both
+    /// with `trade: null` and with a deterministic fill payload, and the replace
+    /// pair.
+    ///
+    /// The fixture lives at `tests/fixtures/journal_event_v0.8.0.json`.
+    #[test]
+    fn test_journal_event_v0_8_0_fixture_decodes_and_is_stable() {
+        const FIXTURE: &str = include_str!("../../tests/fixtures/journal_event_v0.8.0.json");
+
+        let decoded: Vec<OptionChainEvent> =
+            serde_json::from_str(FIXTURE).expect("v0.8.0 journal fixture must decode");
+        assert_eq!(decoded.len(), 10, "fixture should hold ten events");
+
+        // Spot-check the #148 shapes landed as expected.
+        assert!(matches!(
+            decoded[0].result,
+            OptionChainResult::OrderAdded { trade: None, .. }
+        ));
+        assert!(matches!(
+            decoded[8].command,
+            OptionChainCommand::AddOrder {
+                tif: TimeInForce::Gtd(1_700_000_000_000),
+                ..
+            }
+        ));
+        assert!(matches!(
+            decoded[8].result,
+            OptionChainResult::OrderAdded { trade: Some(_), .. }
+        ));
+        assert!(matches!(
+            decoded[9].command,
+            OptionChainCommand::ReplaceOrder { price: 105, .. }
+        ));
+        assert!(matches!(
+            decoded[9].result,
+            OptionChainResult::OrderReplaced { .. }
+        ));
+
+        // Strict re-encode: the current schema is fully materialized in the
+        // fixture, so no additive-field patching is needed.
+        let reencoded: serde_json::Value =
+            serde_json::to_value(&decoded).expect("re-encode decoded events");
+        let on_disk: serde_json::Value =
+            serde_json::from_str(FIXTURE).expect("parse fixture as value");
+        assert_eq!(
+            reencoded, on_disk,
+            "re-encoded journal diverged from the checked-in v0.8.0 wire format"
+        );
     }
 
     /// Negative guard proving `deny_unknown_fields` is active at every journal
@@ -2921,6 +3376,60 @@ mod tests {
             serde_json::from_str::<OptionChainEvent>(in_evict_result).is_err(),
             "unknown field inside ExpiredEvicted must be rejected"
         );
+
+        // Extra field inside the #148 enriched AddOrder command struct-variant
+        // (alongside the new tif/user_id fields, to prove they did not weaken
+        // deny_unknown_fields).
+        let in_enriched_add = r#"{
+            "sequence_num": 1,
+            "timestamp_ns": 2,
+            "command": { "AddOrder": {
+                "symbol": "BTC-20240329-50000-C",
+                "order_id": "42",
+                "side": "BUY",
+                "price": 100,
+                "quantity": 10,
+                "tif": "IOC",
+                "user_id": "0707070707070707070707070707070707070707070707070707070707070707",
+                "extra": 1
+            } },
+            "result": { "OrderAdded": { "order_id": "42", "trade": null } }
+        }"#;
+        assert!(
+            serde_json::from_str::<OptionChainEvent>(in_enriched_add).is_err(),
+            "unknown field inside the enriched AddOrder must be rejected"
+        );
+
+        // Extra field inside the #148 ReplaceOrder command struct-variant.
+        let in_replace_command = r#"{
+            "sequence_num": 1,
+            "timestamp_ns": 2,
+            "command": { "ReplaceOrder": {
+                "symbol": "BTC-20240329-50000-C",
+                "order_id": "42",
+                "price": 105,
+                "quantity": 7,
+                "side": "BUY",
+                "extra": 1
+            } },
+            "result": { "OrderReplaced": { "order_id": "42" } }
+        }"#;
+        assert!(
+            serde_json::from_str::<OptionChainEvent>(in_replace_command).is_err(),
+            "unknown field inside ReplaceOrder must be rejected"
+        );
+
+        // Extra field inside the #148 OrderReplaced result struct-variant.
+        let in_replaced_result = r#"{
+            "sequence_num": 1,
+            "timestamp_ns": 2,
+            "command": { "CancelOrder": { "symbol": "BTC-20240329-50000-C", "order_id": "42" } },
+            "result": { "OrderReplaced": { "order_id": "42", "extra": 1 } }
+        }"#;
+        assert!(
+            serde_json::from_str::<OptionChainEvent>(in_replaced_result).is_err(),
+            "unknown field inside OrderReplaced must be rejected"
+        );
     }
 
     /// Pins the 0.7.0 wire format of the appended `EvictExpiredOrders` /
@@ -2975,6 +3484,163 @@ mod tests {
         assert!(
             serde_json::from_str::<OldCommand>(cmd_bytes).is_err(),
             "a binary predating EvictExpiredOrders must reject the new variant tag"
+        );
+    }
+
+    /// Pins the #148 enriched `AddOrder` wire shape: the appended `tif` /
+    /// `user_id` fields, the pricelevel casing of the `Gtd` payload
+    /// (`{"GTD": ms}`, not `snake_case`), and the hex-string `user_id`. Also pins
+    /// that the default `tif`/`user` still serialize explicitly (no
+    /// `skip_serializing_if`), which is what keeps the JSON/bincode encodings
+    /// symmetric across a decode/encode round-trip.
+    #[test]
+    fn test_add_order_wire_format_pinned() {
+        // Non-default tif (Gtd) + nonzero user.
+        let gtd = OptionChainCommand::AddOrder {
+            symbol: "BTC-20240329-50000-C".to_string(),
+            order_id: OrderId::sequential(42),
+            side: Side::Buy,
+            price: 100,
+            quantity: 4,
+            tif: TimeInForce::Gtd(1_700_000_000_000),
+            user_id: Hash32::from([7u8; 32]),
+        };
+        let value = serde_json::to_value(&gtd).expect("serialize");
+        let expected = serde_json::json!({
+            "AddOrder": {
+                "symbol": "BTC-20240329-50000-C",
+                "order_id": "42",
+                "side": "BUY",
+                "price": 100,
+                "quantity": 4,
+                "tif": { "GTD": 1_700_000_000_000_u64 },
+                "user_id": "0707070707070707070707070707070707070707070707070707070707070707"
+            }
+        });
+        assert_eq!(value, expected, "enriched AddOrder wire format drifted");
+
+        // Default tif/user still serialize explicitly.
+        let default = OptionChainCommand::AddOrder {
+            symbol: "BTC-20240329-50000-C".to_string(),
+            order_id: OrderId::sequential(42),
+            side: Side::Sell,
+            price: 110,
+            quantity: 5,
+            tif: TimeInForce::Gtc,
+            user_id: Hash32::zero(),
+        };
+        let default_value = serde_json::to_value(&default).expect("serialize default");
+        assert_eq!(
+            default_value["AddOrder"]["tif"],
+            serde_json::json!("GTC"),
+            "default tif must serialize as \"GTC\""
+        );
+        assert_eq!(
+            default_value["AddOrder"]["user_id"],
+            serde_json::json!(Hash32::zero().to_hex()),
+            "default user_id must serialize as the zero hex string"
+        );
+    }
+
+    /// Pins the wire shape of an `OrderAdded` that carries a fill payload: the
+    /// nested `TradeResult` / `MatchResult` / `Trade` structure, with `Id`s as
+    /// strings and numeric price/quantity/timestamp.
+    #[test]
+    fn test_order_added_with_trade_wire_format_pinned() {
+        let result = OptionChainResult::OrderAdded {
+            order_id: OrderId::sequential(42),
+            trade: Some(deterministic_trade_result()),
+        };
+        let value = serde_json::to_value(&result).expect("serialize");
+        let expected = serde_json::json!({
+            "OrderAdded": {
+                "order_id": "42",
+                "trade": {
+                    "symbol": "BTC-20240329-50000-C",
+                    "match_result": {
+                        "order_id": "42",
+                        "trades": {
+                            "trades": [
+                                {
+                                    "trade_id": "9001",
+                                    "taker_order_id": "42",
+                                    "maker_order_id": "43",
+                                    "price": 100,
+                                    "quantity": 4,
+                                    "taker_side": "BUY",
+                                    "timestamp": 1_700_000_000_000_u64
+                                }
+                            ]
+                        },
+                        "remaining_quantity": 0,
+                        "is_complete": true,
+                        "filled_order_ids": [],
+                        "outcome": "filled"
+                    },
+                    "total_maker_fees": 0,
+                    "total_taker_fees": 0,
+                    "engine_seq": 0,
+                    "quote_notional": 400
+                }
+            }
+        });
+        assert_eq!(value, expected, "OrderAdded-with-trade wire format drifted");
+    }
+
+    /// Pins the #148 `ReplaceOrder` / `OrderReplaced` wire format and proves the
+    /// old-binary-reads-new-journal asymmetry: a binary that predates the
+    /// variant rejects the new tag (unknown variant), independent of
+    /// `deny_unknown_fields`.
+    #[test]
+    fn test_replace_order_wire_format_pinned() {
+        let event = OptionChainEvent {
+            sequence_num: 10,
+            timestamp_ns: 42,
+            command: OptionChainCommand::ReplaceOrder {
+                symbol: "BTC-20240329-50000-C".to_string(),
+                order_id: OrderId::sequential(42),
+                price: 105,
+                quantity: 7,
+                side: Side::Buy,
+            },
+            result: OptionChainResult::OrderReplaced {
+                order_id: OrderId::sequential(42),
+            },
+        };
+        let value = serde_json::to_value(&event).expect("serialize");
+        let expected = serde_json::json!({
+            "sequence_num": 10,
+            "timestamp_ns": 42,
+            "command": { "ReplaceOrder": {
+                "symbol": "BTC-20240329-50000-C",
+                "order_id": "42",
+                "price": 105,
+                "quantity": 7,
+                "side": "BUY"
+            } },
+            "result": { "OrderReplaced": { "order_id": "42" } }
+        });
+        assert_eq!(value, expected, "ReplaceOrder wire format drifted");
+
+        // Old-binary-reads-new-journal: an enum missing the ReplaceOrder arm must
+        // reject the journaled bytes (unknown variant tag).
+        #[derive(serde::Deserialize)]
+        #[serde(rename_all = "PascalCase")]
+        #[allow(dead_code)]
+        enum OldCommand {
+            AddOrder,
+            CancelOrder,
+        }
+        let cmd_bytes = r#"{ "ReplaceOrder": {
+            "symbol": "BTC-20240329-50000-C",
+            "order_id": "42",
+            "price": 105,
+            "quantity": 7,
+            "side": "BUY"
+        } }"#;
+        assert!(
+            serde_json::from_str::<OldCommand>(cmd_bytes).is_err(),
+            "a binary predating ReplaceOrder must reject the new variant tag"
         );
     }
 
@@ -3162,6 +3828,251 @@ mod tests {
         }
         // Nothing was materialized for an unparseable symbol.
         assert_eq!(book.expiration_count(), 0);
+    }
+
+    // ── Submit: add order with tif / user, and fill attribution (#148) ────
+
+    #[test]
+    fn test_submit_add_order_with_tif_and_user_executes_and_journals() {
+        let journal: Arc<dyn OptionChainJournal> = Arc::new(InMemoryOptionChainJournal::new());
+        let book = SequencedUnderlyingOrderBook::with_journal("BTC", Arc::clone(&journal));
+        let user = Hash32::from([9u8; 32]);
+        // A far-future GTD deadline (Unix ms): admission accepts it, so the order
+        // rests rather than being evicted on entry.
+        let tif = TimeInForce::Gtd(10_000_000_000_000);
+
+        let receipt = book
+            .submit_add_order_with(
+                "BTC-20240329-50000-C",
+                OrderId::sequential(1),
+                Side::Buy,
+                100,
+                10,
+                tif,
+                user,
+            )
+            .expect("submit");
+        assert!(receipt.result.is_success(), "got {:?}", receipt.result);
+
+        // The journaled command carries the tif and user identity verbatim.
+        let events = journal.read_from(0).expect("read journal");
+        assert_eq!(events.len(), 1);
+        match &events[0].command {
+            OptionChainCommand::AddOrder {
+                tif: journaled_tif,
+                user_id,
+                ..
+            } => {
+                assert_eq!(*journaled_tif, tif);
+                assert_eq!(*user_id, user);
+            }
+            other => panic!("expected AddOrder, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_submit_add_order_defaults_to_gtc_and_zero_user() {
+        let journal: Arc<dyn OptionChainJournal> = Arc::new(InMemoryOptionChainJournal::new());
+        let book = SequencedUnderlyingOrderBook::with_journal("BTC", Arc::clone(&journal));
+
+        book.submit_add_order(
+            "BTC-20240329-50000-C",
+            OrderId::sequential(1),
+            Side::Buy,
+            100,
+            10,
+        )
+        .expect("submit");
+
+        let events = journal.read_from(0).expect("read journal");
+        match &events[0].command {
+            OptionChainCommand::AddOrder { tif, user_id, .. } => {
+                assert_eq!(*tif, TimeInForce::Gtc);
+                assert_eq!(*user_id, Hash32::zero());
+            }
+            other => panic!("expected AddOrder, got {other:?}"),
+        }
+
+        // And they materialize on the wire as "GTC" + the zero hex string.
+        let value = serde_json::to_value(&events[0]).expect("serialize event");
+        assert_eq!(
+            value["command"]["AddOrder"]["tif"],
+            serde_json::json!("GTC")
+        );
+        assert_eq!(
+            value["command"]["AddOrder"]["user_id"],
+            serde_json::json!(Hash32::zero().to_hex())
+        );
+    }
+
+    #[test]
+    fn test_add_order_old_wire_decodes_with_gtc_and_zero_user_defaults() {
+        // A pre-#148 AddOrder command has no tif / user_id fields. It must decode
+        // to the good-till-cancelled, zero-user defaults so old journals replay
+        // identically.
+        let old_wire = r#"{ "AddOrder": {
+            "symbol": "BTC-20240329-50000-C",
+            "order_id": "1",
+            "side": "BUY",
+            "price": 100,
+            "quantity": 10
+        } }"#;
+        let command: OptionChainCommand =
+            serde_json::from_str(old_wire).expect("old AddOrder wire must decode");
+        match command {
+            OptionChainCommand::AddOrder { tif, user_id, .. } => {
+                assert_eq!(tif, TimeInForce::Gtc);
+                assert_eq!(user_id, Hash32::zero());
+            }
+            other => panic!("expected AddOrder, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_order_added_carries_trade_when_add_fills() {
+        // The fixture seeds a resting call sell@110 qty5; a marketable buy@110
+        // crosses it and executes a fill, so OrderAdded carries the trade.
+        let (book, _, symbol) = make_book_with_orders();
+
+        let receipt = book
+            .submit_add_order(&symbol, OrderId::new(), Side::Buy, 110, 5)
+            .expect("submit");
+        match &receipt.result {
+            OptionChainResult::OrderAdded { trade, .. } => {
+                let trade = trade.as_ref().expect("a crossing add must carry fills");
+                assert!(
+                    !trade.match_result.trades().is_empty(),
+                    "trade payload must record at least one fill"
+                );
+            }
+            other => panic!("expected OrderAdded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_order_added_trade_none_when_add_rests() {
+        // A buy@95 sits below the resting sell@110, so it rests without crossing
+        // and OrderAdded carries no trade.
+        let (book, _, symbol) = make_book_with_orders();
+
+        let receipt = book
+            .submit_add_order(&symbol, OrderId::new(), Side::Buy, 95, 5)
+            .expect("submit");
+        assert!(matches!(
+            receipt.result,
+            OptionChainResult::OrderAdded { trade: None, .. }
+        ));
+    }
+
+    // ── Submit: replace order (#148) ─────────────────────────────────────
+
+    #[test]
+    fn test_submit_replace_order_success_returns_order_replaced() {
+        let book = SequencedUnderlyingOrderBook::new("BTC");
+        let symbol = "BTC-20240329-50000-C";
+        let oid = OrderId::sequential(1);
+        book.submit_add_order(symbol, oid, Side::Buy, 100, 10)
+            .expect("seed add");
+
+        let receipt = book
+            .submit_replace_order(symbol, oid, 105, 7, Side::Buy)
+            .expect("submit replace");
+        match &receipt.result {
+            OptionChainResult::OrderReplaced { order_id } => assert_eq!(*order_id, oid),
+            other => panic!("expected OrderReplaced, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_submit_replace_order_book_not_found() {
+        let book = SequencedUnderlyingOrderBook::new("BTC");
+        // A valid, well-formed symbol whose book was never created: replace uses
+        // the non-creating resolver, so it reports BookNotFound.
+        let receipt = book
+            .submit_replace_order(
+                "BTC-20240329-50000-C",
+                OrderId::sequential(1),
+                105,
+                7,
+                Side::Buy,
+            )
+            .expect("submit");
+        assert!(matches!(
+            receipt.result,
+            OptionChainResult::BookNotFound { .. }
+        ));
+    }
+
+    #[test]
+    fn test_submit_replace_order_unknown_order_rejected_deterministically() {
+        let book = SequencedUnderlyingOrderBook::new("BTC");
+        let symbol = "BTC-20240329-50000-C";
+        // The book exists (one resting order), but the replaced id is not resting.
+        book.submit_add_order(symbol, OrderId::sequential(1), Side::Buy, 100, 10)
+            .expect("seed");
+
+        let unknown = OrderId::sequential(999);
+        let receipt = book
+            .submit_replace_order(symbol, unknown, 105, 7, Side::Buy)
+            .expect("submit");
+        match &receipt.result {
+            OptionChainResult::Rejected { reason } => {
+                assert!(
+                    reason.contains("order not found"),
+                    "reason should name the missing order, got {reason:?}"
+                );
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_submit_replace_order_does_not_vivify_expiration_or_strike() {
+        let book = SequencedUnderlyingOrderBook::new("BTC");
+        assert_eq!(book.expiration_count(), 0);
+
+        let receipt = book
+            .submit_replace_order(
+                "BTC-20240329-50000-C",
+                OrderId::sequential(1),
+                105,
+                7,
+                Side::Buy,
+            )
+            .expect("submit");
+        assert!(matches!(
+            receipt.result,
+            OptionChainResult::BookNotFound { .. }
+        ));
+        // The non-creating resolution left the hierarchy untouched — no expiration
+        // or strike was materialized by the replace.
+        assert_eq!(book.expiration_count(), 0);
+        assert_eq!(book.total_order_count(), 0);
+    }
+
+    #[test]
+    fn test_submit_replace_order_underlying_mismatch_rejected() {
+        let book = SequencedUnderlyingOrderBook::new("BTC");
+        // An ETH symbol against a BTC book is a cross-underlying command, rejected
+        // with the typed reason before any book resolution.
+        let receipt = book
+            .submit_replace_order(
+                "ETH-20240329-50000-C",
+                OrderId::sequential(1),
+                105,
+                7,
+                Side::Buy,
+            )
+            .expect("submit");
+        match &receipt.result {
+            OptionChainResult::Rejected { reason } => {
+                assert!(
+                    reason.contains("ETH") || reason.contains("BTC"),
+                    "reason should name the mismatched underlyings, got {reason:?}"
+                );
+            }
+            other => panic!("expected Rejected, got {other:?}"),
+        }
     }
 
     // ── Submit: cancel order ─────────────────────────────────────────────

--- a/src/orderbook/validation.rs
+++ b/src/orderbook/validation.rs
@@ -13,6 +13,7 @@ use crate::error::{Error, Result};
 /// - **Lot size**: quantities must be exact multiples of the lot size
 /// - **Min order size**: orders below this quantity are rejected
 /// - **Max order size**: orders above this quantity are rejected
+/// - **Max price**: orders priced above this bound are rejected crate-side
 ///
 /// All fields default to `None`, which disables the corresponding validation.
 ///
@@ -45,6 +46,10 @@ pub struct ValidationConfig {
     /// Maximum allowed order quantity. Orders with quantity above this value
     /// are rejected. `None` disables maximum size validation.
     max_order_size: Option<u64>,
+    /// Maximum allowed order price in smallest price units; orders priced above
+    /// are rejected crate-side (the upstream engine has no price-bound hook);
+    /// `None` disables.
+    max_price: Option<u128>,
 }
 
 impl ValidationConfig {
@@ -133,6 +138,31 @@ impl ValidationConfig {
         self
     }
 
+    /// Sets the maximum order price (in smallest price units).
+    ///
+    /// Orders priced above `max_price` are rejected crate-side, because the
+    /// upstream matching engine has no price-bound hook to delegate to.
+    ///
+    /// # Arguments
+    ///
+    /// * `max_price` - Maximum allowed order price in smallest price units
+    ///
+    /// # Footgun
+    ///
+    /// This setter is infallible. Setting `Some(0)` rejects every order (no
+    /// price is `<= 0`); to disable the price bound leave it unset (`None`), and
+    /// call [`validate`](Self::validate) to reject a zero bound as an error.
+    ///
+    /// A finite price bound also lets venues prove upstream fee saturation
+    /// unreachable (see orderbook-rs `FeeSchedule::max_guaranteed_exact_notional_for_bps`,
+    /// available from 0.10.4).
+    #[must_use]
+    #[inline]
+    pub const fn with_max_price(mut self, max_price: u128) -> Self {
+        self.max_price = Some(max_price);
+        self
+    }
+
     /// Returns the configured tick size, if any.
     #[must_use]
     #[inline]
@@ -161,6 +191,13 @@ impl ValidationConfig {
         self.max_order_size
     }
 
+    /// Returns the configured maximum order price, if any.
+    #[must_use]
+    #[inline]
+    pub const fn max_price(&self) -> Option<u128> {
+        self.max_price
+    }
+
     /// Returns `true` if no validation rules are configured.
     #[must_use]
     #[inline]
@@ -169,6 +206,7 @@ impl ValidationConfig {
             && self.lot_size.is_none()
             && self.min_order_size.is_none()
             && self.max_order_size.is_none()
+            && self.max_price.is_none()
     }
 
     /// Validates the configured rules, rejecting structurally-broken settings.
@@ -186,6 +224,7 @@ impl ValidationConfig {
     /// - `tick_size` is set to zero
     /// - `lot_size` is set to zero
     /// - `min_order_size` is set to zero
+    /// - `max_price` is set to zero
     /// - both `min_order_size` and `max_order_size` are set and
     ///   `max_order_size < min_order_size`
     pub fn validate(&self) -> Result<()> {
@@ -202,6 +241,11 @@ impl ValidationConfig {
         if self.min_order_size == Some(0) {
             return Err(Error::configuration(
                 "min_order_size must be at least 1 (got 0); leave it unset to disable minimum-size validation",
+            ));
+        }
+        if self.max_price == Some(0) {
+            return Err(Error::configuration(
+                "max_price must be at least 1 (got 0); leave it unset to disable the price bound",
             ));
         }
         if let (Some(min), Some(max)) = (self.min_order_size, self.max_order_size)
@@ -245,6 +289,13 @@ impl std::fmt::Display for ValidationConfig {
                 write!(f, ", ")?;
             }
             write!(f, "max={max}")?;
+            first = false;
+        }
+        if let Some(max_price) = self.max_price {
+            if !first {
+                write!(f, ", ")?;
+            }
+            write!(f, "max_price={max_price}")?;
         }
         write!(f, ")")
     }
@@ -392,5 +443,48 @@ mod tests {
         // A max with no min is a valid one-sided window.
         let config = ValidationConfig::new().with_max_order_size(500);
         assert!(config.validate().is_ok());
+    }
+
+    // ========== ValidationConfig::max_price tests ==========
+
+    #[test]
+    fn test_validation_config_with_max_price_builder() {
+        let config = ValidationConfig::new().with_max_price(1_000_000);
+        assert_eq!(config.max_price(), Some(1_000_000));
+    }
+
+    #[test]
+    fn test_validation_config_is_empty_false_with_only_max_price() {
+        let config = ValidationConfig::new().with_max_price(500);
+        assert!(!config.is_empty());
+        assert_eq!(config.tick_size(), None);
+        assert_eq!(config.max_order_size(), None);
+    }
+
+    #[test]
+    fn test_validation_config_validate_zero_max_price_rejected() {
+        let config = ValidationConfig::new().with_max_price(0);
+        let err = match config.validate() {
+            Ok(()) => panic!("expected zero max_price to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("max_price"));
+        assert!(err.to_string().contains('0'));
+    }
+
+    #[test]
+    fn test_validation_config_validate_max_price_set_ok() {
+        let config = ValidationConfig::new().with_max_price(1_000_000);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validation_config_display_includes_max_price() {
+        let config = ValidationConfig::new()
+            .with_tick_size(100)
+            .with_max_price(999);
+        let display = format!("{config}");
+        assert!(display.contains("tick=100"));
+        assert!(display.contains("max_price=999"));
     }
 }

--- a/tests/fixtures/journal_event_v0.8.0.json
+++ b/tests/fixtures/journal_event_v0.8.0.json
@@ -1,0 +1,215 @@
+[
+  {
+    "sequence_num": 1,
+    "timestamp_ns": 1700000000000000000,
+    "command": {
+      "AddOrder": {
+        "symbol": "BTC-20240329-50000-C",
+        "order_id": "42",
+        "side": "BUY",
+        "price": 100,
+        "quantity": 10,
+        "tif": "GTC",
+        "user_id": "0000000000000000000000000000000000000000000000000000000000000000"
+      }
+    },
+    "result": {
+      "OrderAdded": {
+        "order_id": "42",
+        "trade": null
+      }
+    }
+  },
+  {
+    "sequence_num": 2,
+    "timestamp_ns": 1700000000000000001,
+    "command": {
+      "CancelOrder": {
+        "symbol": "BTC-20240329-50000-C",
+        "order_id": "42"
+      }
+    },
+    "result": {
+      "OrderCancelled": {
+        "order_id": "42"
+      }
+    }
+  },
+  {
+    "sequence_num": 3,
+    "timestamp_ns": 1700000000000000002,
+    "command": {
+      "MassCancel": {
+        "scope": {
+          "Strike": {
+            "expiration": {
+              "datetime": "2024-03-29T23:59:59Z"
+            },
+            "strike": 50000
+          }
+        },
+        "cancel_type": {
+          "BySide": "SELL"
+        }
+      }
+    },
+    "result": {
+      "MassCancelled": {
+        "cancelled_count": 4
+      }
+    }
+  },
+  {
+    "sequence_num": 4,
+    "timestamp_ns": 1700000000000000003,
+    "command": {
+      "MassCancel": {
+        "scope": "Underlying",
+        "cancel_type": {
+          "ByUser": "0707070707070707070707070707070707070707070707070707070707070707"
+        }
+      }
+    },
+    "result": {
+      "Rejected": {
+        "reason": "boom"
+      }
+    }
+  },
+  {
+    "sequence_num": 5,
+    "timestamp_ns": 1700000000000000004,
+    "command": {
+      "MassCancel": {
+        "scope": {
+          "Book": "BTC-20240329-50000-C"
+        },
+        "cancel_type": "All"
+      }
+    },
+    "result": {
+      "BookNotFound": {
+        "symbol": "ETH-20240329-50000-C"
+      }
+    }
+  },
+  {
+    "sequence_num": 6,
+    "timestamp_ns": 1700000000000000005,
+    "command": {
+      "MassCancel": {
+        "scope": {
+          "Expiration": {
+            "datetime": "2024-03-29T23:59:59Z"
+          }
+        },
+        "cancel_type": "All"
+      }
+    },
+    "result": {
+      "MassCancelled": {
+        "cancelled_count": 0
+      }
+    }
+  },
+  {
+    "sequence_num": 7,
+    "timestamp_ns": 1700000000000000006,
+    "command": {
+      "SetInstrumentStatus": {
+        "symbol": "BTC-20240329-50000-C",
+        "status": "Halted"
+      }
+    },
+    "result": {
+      "StatusChanged": {
+        "symbol": "BTC-20240329-50000-C",
+        "status": "Halted"
+      }
+    }
+  },
+  {
+    "sequence_num": 8,
+    "timestamp_ns": 1700000000000000007,
+    "command": {
+      "EvictExpiredOrders": {
+        "now_ms": 10000000000000
+      }
+    },
+    "result": {
+      "ExpiredEvicted": {
+        "evicted_ids": [
+          "42",
+          "43"
+        ]
+      }
+    }
+  },
+  {
+    "sequence_num": 9,
+    "timestamp_ns": 1700000000000000008,
+    "command": {
+      "AddOrder": {
+        "symbol": "BTC-20240329-50000-C",
+        "order_id": "42",
+        "side": "BUY",
+        "price": 100,
+        "quantity": 4,
+        "tif": {
+          "GTD": 1700000000000
+        },
+        "user_id": "0707070707070707070707070707070707070707070707070707070707070707"
+      }
+    },
+    "result": {
+      "OrderAdded": {
+        "order_id": "42",
+        "trade": {
+          "symbol": "BTC-20240329-50000-C",
+          "match_result": {
+            "order_id": "42",
+            "trades": {
+              "trades": [
+                {
+                  "trade_id": "9001",
+                  "taker_order_id": "42",
+                  "maker_order_id": "43",
+                  "price": 100,
+                  "quantity": 4,
+                  "taker_side": "BUY",
+                  "timestamp": 1700000000000
+                }
+              ]
+            },
+            "remaining_quantity": 0,
+            "is_complete": true,
+            "filled_order_ids": [],
+            "outcome": "filled"
+          },
+          "total_maker_fees": 0,
+          "total_taker_fees": 0,
+          "engine_seq": 0,
+          "quote_notional": 400
+        }
+      }
+    }
+  },
+  {
+    "sequence_num": 10,
+    "timestamp_ns": 1700000000000000009,
+    "command": {
+      "ReplaceOrder": {
+        "symbol": "BTC-20240329-50000-C",
+        "order_id": "42",
+        "price": 105,
+        "quantity": 7,
+        "side": "BUY"
+      }
+    },
+    "result": {
+      "OrderReplaced": {
+        "order_id": "42"
+      }
+    }
+  }
+]

--- a/tests/unit/orderbook_tests.rs
+++ b/tests/unit/orderbook_tests.rs
@@ -1,6 +1,8 @@
 //! Integration tests for the orderbook module.
 
-use option_chain_orderbook::orderbook::{OptionOrderBook, UnderlyingOrderBookManager};
+use option_chain_orderbook::orderbook::{
+    OptionOrderBook, UnderlyingOrderBookManager, ValidationConfig,
+};
 use optionstratlib::prelude::pos_or_panic;
 use optionstratlib::{ExpirationDate, OptionStyle};
 use orderbook_rs::{OrderId, Side};
@@ -209,4 +211,60 @@ fn test_cancel_by_side_across_underlyings() {
     assert_eq!(result.total_cancelled(), 2);
     assert_eq!(result.books_affected(), 2);
     assert_eq!(manager.total_order_count(), 2);
+}
+
+#[test]
+fn test_hierarchy_set_validation_max_price_propagates_to_new_strikes() {
+    let manager = UnderlyingOrderBookManager::new();
+    let exp_date = ExpirationDate::Days(pos_or_panic!(30.0));
+
+    let btc = manager.get_or_create("BTC");
+    // Configure the price bound BEFORE vivifying the expiration/strike so the
+    // new leaf inherits it through the validation propagation path.
+    btc.set_validation(ValidationConfig::new().with_max_price(1_000));
+
+    let exp = btc.get_or_create_expiration(exp_date);
+    let strike = exp.get_or_create_strike(50000);
+
+    // An above-bound add on the freshly vivified leaf is rejected crate-side.
+    let rejected = strike
+        .call()
+        .add_limit_order(OrderId::new(), Side::Buy, 1_001, 10);
+    let err = match rejected {
+        Ok(()) => panic!("above-bound add should be rejected on a propagated leaf"),
+        Err(e) => e,
+    };
+    assert!(err.to_string().contains("max_price"));
+
+    // A within-bound add on the same leaf still succeeds.
+    strike
+        .call()
+        .add_limit_order(OrderId::new(), Side::Buy, 1_000, 10)
+        .unwrap_or_else(|err| panic!("within-bound add failed: {err}"));
+    assert_eq!(strike.call().order_count(), 1);
+}
+
+#[test]
+fn test_replace_order_through_hierarchy_handles() {
+    let manager = UnderlyingOrderBookManager::new();
+    let exp_date = ExpirationDate::Days(pos_or_panic!(30.0));
+
+    let btc = manager.get_or_create("BTC");
+    let exp = btc.get_or_create_expiration(exp_date);
+    let strike = exp.get_or_create_strike(50000);
+
+    let id = OrderId::new();
+    strike
+        .call()
+        .add_limit_order(id, Side::Buy, 100, 10)
+        .unwrap_or_else(|err| panic!("add failed: {err}"));
+
+    // Replace through the strike's call() leaf handle.
+    let replaced = strike
+        .call()
+        .replace_order(id, 110, 20, Side::Buy)
+        .unwrap_or_else(|err| panic!("replace failed: {err}"));
+    assert!(replaced, "replace should report a hit");
+    assert_eq!(strike.call().best_bid(), Some(110));
+    assert_eq!(strike.call().order_count(), 1);
 }

--- a/tests/unit/sequencer_tests.rs
+++ b/tests/unit/sequencer_tests.rs
@@ -897,3 +897,90 @@ fn test_replay_old_style_add_order_journal_applies_gtc_defaults() {
         "an old-style AddOrder must replay to the Gtc / zero-user default state"
     );
 }
+
+#[test]
+fn test_replay_rejected_after_fills_ioc_remainder_equals_live() {
+    // Error-after-fills: an IOC buy for more than the resting liquidity consumes
+    // the entire resting ask (a real, listener-visible fill) and THEN the engine
+    // returns a typed "insufficient liquidity" error for the remainder it can
+    // neither fill nor rest. So the journaled result is `Rejected` even though
+    // contracts actually traded. #148 makes this path reachable through the
+    // journaled stream for the first time (IOC via `submit_add_order_with`); this
+    // test pins that submit and replay stay equivalent across it.
+    //
+    // Empirically observed result shape (orderbook-rs 0.10.3): `Rejected` with
+    // reason "…Insufficient liquidity for BUY order: requested 10, available 5",
+    // with the resting ask fully consumed by the partial fill.
+    let journal = Arc::new(InMemoryOptionChainJournal::new());
+    let symbol = "BTC-20240329-50000-C";
+
+    let live = fresh_book(&journal);
+    // Resting ask: 5 contracts at 100.
+    live.submit_add_order(symbol, oid(1), Side::Sell, 100, 5)
+        .expect("seed resting ask");
+    // IOC buy for 10 at the crossing price: fills the 5 available, then errors on
+    // the 5-contract remainder.
+    let receipt = live
+        .submit_add_order_with(
+            symbol,
+            oid(2),
+            Side::Buy,
+            100,
+            10,
+            TimeInForce::Ioc,
+            Hash32::zero(),
+        )
+        .expect("submit ioc: journaling succeeds even though the result is a rejection");
+
+    // (1) The journaled result is Rejected, yet the resting ask was fully consumed
+    //     on the live book — the fills happened, listener-visible only.
+    assert!(
+        matches!(receipt.result, OptionChainResult::Rejected { .. }),
+        "IOC-over-liquidity must journal a Rejected result, got {:?}",
+        receipt.result
+    );
+    let live_leaf = call_leaf(&live, symbol).expect("live leaf");
+    assert_eq!(
+        live_leaf.call().best_ask(),
+        None,
+        "the resting ask must be fully consumed by the partial fill"
+    );
+    assert_eq!(
+        live_leaf.call().total_ask_depth(),
+        0,
+        "no ask depth remains after the fill"
+    );
+    assert_eq!(
+        live_leaf.call().order_count(),
+        0,
+        "the IOC remainder did not rest"
+    );
+
+    // The journaled event's result matches the receipt (Rejected).
+    let events = journal.read_from(0).expect("read journal");
+    assert_eq!(
+        events.len(),
+        2,
+        "the seed add and the IOC are both journaled"
+    );
+    assert!(
+        matches!(events[1].result, OptionChainResult::Rejected { .. }),
+        "the journaled IOC result must be Rejected"
+    );
+
+    let live_snapshot = snapshot(&live);
+
+    // (2) Replay into a fresh, identically-configured instance reproduces the
+    //     exact same full-state snapshot — the fill-then-reject is deterministic.
+    let replay = fresh_book(&journal);
+    let replayed = replay.replay(0).expect("replay");
+    assert_eq!(replayed, 2, "replay re-runs both journaled commands");
+    // (3) Replay reads the journal, it never appends: the length is unchanged.
+    assert_eq!(journal.len(), 2, "replay must not mutate the journal");
+
+    assert_eq!(
+        live_snapshot,
+        snapshot(&replay),
+        "replayed error-after-fills state must equal live"
+    );
+}

--- a/tests/unit/sequencer_tests.rs
+++ b/tests/unit/sequencer_tests.rs
@@ -36,10 +36,12 @@
 use option_chain_orderbook::SymbolParser;
 use option_chain_orderbook::orderbook::{
     InMemoryOptionChainJournal, InstrumentRegistry, InstrumentStatus, MassCancelScope,
-    MassCancelType, OptionChainJournal, OptionOrderBook, SequencedUnderlyingOrderBook, SymbolIndex,
+    MassCancelType, OptionChainEvent, OptionChainJournal, OptionChainResult, OptionOrderBook,
+    SequencedUnderlyingOrderBook, SymbolIndex,
 };
 use optionstratlib::OptionStyle;
 use orderbook_rs::{Clock, OrderId, Side, StubClock, TimeInForce};
+use pricelevel::Hash32;
 use std::sync::Arc;
 
 // ── Deterministic test inputs ──────────────────────────────────────────────
@@ -157,8 +159,49 @@ fn drive_command_prefix(book: &SequencedUnderlyingOrderBook) -> usize {
     )
     .expect("mass cancel b60 strike sell");
 
-    // 15 adds + 2 cancels + 1 halt + 1 rejected add + 2 mass cancels.
-    21
+    // ── #148 behaviors on a fresh expiration C (kept off A/B so the existing
+    //    per-contract spot-checks are undisturbed): a crossing add that fills, an
+    //    IOC add, an add with a nonzero user identity, a replace that rematches
+    //    at a crossing level, and a replace of an unknown id (rejected). All are
+    //    deterministic, so replay rebuilds identical state. ──
+    let c45c = "BTC-20240927-45000-C";
+    let c50c = "BTC-20240927-50000-C";
+    let user_x = Hash32::from([3u8; 32]);
+
+    // c45c: a resting sell owned by a nonzero user; a marketable buy then crosses
+    // it and executes a partial fill, leaving the sell resting at reduced size.
+    book.submit_add_order_with(c45c, oid(20), Side::Sell, 500, 5, TimeInForce::Gtc, user_x)
+        .expect("add c45c sell (nonzero user)");
+    book.submit_add_order(c45c, oid(21), Side::Buy, 500, 3)
+        .expect("add c45c crossing buy (fills)");
+    // An IOC buy below the resting ask crosses nothing and does not rest: a
+    // deterministic no-op on resting state.
+    book.submit_add_order_with(
+        c45c,
+        oid(22),
+        Side::Buy,
+        400,
+        4,
+        TimeInForce::Ioc,
+        Hash32::zero(),
+    )
+    .expect("add c45c ioc buy");
+
+    // c50c: a resting sell and a resting buy below it; re-pricing the buy up to
+    // the ask makes the replacement rematch and clear both orders.
+    book.submit_add_order(c50c, oid(23), Side::Sell, 600, 5)
+        .expect("add c50c sell");
+    book.submit_add_order(c50c, oid(24), Side::Buy, 580, 5)
+        .expect("add c50c buy below ask");
+    book.submit_replace_order(c50c, oid(24), 600, 5, Side::Buy)
+        .expect("replace c50c buy up to crossing level");
+    // A replace of an id that is not resting is a deterministic rejection.
+    book.submit_replace_order(c50c, oid(999), 100, 1, Side::Buy)
+        .expect("replace unknown id (rejected)");
+
+    // 15 adds + 2 cancels + 1 halt + 1 rejected add + 2 mass cancels (expirations
+    // A/B) plus the 7 #148 commands on expiration C (5 adds + 2 replaces).
+    28
 }
 
 // ── Comparable full-state snapshot (the oracle) ────────────────────────────
@@ -400,10 +443,12 @@ fn test_replay_equals_live_full_state_oracle() {
 
     // Spot-check the live structure so the prefix's intent is explicit and a
     // silently-rejected order would be caught before the oracle runs.
-    // The halted a55c keeps its 3 resting orders; the rejected add rested
-    // nothing, so the total is unchanged at 10.
-    assert_eq!(live.expiration_count(), 2);
-    assert_eq!(live.total_order_count(), 10);
+    // Expirations A/B leave 10 resting orders (the halted a55c keeps its 3; the
+    // rejected add rested nothing). The #148 expiration C adds one net resting
+    // order (c45c's partially-filled sell; c50c is cleared by its replace
+    // rematch), for 11 total across three expirations.
+    assert_eq!(live.expiration_count(), 3);
+    assert_eq!(live.total_order_count(), 11);
     let exp_a = live
         .underlying()
         .get_expiration(
@@ -499,8 +544,9 @@ fn test_replay_registry_ids_match_live() {
             "instrument symbol diverged for id {live_id}"
         );
     }
-    // Six leaf books: 3 strikes × (call + put).
-    assert_eq!(live_ids.len(), 6);
+    // Ten leaf books: 5 strikes × (call + put) — A 50000/55000, B 60000, and the
+    // #148 expiration C 45000/50000.
+    assert_eq!(live_ids.len(), 10);
 }
 
 #[test]
@@ -548,8 +594,8 @@ fn test_replay_into_empty_book_then_resume_is_consistent() {
         .submit_add_order("BTC-20240329-50000-C", new_oid, Side::Buy, 101, 2)
         .expect("post-replay add");
     assert_eq!(journal.len(), submitted + 1);
-    // 10 rebuilt resting orders + 1 new.
-    assert_eq!(resumed.total_order_count(), 11);
+    // 11 rebuilt resting orders + 1 new.
+    assert_eq!(resumed.total_order_count(), 12);
 }
 
 // ── Concurrent submit: gate ordering + replay-under-load oracle ─────────────
@@ -762,5 +808,92 @@ fn test_replay_with_injected_stub_clock_equals_live() {
         live_snapshot,
         snapshot(&replay),
         "replayed state under a fresh StubClock must equal live state under its own fresh StubClock"
+    );
+}
+
+#[test]
+fn test_replay_replace_rematch_equals_live() {
+    // A focused journal whose replace re-prices a resting buy up to the ask so it
+    // rematches and clears both orders, plus one untouched resting bid. Replaying
+    // that journal into a fresh book must rebuild identical state — the replace
+    // rematches identically because replay re-runs it through the same engine
+    // path.
+    let journal = Arc::new(InMemoryOptionChainJournal::new());
+    let symbol = "BTC-20240329-50000-C";
+
+    let live = fresh_book(&journal);
+    live.submit_add_order(symbol, oid(1), Side::Sell, 600, 5)
+        .expect("seed sell");
+    live.submit_add_order(symbol, oid(2), Side::Buy, 580, 5)
+        .expect("seed buy below ask");
+    // An untouched resting bid so the rebuilt book is non-empty after the rematch.
+    live.submit_add_order(symbol, oid(3), Side::Buy, 100, 4)
+        .expect("resting bid");
+    let replaced = live
+        .submit_replace_order(symbol, oid(2), 600, 5, Side::Buy)
+        .expect("replace up to the crossing level");
+    assert!(
+        matches!(replaced.result, OptionChainResult::OrderReplaced { .. }),
+        "replace must succeed live: {:?}",
+        replaced.result
+    );
+
+    let live_snapshot = snapshot(&live);
+
+    let replay = fresh_book(&journal);
+    let replayed = replay.replay(0).expect("replay");
+    assert_eq!(replayed, 4, "replay re-runs all four journaled commands");
+    assert_eq!(
+        live_snapshot,
+        snapshot(&replay),
+        "replayed replace-rematch state must equal live"
+    );
+}
+
+#[test]
+fn test_replay_old_style_add_order_journal_applies_gtc_defaults() {
+    // A journal written before #148: the AddOrder command has no tif / user_id,
+    // and the OrderAdded result has no trade. It must decode (fields defaulting
+    // to Gtc / zero user / no trade) and replay into the SAME state a current
+    // Gtc, zero-user add produces.
+    let symbol = "BTC-20240329-50000-C";
+
+    // Live equivalent via the current API with the explicit pre-#148 defaults.
+    let live_journal = Arc::new(InMemoryOptionChainJournal::new());
+    let live = fresh_book(&live_journal);
+    live.submit_add_order(symbol, oid(1), Side::Buy, 100, 10)
+        .expect("live add");
+    let live_snapshot = snapshot(&live);
+
+    // Hand-built OLD-style journal JSON: no tif / user_id / trade fields.
+    let old_journal_json = r#"[
+        {
+            "sequence_num": 0,
+            "timestamp_ns": 1700000000000000000,
+            "command": { "AddOrder": {
+                "symbol": "BTC-20240329-50000-C",
+                "order_id": "1",
+                "side": "BUY",
+                "price": 100,
+                "quantity": 10
+            } },
+            "result": { "OrderAdded": { "order_id": "1" } }
+        }
+    ]"#;
+    let events: Vec<OptionChainEvent> =
+        serde_json::from_str(old_journal_json).expect("old-style journal must decode");
+
+    let replay_journal = Arc::new(InMemoryOptionChainJournal::new());
+    for event in &events {
+        replay_journal.append(event).expect("append old event");
+    }
+    let replay = fresh_book(&replay_journal);
+    let replayed = replay.replay(0).expect("replay old journal");
+    assert_eq!(replayed, 1, "the single old-style event replays");
+
+    assert_eq!(
+        live_snapshot,
+        snapshot(&replay),
+        "an old-style AddOrder must replay to the Gtc / zero-user default state"
     );
 }


### PR DESCRIPTION
## Stack

- **Stack: #147 → #148 (this PR is 2 of 2, the top of the stack).**
- Base branch: `stack/1-147-deterministic-seams` — **already merged as #149**, so the diff against `main` now shows only this PR's commits.
- Stacked on: #149 (merged).
- Includes the release prep: version bump to **0.8.0**, CHANGELOG and `MIGRATING-0.8.0.md`.

## Summary

A venue wrapping the sequenced hierarchy could not capture every matching outcome losslessly: `OrderAdded` dropped the fills, `AddOrder` had no TIF or account identity, the trade-capture slot had no consuming read, there was no atomic replace, and no enforceable price bound existed. This PR closes all five gaps on top of #147's determinism seams and prepares the 0.8.0 release.

## Changes

- **`OrderAdded` carries the fills**: new `trade: Option<TradeResult>` — `Some` iff the add crossed, attributed per-call via the engine's `_with_result` primitive (never the shared capture slot). A journaled `Rejected` after real fills (unfillable IOC remainder, STP taker-cancel) is deterministic, documented, and pinned by a replay test.
- **`AddOrder` carries `tif` + `user_id`** (serde defaults `Gtc` / zero): TIF variety and account/STP identity ride the journaled path. New `submit_add_order_with(...)`; `submit_add_order` unchanged.
- **Atomic replace**: `ReplaceOrder` command + `OrderReplaced` result + leaf `replace_order()` over the engine's validate-first `OrderUpdate::Replace` — the original order survives any rejection; a replace resolves via the non-creating lookup and never vivifies strikes.
- **Capture slot take/clear**: `take_trade_result()` (atomic consuming read) and `clear_trade_capture()`, closing the stale-read hole.
- **Max price bound**: `ValidationConfig::with_max_price` enforced crate-side on every add and replace path (the engine has no price-bound hook); readback merges the leaf-held bound.
- **Release prep**: 0.8.0 bump (required — the variant-field additions are source-breaking against the published 0.7.0 baseline), CHANGELOG entry covering #147 + #148, `MIGRATING-0.8.0.md`.

## Technical decisions

- `trade` is `Some` only when fills occurred: `None` stays the canonical no-fill representation (identical to what old journals decode to), keeps journals small, and shrinks the non-replay-stable payload surface. No `skip_serializing_if` (encode/decode symmetry).
- Wire compatibility is scoped honestly: additive `#[serde(default)]` fields keep every pre-0.8.0 **JSON** journal decoding and replaying identically (frozen v0.5.0 fixture test, patched in-memory only); positional codecs (bincode) cannot apply missing-field defaults — documented in the variant docs, CHANGELOG and migration guide. Variant appends (`ReplaceOrder`/`OrderReplaced`) are codec-safe.
- `TradeResult.engine_seq`, trade ids and trade timestamps are not replay-stable until [OrderBook-rs#199](https://github.com/joaquinbejar/OrderBook-rs/issues/199) ships; replay discards journaled results by design, so the replay==live state oracle is unaffected.
- Replace fills are listener-only in v1; carrying them in `OrderReplaced` is a follow-up once #199 makes trade ids replay-stable.
- Max price rejection is one branch on an immutable `Option<u128>` with `#[cold]` error construction — zero cost on the happy path (hot-path review clean).

## Public API impact

- `OptionChainCommand::AddOrder` + `tif`, `user_id`; `OptionChainResult::OrderAdded` + `trade`; new `ReplaceOrder` / `OrderReplaced` variants (appended; enums `non_exhaustive`).
- New: `SequencedUnderlyingOrderBook::{submit_add_order_with, submit_replace_order}`; `OptionOrderBook::{replace_order, take_trade_result, clear_trade_capture}`; `ValidationConfig::{with_max_price, max_price}`.
- Source break: literal construction / full-field patterns of `AddOrder` / `OrderAdded` need the new fields (or `..`) — walkthrough in `MIGRATING-0.8.0.md`. No new re-exports needed (all types already at the crate root). `src/lib.rs` docs untouched → README unchanged.

## Testing

- [x] Unit tests added or updated
- [x] Round-trip serde tests for new event / DTO shapes
- [x] Integration tests under `tests/unit/` added or updated (if applicable)
- [x] Replay determinism covered for sequencer changes (replayed state == live)
- [x] `make pre-push` run locally and clean

New coverage: wire pins for enriched `AddOrder` (GTD casing + hex user), `OrderAdded`-with-trade (deterministic fixture payload — no wall clock / random ids), `ReplaceOrder` (+ old-binary-rejects-new-variant simulation); strict v0.8.0 fixture + patched v0.5.0 back-compat fixture test; deny-unknown-fields probes; replay oracles extended with crossing fills, IOC, nonzero user, replace-that-rematches, unknown-id replace; focused `test_replay_replace_rematch_equals_live`, `test_replay_old_style_add_order_journal_applies_gtc_defaults`, and `test_replay_rejected_after_fills_ioc_remainder_equals_live`; max-price across all 8 add paths + replace; capture take/clear incl. poisoned-lock recovery. Totals: **861 lib + 36 integration + 110 doctests, 0 failures**.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic on protocol counters — no `saturating_*` / `wrapping_*`
- [x] No `unsafe` introduced
- [x] Layering respected (one-way leaf-up; Greeks / eventing not depended on by the core hierarchy)
- [x] Matching delegated to `orderbook-rs`; Greeks delegated to `optionstratlib`
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) updated if the public surface changed

Closes #148
