### PR TITLE
Per-contract price banding on ContractSpecs, tightest-wins (#152)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,13 @@ matching engine itself is `orderbook-rs`. On top of that engine it provides:
   [`orderbook::ContractSpecs`], [`orderbook::StrikeGenerator`], and
   [`orderbook::StrikeRangeConfig`] for fast lookup and strike management.
 - **Order policy hooks**: a crate-local [`orderbook::ValidationConfig`]
-  (order/price/qty limits) plus the upstream [`orderbook::FeeSchedule`] and
-  self-trade prevention [`orderbook::STPMode`] — all applied by `orderbook-rs`
-  at the leaf engine.
+  (order/qty limits and an inclusive `[min_price, max_price]` price band)
+  plus the upstream [`orderbook::FeeSchedule`] and self-trade prevention
+  [`orderbook::STPMode`]. Tick/lot/size limits, fees, and STP are applied by
+  `orderbook-rs` at the leaf engine; the price band is enforced crate-side
+  (the engine has no price-bound hook) and, when both a
+  [`orderbook::ContractSpecs`] band and a validation band apply to the same
+  contract, they are merged tightest-wins.
 - **Optional eventing**: NATS publishing (`nats` feature) and a
   command/event/journal/replay sequencer (`sequencer` feature).
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,9 +122,13 @@
 //!   [`orderbook::ContractSpecs`], [`orderbook::StrikeGenerator`], and
 //!   [`orderbook::StrikeRangeConfig`] for fast lookup and strike management.
 //! - **Order policy hooks**: a crate-local [`orderbook::ValidationConfig`]
-//!   (order/price/qty limits) plus the upstream [`orderbook::FeeSchedule`] and
-//!   self-trade prevention [`orderbook::STPMode`] — all applied by `orderbook-rs`
-//!   at the leaf engine.
+//!   (order/qty limits and an inclusive `[min_price, max_price]` price band)
+//!   plus the upstream [`orderbook::FeeSchedule`] and self-trade prevention
+//!   [`orderbook::STPMode`]. Tick/lot/size limits, fees, and STP are applied by
+//!   `orderbook-rs` at the leaf engine; the price band is enforced crate-side
+//!   (the engine has no price-bound hook) and, when both a
+//!   [`orderbook::ContractSpecs`] band and a validation band apply to the same
+//!   contract, they are merged tightest-wins.
 //! - **Optional eventing**: NATS publishing (`nats` feature) and a
 //!   command/event/journal/replay sequencer (`sequencer` feature).
 //!

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -341,8 +341,15 @@ pub struct OptionOrderBook {
     /// Crate-side maximum order price (smallest price units); orders priced
     /// above are rejected before reaching the engine. The upstream engine has
     /// no price-bound hook, so this bound cannot be delegated and is enforced
-    /// here. `None` disables the bound.
+    /// here. `None` disables the upper bound.
     max_price: Option<u128>,
+    /// Crate-side minimum order price (smallest price units); orders priced
+    /// below are rejected before reaching the engine. Same rationale as
+    /// [`max_price`](Self::max_price): the engine has no price-bound hook.
+    /// `None` disables the lower bound. Together the two form an inclusive
+    /// `[min_price, max_price]` band checked in
+    /// [`check_price_band`](Self::check_price_band).
+    min_price: Option<u128>,
 }
 
 impl OptionOrderBook {
@@ -372,12 +379,17 @@ impl OptionOrderBook {
         if let Some(ref validation) = config.validation {
             Self::apply_validation(&mut book, validation);
         }
-        // The max-price bound is enforced crate-side (no engine hook), so keep a
-        // copy on the book rather than delegating it to the inner order book.
+        // The price band is enforced crate-side (no engine hook), so keep a copy
+        // of each bound on the book rather than delegating it to the inner order
+        // book.
         let max_price = config
             .validation
             .as_ref()
             .and_then(ValidationConfig::max_price);
+        let min_price = config
+            .validation
+            .as_ref()
+            .and_then(ValidationConfig::min_price);
         if let Some(schedule) = config.fee_schedule {
             book.set_fee_schedule(Some(schedule));
         }
@@ -464,6 +476,7 @@ impl OptionOrderBook {
             trade_capture_armed: armed,
             terminal_counters,
             max_price,
+            min_price,
         }
     }
 
@@ -571,9 +584,10 @@ impl OptionOrderBook {
         if let Some(max) = config.max_order_size() {
             book.set_max_order_size(max);
         }
-        // `max_price` is intentionally NOT delegated to the engine: `orderbook_rs`
-        // exposes no price-bound setter, so the bound is stored on the leaf and
-        // enforced crate-side in `check_max_price`.
+        // The price band (`min_price` / `max_price`) is intentionally NOT
+        // delegated to the engine: `orderbook_rs` exposes no price-bound setter,
+        // so the bounds are stored on the leaf and enforced crate-side in
+        // `check_price_band`.
     }
 
     /// Returns the current validation configuration read back from the underlying book,
@@ -593,11 +607,14 @@ impl OptionOrderBook {
         if let Some(max) = self.book.max_order_size() {
             config = config.with_max_order_size(max);
         }
-        // The price bound lives on the leaf, not the engine, so merge it back in
-        // before the emptiness check so a book configured with only a max_price
-        // still reports its config.
+        // The price band lives on the leaf, not the engine, so merge both bounds
+        // back in before the emptiness check so a book configured with only a
+        // band still reports its config.
         if let Some(bound) = self.max_price {
             config = config.with_max_price(bound);
+        }
+        if let Some(bound) = self.min_price {
+            config = config.with_min_price(bound);
         }
         if config.is_empty() {
             None
@@ -1007,17 +1024,24 @@ impl OptionOrderBook {
         }
     }
 
-    /// Rejects an order priced above the crate-side `max_price` bound.
+    /// Rejects an order priced outside the crate-side `[min_price, max_price]`
+    /// band.
     ///
-    /// The happy path (no bound, or price within the bound) is allocation-free;
-    /// the error construction is offloaded to a `#[cold]` helper so the check
-    /// stays branch-predictable on the submission hot path.
+    /// Checks the upper bound first, then the lower bound — at most two `Option`
+    /// compares. The happy path (no band, or price within the band) is
+    /// allocation-free; each error construction is offloaded to a `#[cold]`
+    /// helper so the check stays branch-predictable on the submission hot path.
     #[inline]
-    fn check_max_price(&self, price: u128) -> Result<()> {
+    fn check_price_band(&self, price: u128) -> Result<()> {
         if let Some(bound) = self.max_price
             && price > bound
         {
             return Err(self.max_price_exceeded(price, bound));
+        }
+        if let Some(bound) = self.min_price
+            && price < bound
+        {
+            return Err(self.min_price_violated(price, bound));
         }
         Ok(())
     }
@@ -1029,6 +1053,17 @@ impl OptionOrderBook {
     fn max_price_exceeded(&self, price: u128, bound: u128) -> Error {
         Error::validation(format!(
             "price {price} exceeds max_price {bound} for {}",
+            self.symbol
+        ))
+    }
+
+    /// Builds the `min_price` violation error. Cold + un-inlined so the common
+    /// in-bounds path carries none of the formatting code.
+    #[cold]
+    #[inline(never)]
+    fn min_price_violated(&self, price: u128, bound: u128) -> Error {
+        Error::validation(format!(
+            "price {price} is below min_price {bound} for {}",
             self.symbol
         ))
     }
@@ -1046,8 +1081,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
-    ///   configured `max_price` bound.
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
     pub fn add_limit_order(
         &self,
         order_id: OrderId,
@@ -1056,7 +1091,7 @@ impl OptionOrderBook {
         quantity: u64,
     ) -> Result<()> {
         self.check_active()?;
-        self.check_max_price(price)?;
+        self.check_price_band(price)?;
         self.book
             .add_limit_order(order_id, price, quantity, side, TimeInForce::Gtc, None)?;
         Ok(())
@@ -1076,8 +1111,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
-    ///   configured `max_price` bound.
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
     pub fn add_limit_order_with_tif(
         &self,
         order_id: OrderId,
@@ -1087,7 +1122,7 @@ impl OptionOrderBook {
         tif: TimeInForce,
     ) -> Result<()> {
         self.check_active()?;
-        self.check_max_price(price)?;
+        self.check_price_band(price)?;
         self.book
             .add_limit_order(order_id, price, quantity, side, tif, None)?;
         Ok(())
@@ -1110,8 +1145,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
-    ///   configured `max_price` bound.
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order
     ///   (e.g., `MissingUserId` when STP is enabled and `user_id` is zero).
     pub fn add_limit_order_with_user(
@@ -1123,7 +1158,7 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<()> {
         self.check_active()?;
-        self.check_max_price(price)?;
+        self.check_price_band(price)?;
         self.book.add_limit_order_with_user(
             order_id,
             price,
@@ -1153,8 +1188,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
-    ///   configured `max_price` bound.
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order.
     pub fn add_limit_order_with_tif_and_user(
         &self,
@@ -1166,7 +1201,7 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<()> {
         self.check_active()?;
-        self.check_max_price(price)?;
+        self.check_price_band(price)?;
         self.book
             .add_limit_order_with_user(order_id, price, quantity, side, tif, user_id, None)?;
         Ok(())
@@ -1209,8 +1244,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
-    ///   configured `max_price` bound.
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order.
     ///
     /// On an error-after-fills path (an unfillable IOC remainder, or a
@@ -1226,7 +1261,7 @@ impl OptionOrderBook {
         quantity: u64,
     ) -> Result<TradeResult> {
         self.check_active()?;
-        self.check_max_price(price)?;
+        self.check_price_band(price)?;
         let (_order, trade) = self.book.add_limit_order_with_result(
             order_id,
             price,
@@ -1248,8 +1283,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
-    ///   configured `max_price` bound.
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order
     ///   (including error-after-fills paths, where executed fills reach only the trade listener).
     pub fn add_limit_order_with_tif_full(
@@ -1261,7 +1296,7 @@ impl OptionOrderBook {
         tif: TimeInForce,
     ) -> Result<TradeResult> {
         self.check_active()?;
-        self.check_max_price(price)?;
+        self.check_price_band(price)?;
         let (_order, trade) = self
             .book
             .add_limit_order_with_result(order_id, price, quantity, side, tif, None)?;
@@ -1278,8 +1313,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
-    ///   configured `max_price` bound.
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order
     ///   (including error-after-fills paths, where executed fills reach only the trade listener).
     pub fn add_limit_order_with_user_full(
@@ -1291,7 +1326,7 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<TradeResult> {
         self.check_active()?;
-        self.check_max_price(price)?;
+        self.check_price_band(price)?;
         let (_order, trade) = self.book.add_limit_order_with_user_and_result(
             order_id,
             price,
@@ -1315,8 +1350,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
-    ///   configured `max_price` bound.
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream book rejects the order
     ///   (including error-after-fills paths, where executed fills reach only the trade listener).
     pub fn add_limit_order_with_tif_and_user_full(
@@ -1329,7 +1364,7 @@ impl OptionOrderBook {
         user_id: Hash32,
     ) -> Result<TradeResult> {
         self.check_active()?;
-        self.check_max_price(price)?;
+        self.check_price_band(price)?;
         let (_order, trade) = self.book.add_limit_order_with_user_and_result(
             order_id, price, quantity, side, tif, user_id, None,
         )?;
@@ -1397,8 +1432,8 @@ impl OptionOrderBook {
     ///
     /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
     ///   [`Active`](InstrumentStatus::Active).
-    /// - [`ValidationError`](crate::Error::ValidationError) if `price` exceeds the
-    ///   configured `max_price` bound.
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
     /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream engine rejects the
     ///   replacement (e.g. a tick/lot shape violation or a risk/STP rejection);
     ///   on any such rejection the original order survives.
@@ -1410,7 +1445,7 @@ impl OptionOrderBook {
         side: Side,
     ) -> Result<bool> {
         self.check_active()?;
-        self.check_max_price(price)?;
+        self.check_price_band(price)?;
         // Map the engine's validate-first replace like `cancel_order`: Some =>
         // replaced, None => the order was not resting, Err => a real engine
         // rejection (with the original left untouched).
@@ -4363,6 +4398,153 @@ mod tests {
             .expect("config present with only max_price");
         assert_eq!(config.max_price(), Some(2_000));
         assert_eq!(config.tick_size(), None);
+    }
+
+    // ── min_price / price-band leaf enforcement ─────────────────────────
+
+    /// Builds a book whose only validation rules are an inclusive price band.
+    fn band_book(min: u128, max: u128) -> OptionOrderBook {
+        OptionOrderBook::new_with_config(
+            "BTC-20240329-50000-C",
+            OptionStyle::Call,
+            BookConfig {
+                validation: Some(
+                    ValidationConfig::new()
+                        .with_min_price(min)
+                        .with_max_price(max),
+                ),
+                ..BookConfig::default()
+            },
+        )
+    }
+
+    #[test]
+    fn test_min_price_add_below_bound_rejected_all_eight_paths() {
+        const MIN: u128 = 500;
+        const MAX: u128 = 5_000;
+        const BELOW: u128 = 499;
+        let user = Hash32::from([4u8; 32]);
+        let book = band_book(MIN, MAX);
+
+        // Every add entry point must apply the lower band bound. Normalize each
+        // return type to `Result<()>` so the eight paths check uniformly.
+        let results: Vec<Result<()>> = vec![
+            book.add_limit_order(OrderId::new(), Side::Buy, BELOW, 10),
+            book.add_limit_order_with_tif(OrderId::new(), Side::Buy, BELOW, 10, TimeInForce::Gtc),
+            book.add_limit_order_with_user(OrderId::new(), Side::Buy, BELOW, 10, user),
+            book.add_limit_order_with_tif_and_user(
+                OrderId::new(),
+                Side::Buy,
+                BELOW,
+                10,
+                TimeInForce::Gtc,
+                user,
+            ),
+            book.add_limit_order_full(OrderId::new(), Side::Buy, BELOW, 10)
+                .map(|_| ()),
+            book.add_limit_order_with_tif_full(
+                OrderId::new(),
+                Side::Buy,
+                BELOW,
+                10,
+                TimeInForce::Gtc,
+            )
+            .map(|_| ()),
+            book.add_limit_order_with_user_full(OrderId::new(), Side::Buy, BELOW, 10, user)
+                .map(|_| ()),
+            book.add_limit_order_with_tif_and_user_full(
+                OrderId::new(),
+                Side::Buy,
+                BELOW,
+                10,
+                TimeInForce::Gtc,
+                user,
+            )
+            .map(|_| ()),
+        ];
+
+        assert_eq!(results.len(), 8);
+        for (i, res) in results.into_iter().enumerate() {
+            assert!(
+                matches!(res, Err(Error::ValidationError { .. })),
+                "add path {i} must reject a below-band price with ValidationError"
+            );
+        }
+        assert_eq!(book.order_count(), 0);
+    }
+
+    #[test]
+    fn test_price_band_at_both_bounds_inclusive_accepted() {
+        const MIN: u128 = 500;
+        const MAX: u128 = 5_000;
+        let book = band_book(MIN, MAX);
+        // Both bounds are inclusive.
+        book.add_limit_order(OrderId::new(), Side::Buy, MIN, 10)
+            .expect("price at the lower bound must be accepted");
+        book.add_limit_order(OrderId::new(), Side::Sell, MAX, 10)
+            .expect("price at the upper bound must be accepted");
+        assert_eq!(book.order_count(), 2);
+    }
+
+    #[test]
+    fn test_min_price_unset_never_rejects_low_price() {
+        // No min_price configured (only a max): a very low price is admitted.
+        let book = max_price_book(5_000);
+        let res = book.add_limit_order(OrderId::new(), Side::Buy, 1, 10);
+        assert!(
+            res.is_ok(),
+            "no lower bound means no low-price rejection: {res:?}"
+        );
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_price_band_within_band_accepted() {
+        let book = band_book(500, 5_000);
+        let res = book.add_limit_order(OrderId::new(), Side::Buy, 1_000, 10);
+        assert!(
+            res.is_ok(),
+            "a price inside the band must be accepted: {res:?}"
+        );
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_min_price_enforced_on_replace_order() {
+        let book = band_book(500, 5_000);
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 1_000, 10)
+            .expect("add within band");
+        // Reprice below the lower bound: rejected crate-side, original untouched.
+        let res = book.replace_order(id, 499, 10, Side::Buy);
+        assert!(
+            matches!(res, Err(Error::ValidationError { .. })),
+            "replace below the band must be rejected crate-side: {res:?}"
+        );
+        assert_eq!(book.best_bid(), Some(1_000));
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_validation_config_readback_merges_min_price() {
+        let book = OptionOrderBook::new_with_config(
+            "BTC-20240329-50000-C",
+            OptionStyle::Call,
+            BookConfig {
+                validation: Some(ValidationConfig::new().with_min_price(250)),
+                ..BookConfig::default()
+            },
+        );
+        let config = book.validation_config().expect("config present");
+        assert_eq!(config.min_price(), Some(250));
+    }
+
+    #[test]
+    fn test_validation_config_readback_merges_full_band() {
+        let book = band_book(500, 5_000);
+        let config = book.validation_config().expect("config present");
+        assert_eq!(config.min_price(), Some(500));
+        assert_eq!(config.max_price(), Some(5_000));
     }
 
     // ── trade-capture take / clear ──────────────────────────────────────

--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -178,6 +178,14 @@ impl OptionChainOrderBook {
     /// Sets the contract specifications for this chain.
     ///
     /// Also propagates the specs to the strike manager for newly created strikes.
+    ///
+    /// **Band exception:** the specs' `[min_price, max_price]` price band IS
+    /// applied to option books created afterwards (merged tightest-wins by the
+    /// strike manager's internal effective-validation merge), even though the
+    /// other spec fields reach the leaf only through a derived
+    /// [`ValidationConfig`](super::validation::ValidationConfig) at the
+    /// underlying level. Setting specs directly here therefore activates the
+    /// band without going through the underlying derivation.
     pub fn set_specs(&self, specs: ContractSpecs) {
         self.strikes.set_specs(specs);
     }
@@ -1029,6 +1037,8 @@ impl OptionChainOrderBookManager {
     ///
     /// Existing chains are not affected. Only newly created chains
     /// via [`get_or_create`](Self::get_or_create) will have these specs propagated.
+    /// The specs' `[min_price, max_price]` price band is enforced crate-side at
+    /// the leaf (see [`OptionChainOrderBook::set_specs`]).
     pub fn set_specs(&self, specs: ContractSpecs) {
         self.contract_specs.set(Some(specs));
     }

--- a/src/orderbook/contract_specs.rs
+++ b/src/orderbook/contract_specs.rs
@@ -60,6 +60,15 @@ impl std::fmt::Display for SettlementType {
 /// When set on an `UnderlyingOrderBook`, a [`ValidationConfig`] is automatically
 /// derived from the tick/lot/min/max fields and applied to all future order books.
 ///
+/// # Price band
+///
+/// The optional inclusive `[min_price, max_price]` band (in smallest price
+/// units) is enforced crate-side at the leaf, since the upstream engine has no
+/// price-bound hook. When both a spec band and a validation-slot band apply to
+/// the same leaf they are merged tightest-wins (see
+/// [`ValidationConfig::tightened_price_band`]). Band-free specs serialize to the
+/// exact 0.8.0 wire shape (the two band fields are skipped when unset).
+///
 /// # Examples
 ///
 /// ```
@@ -100,6 +109,16 @@ pub struct ContractSpecs {
     exercise_style: ExerciseStyle,
     /// Settlement currency symbol (e.g., "USDC").
     settlement_currency: String,
+    /// Minimum allowed order price in smallest price units; orders priced below
+    /// are rejected crate-side. `None` disables the lower bound. Serialized only
+    /// when set, so band-free specs keep the 0.8.0 wire shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    min_price: Option<u128>,
+    /// Maximum allowed order price in smallest price units; orders priced above
+    /// are rejected crate-side. `None` disables the upper bound. Serialized only
+    /// when set, so band-free specs keep the 0.8.0 wire shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    max_price: Option<u128>,
 }
 
 impl Default for ContractSpecs {
@@ -114,6 +133,8 @@ impl Default for ContractSpecs {
             settlement: SettlementType::Cash,
             exercise_style: ExerciseStyle::European,
             settlement_currency: "USDC".to_string(),
+            min_price: None,
+            max_price: None,
         }
     }
 }
@@ -180,10 +201,28 @@ impl ContractSpecs {
         &self.settlement_currency
     }
 
-    /// Derives a [`ValidationConfig`] from this contract's tick/lot/min/max fields.
+    /// Returns the minimum allowed order price (smallest price units), if any.
+    #[must_use]
+    #[inline]
+    pub const fn min_price(&self) -> Option<u128> {
+        self.min_price
+    }
+
+    /// Returns the maximum allowed order price (smallest price units), if any.
+    #[must_use]
+    #[inline]
+    pub const fn max_price(&self) -> Option<u128> {
+        self.max_price
+    }
+
+    /// Derives a [`ValidationConfig`] from this contract's tick/lot/min/max
+    /// fields and its optional price band.
     ///
     /// This is used internally to auto-configure order validation when specs are
-    /// attached to the hierarchy.
+    /// attached to the hierarchy. The `[min_price, max_price]` band is carried
+    /// through via [`ValidationConfig::tightened_price_band`], so a spec band set
+    /// at the underlying level flows into the derived validation config with no
+    /// extra wiring at the derivation site.
     #[must_use]
     pub fn to_validation_config(&self) -> ValidationConfig {
         ValidationConfig::new()
@@ -191,6 +230,7 @@ impl ContractSpecs {
             .with_lot_size(self.lot_size)
             .with_min_order_size(self.min_order_size)
             .with_max_order_size(self.max_order_size)
+            .tightened_price_band(self.min_price, self.max_price)
     }
 
     /// Validates these specifications, rejecting structurally-broken values.
@@ -209,6 +249,9 @@ impl ContractSpecs {
     /// - `contract_size` is zero
     /// - `min_order_size` is zero
     /// - `max_order_size < min_order_size`
+    /// - `min_price` is set to zero, or `max_price` is set to zero
+    /// - both band bounds are set and `min_price > max_price` (an inverted band;
+    ///   `min_price == max_price` is a valid single-price band)
     pub fn validate(&self) -> Result<()> {
         if self.tick_size == 0 {
             return Err(Error::configuration(format!(
@@ -240,6 +283,23 @@ impl ContractSpecs {
                 self.max_order_size, self.min_order_size
             )));
         }
+        if self.min_price == Some(0) {
+            return Err(Error::configuration(
+                "min_price must be at least 1 (got 0); leave it unset to disable the lower price bound",
+            ));
+        }
+        if self.max_price == Some(0) {
+            return Err(Error::configuration(
+                "max_price must be at least 1 (got 0); leave it unset to disable the upper price bound",
+            ));
+        }
+        if let (Some(min), Some(max)) = (self.min_price, self.max_price)
+            && min > max
+        {
+            return Err(Error::configuration(format!(
+                "min_price ({min}) must be less than or equal to max_price ({max})"
+            )));
+        }
         Ok(())
     }
 }
@@ -248,7 +308,7 @@ impl std::fmt::Display for ContractSpecs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ContractSpecs(tick={}, lot={}, contract={}, min={}, max={}, {}, {}, {})",
+            "ContractSpecs(tick={}, lot={}, contract={}, min={}, max={}, {}, {}, {}",
             self.tick_size,
             self.lot_size,
             self.contract_size,
@@ -257,7 +317,14 @@ impl std::fmt::Display for ContractSpecs {
             self.settlement,
             self.exercise_style,
             self.settlement_currency,
-        )
+        )?;
+        if let Some(min_price) = self.min_price {
+            write!(f, ", min_price={min_price}")?;
+        }
+        if let Some(max_price) = self.max_price {
+            write!(f, ", max_price={max_price}")?;
+        }
+        write!(f, ")")
     }
 }
 
@@ -345,13 +412,34 @@ impl ContractSpecsBuilder {
         self
     }
 
+    /// Sets the minimum allowed order price (smallest price units).
+    ///
+    /// Orders priced below this bound are rejected crate-side. Leave unset to
+    /// disable the lower bound.
+    #[inline]
+    pub const fn min_price(mut self, min_price: u128) -> Self {
+        self.inner.min_price = Some(min_price);
+        self
+    }
+
+    /// Sets the maximum allowed order price (smallest price units).
+    ///
+    /// Orders priced above this bound are rejected crate-side. Leave unset to
+    /// disable the upper bound.
+    #[inline]
+    pub const fn max_price(mut self, max_price: u128) -> Self {
+        self.inner.max_price = Some(max_price);
+        self
+    }
+
     /// Consumes the builder and returns a validated [`ContractSpecs`].
     ///
     /// # Errors
     ///
     /// Returns [`Error::ConfigurationError`]
     /// if the assembled specs are structurally invalid (zero tick / lot /
-    /// contract / minimum size, or an inverted `[min, max]` order-size window);
+    /// contract / minimum size, an inverted `[min, max]` order-size window, a
+    /// zero price bound, or an inverted `[min_price, max_price]` band);
     /// see [`ContractSpecs::validate`].
     pub fn build(self) -> Result<ContractSpecs> {
         self.inner.validate()?;
@@ -653,5 +741,140 @@ mod tests {
     fn test_contract_specs_validate_default_ok() {
         let specs = ContractSpecs::default();
         assert!(specs.validate().is_ok());
+    }
+
+    // ========== ContractSpecs price band tests ==========
+
+    #[test]
+    fn test_builder_sets_price_band() {
+        let specs = ContractSpecs::builder()
+            .min_price(100)
+            .max_price(1_000)
+            .build()
+            .expect("valid band");
+        assert_eq!(specs.min_price(), Some(100));
+        assert_eq!(specs.max_price(), Some(1_000));
+    }
+
+    #[test]
+    fn test_default_specs_have_no_price_band() {
+        let specs = ContractSpecs::default();
+        assert_eq!(specs.min_price(), None);
+        assert_eq!(specs.max_price(), None);
+    }
+
+    #[test]
+    fn test_to_validation_config_carries_price_band() {
+        let specs = ContractSpecs::builder()
+            .tick_size(10)
+            .min_price(100)
+            .max_price(1_000)
+            .build()
+            .expect("valid band");
+        let config = specs.to_validation_config();
+        assert_eq!(config.min_price(), Some(100));
+        assert_eq!(config.max_price(), Some(1_000));
+        // The non-band fields still derive as before.
+        assert_eq!(config.tick_size(), Some(10));
+    }
+
+    #[test]
+    fn test_validate_zero_min_price_rejected() {
+        let result = ContractSpecs::builder().min_price(0).build();
+        let err = match result {
+            Ok(_) => panic!("expected zero min_price to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("min_price"));
+        assert!(err.to_string().contains('0'));
+    }
+
+    #[test]
+    fn test_validate_zero_max_price_rejected() {
+        let result = ContractSpecs::builder().max_price(0).build();
+        let err = match result {
+            Ok(_) => panic!("expected zero max_price to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("max_price"));
+    }
+
+    #[test]
+    fn test_validate_inverted_price_band_rejected() {
+        let result = ContractSpecs::builder()
+            .min_price(1_000)
+            .max_price(500)
+            .build();
+        let err = match result {
+            Ok(_) => panic!("expected an inverted band to be rejected"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("min_price"));
+        assert!(msg.contains("500"));
+        assert!(msg.contains("1000"));
+    }
+
+    #[test]
+    fn test_validate_degenerate_price_band_ok() {
+        let specs = ContractSpecs::builder()
+            .min_price(750)
+            .max_price(750)
+            .build();
+        assert!(specs.is_ok());
+    }
+
+    #[test]
+    fn test_deserialize_v080_json_without_band_fields_ok() {
+        // A hand-written 0.8.0-shape payload (no band fields at all) must still
+        // deserialize, with the band defaulting to None via serde(default).
+        let json = r#"{"tick_size":100,"lot_size":10,"contract_size":1,"min_order_size":1,"max_order_size":10000,"settlement":"Cash","exercise_style":"European","settlement_currency":"USDC"}"#;
+        let specs: ContractSpecs =
+            serde_json::from_str(json).expect("v0.8.0 specs json must deserialize");
+        assert_eq!(specs.min_price(), None);
+        assert_eq!(specs.max_price(), None);
+        assert_eq!(specs.tick_size(), 100);
+        assert_eq!(specs.settlement_currency(), "USDC");
+    }
+
+    #[test]
+    fn test_band_free_specs_serialize_without_band_fields() {
+        // skip_serializing_if keeps the 0.8.0 wire shape for band-free specs.
+        let specs = ContractSpecs::default();
+        let json = serde_json::to_string(&specs).expect("serialize");
+        assert!(
+            !json.contains("min_price"),
+            "band-free specs must omit min_price: {json}"
+        );
+        assert!(
+            !json.contains("max_price"),
+            "band-free specs must omit max_price: {json}"
+        );
+    }
+
+    #[test]
+    fn test_display_includes_price_band_when_set() {
+        let specs = ContractSpecs::builder()
+            .min_price(100)
+            .max_price(900)
+            .build()
+            .expect("valid band");
+        let display = format!("{specs}");
+        assert!(display.contains("min_price=100"));
+        assert!(display.contains("max_price=900"));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip_with_price_band() {
+        let specs = ContractSpecs::builder()
+            .min_price(100)
+            .max_price(1_000)
+            .build()
+            .expect("valid band");
+        let json = serde_json::to_string(&specs).expect("serialize");
+        let back: ContractSpecs = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(specs, back);
+        assert_eq!(back.min_price(), Some(100));
+        assert_eq!(back.max_price(), Some(1_000));
     }
 }

--- a/src/orderbook/contract_specs.rs
+++ b/src/orderbook/contract_specs.rs
@@ -67,7 +67,10 @@ impl std::fmt::Display for SettlementType {
 /// price-bound hook. When both a spec band and a validation-slot band apply to
 /// the same leaf they are merged tightest-wins (see
 /// [`ValidationConfig::tightened_price_band`]). Band-free specs serialize to the
-/// exact 0.8.0 wire shape (the two band fields are skipped when unset).
+/// exact 0.8.0 wire shape (the two band fields are skipped when unset). A
+/// band-carrying payload read by a 0.8.0 consumer is silently accepted with
+/// the band fields ignored (this DTO does not use `deny_unknown_fields`), so
+/// the band is enforced only by 0.9.0+ binaries — not a decode failure.
 ///
 /// # Examples
 ///

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -749,6 +749,8 @@ impl ExpirationOrderBookManager {
     ///
     /// Existing expiration books are not affected. Only newly created books
     /// via [`get_or_create`](Self::get_or_create) will have these specs propagated.
+    /// The specs' `[min_price, max_price]` price band is enforced crate-side at
+    /// the leaf (see [`OptionChainOrderBook::set_specs`](super::chain::OptionChainOrderBook::set_specs)).
     pub fn set_specs(&self, specs: ContractSpecs) {
         self.contract_specs.set(Some(specs));
     }

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -1033,8 +1033,14 @@ impl StrikeOrderBookManager {
     /// Sets the contract specs associated with this manager.
     ///
     /// These specs are stored on the manager and can be retrieved later
-    /// via [`specs`](Self::specs). This does not modify any existing
-    /// strike books or automatically apply to newly created ones.
+    /// via [`specs`](Self::specs). Existing strike books are not modified.
+    ///
+    /// **Band exception:** unlike the specs' tick / lot / order-size fields
+    /// (which reach the leaf only through a derived [`ValidationConfig`]), the
+    /// specs' `[min_price, max_price]` price band IS applied to option books
+    /// created by a later [`get_or_create`](Self::get_or_create), merged
+    /// tightest-wins with any validation-slot band by this manager's internal
+    /// `effective_validation` merge.
     pub fn set_specs(&self, specs: ContractSpecs) {
         self.contract_specs.set(Some(specs));
     }
@@ -1057,6 +1063,62 @@ impl StrikeOrderBookManager {
     #[must_use]
     pub fn validation_config(&self) -> Option<ValidationConfig> {
         self.validation_config.get()
+    }
+
+    /// Computes the effective [`ValidationConfig`] for option books this manager
+    /// creates, merging the validation slot with the contract-specs price band.
+    ///
+    /// The `[min_price, max_price]` band from the stored [`ContractSpecs`] is
+    /// merged into the validation slot's band tightest-wins (see
+    /// [`ValidationConfig::tightened_price_band`]); only the band fields are
+    /// taken from the specs (their tick / lot / order-size fields reach the leaf
+    /// through the validation slot, derived at the underlying level). When a
+    /// contract-spec band is present with no validation slot, a band-only config
+    /// is synthesized so the band still reaches the leaf.
+    ///
+    /// This is the single merge point consumed by both `BookConfig` assembly
+    /// sites, so the two option legs (call/put) of a strike share one effective
+    /// config. The merge is pure and side-effect-free apart from a `WARN`: if the
+    /// two sources combine into an inverted band (`min_price > max_price`), it is
+    /// logged at creation and the created books reject every order — the
+    /// incoherence is surfaced, not silently repaired.
+    ///
+    /// Returns `None` only when neither a validation slot nor a spec band is
+    /// configured, preserving the pre-band behavior for band-free managers.
+    #[must_use]
+    fn effective_validation(&self) -> Option<ValidationConfig> {
+        let validation = self.validation_config.get();
+        let band = self
+            .contract_specs
+            .get()
+            .map(|specs| (specs.min_price(), specs.max_price()));
+
+        let merged = match (validation, band) {
+            (Some(config), Some((min, max))) => Some(config.tightened_price_band(min, max)),
+            (Some(config), None) => Some(config),
+            // Specs carry a band but there is no validation slot: synthesize a
+            // band-only config so the band still reaches the leaf.
+            (None, Some((min, max))) if min.is_some() || max.is_some() => {
+                Some(ValidationConfig::new().tightened_price_band(min, max))
+            }
+            (None, _) => None,
+        };
+
+        if let Some(ref config) = merged
+            && let (Some(min), Some(max)) = (config.min_price(), config.max_price())
+            && min > max
+        {
+            tracing::warn!(
+                underlying = %self.underlying,
+                expiration = %self.expiration,
+                min_price = min,
+                max_price = max,
+                "incoherent cross-source price band (min_price > max_price); \
+                 option books created at this strike will reject every order"
+            );
+        }
+
+        merged
     }
 
     /// Sets the STP mode for all future option books created by this manager.
@@ -1276,7 +1338,7 @@ impl StrikeOrderBookManager {
             contract_symbols(&self.underlying, &self.expiration, strike);
 
         let base_config = BookConfig {
-            validation: self.validation_config.get(),
+            validation: self.effective_validation(),
             stp_mode: self.stp_mode.get(),
             fee_schedule: self.fee_schedule.get(),
             clock: self.clock.get(),
@@ -1404,7 +1466,7 @@ impl StrikeOrderBookManager {
     #[cfg(feature = "nats")]
     fn book_config_with_listeners(&self, listeners: Option<PreparedNatsListeners>) -> BookConfig {
         BookConfig {
-            validation: self.validation_config.get(),
+            validation: self.effective_validation(),
             stp_mode: self.stp_mode.get(),
             fee_schedule: self.fee_schedule.get(),
             clock: self.clock.get(),
@@ -2718,5 +2780,161 @@ mod tests {
             "book created after set_clock uses the stub and admits the GTD: {admitted:?}"
         );
         assert_eq!(strike_b.call().order_count(), 1);
+    }
+
+    // ── effective_validation: validation-slot ⊕ specs-band precedence ────
+
+    fn band_manager() -> StrikeOrderBookManager {
+        StrikeOrderBookManager::new("BTC", test_expiration())
+    }
+
+    #[test]
+    fn test_effective_validation_specs_cap_tightens_validation() {
+        let m = band_manager();
+        m.set_validation(ValidationConfig::new().with_max_price(2_000));
+        m.set_specs(
+            ContractSpecs::builder()
+                .max_price(1_000)
+                .build()
+                .expect("valid specs"),
+        );
+        let eff = m.effective_validation().expect("merged config");
+        // The tighter (smaller) upper bound wins: the specs cap.
+        assert_eq!(eff.max_price(), Some(1_000));
+    }
+
+    #[test]
+    fn test_effective_validation_validation_cap_tightens_specs() {
+        let m = band_manager();
+        m.set_validation(ValidationConfig::new().with_max_price(800));
+        m.set_specs(
+            ContractSpecs::builder()
+                .max_price(1_000)
+                .build()
+                .expect("valid specs"),
+        );
+        let eff = m.effective_validation().expect("merged config");
+        // The tighter (smaller) upper bound wins: the validation cap.
+        assert_eq!(eff.max_price(), Some(800));
+    }
+
+    #[test]
+    fn test_effective_validation_specs_floor_tightens_validation() {
+        let m = band_manager();
+        m.set_validation(ValidationConfig::new().with_min_price(100));
+        m.set_specs(
+            ContractSpecs::builder()
+                .min_price(300)
+                .build()
+                .expect("valid specs"),
+        );
+        let eff = m.effective_validation().expect("merged config");
+        // The tighter (larger) lower bound wins: the specs floor.
+        assert_eq!(eff.min_price(), Some(300));
+    }
+
+    #[test]
+    fn test_effective_validation_tick_survives_band_merge() {
+        let m = band_manager();
+        m.set_validation(
+            ValidationConfig::new()
+                .with_tick_size(10)
+                .with_max_price(2_000),
+        );
+        m.set_specs(
+            ContractSpecs::builder()
+                .min_price(100)
+                .max_price(1_000)
+                .build()
+                .expect("valid specs"),
+        );
+        let eff = m.effective_validation().expect("merged config");
+        // Non-band fields from the validation slot are preserved.
+        assert_eq!(eff.tick_size(), Some(10));
+        assert_eq!(eff.min_price(), Some(100));
+        assert_eq!(eff.max_price(), Some(1_000));
+    }
+
+    #[test]
+    fn test_effective_validation_no_band_leaves_config_unchanged() {
+        // Validation slot with no band and no specs: returned unchanged.
+        let m = band_manager();
+        let validation = ValidationConfig::new().with_tick_size(10);
+        m.set_validation(validation.clone());
+        assert_eq!(m.effective_validation(), Some(validation));
+
+        // Neither a validation slot nor a spec band: nothing to apply.
+        let empty = band_manager();
+        assert_eq!(empty.effective_validation(), None);
+    }
+
+    #[test]
+    fn test_effective_validation_incoherent_band_creates_rejecting_book() {
+        let m = band_manager();
+        // Validation floor 600 above the specs cap 500 → merged inverted band.
+        m.set_validation(ValidationConfig::new().with_min_price(600));
+        m.set_specs(
+            ContractSpecs::builder()
+                .max_price(500)
+                .build()
+                .expect("valid specs"),
+        );
+        let eff = m.effective_validation().expect("merged config");
+        assert_eq!(eff.min_price(), Some(600));
+        assert_eq!(eff.max_price(), Some(500));
+
+        // A leaf built from this incoherent band rejects every price: nothing
+        // satisfies 600 <= price <= 500.
+        let strike = m.get_or_create(50000);
+        let at_cap = strike
+            .call()
+            .add_limit_order(OrderId::new(), Side::Buy, 500, 10);
+        let at_floor = strike
+            .call()
+            .add_limit_order(OrderId::new(), Side::Buy, 600, 10);
+        assert!(
+            at_cap.is_err(),
+            "price at the cap is below the floor: rejected"
+        );
+        assert!(
+            at_floor.is_err(),
+            "price at the floor is above the cap: rejected"
+        );
+        assert_eq!(strike.call().order_count(), 0);
+    }
+
+    #[cfg(feature = "nats")]
+    #[test]
+    fn test_effective_validation_band_reaches_leaf_on_nats_path() {
+        // A per-contract factory that installs no publishers still routes strike
+        // creation through the NATS BookConfig site
+        // (`book_config_with_listeners`), which must apply the same effective
+        // band as the non-NATS site.
+        let manager = band_manager();
+        let factory: ContractNatsListenerFactory = Arc::new(|_symbol: &str| None);
+        manager.set_nats_factory(Some(factory));
+        manager.set_validation(
+            ValidationConfig::new()
+                .with_min_price(100)
+                .with_max_price(1_000),
+        );
+
+        let strike = manager.get_or_create(50000);
+        let config = strike.call().validation_config().expect("config present");
+        assert_eq!(config.min_price(), Some(100));
+        assert_eq!(config.max_price(), Some(1_000));
+
+        // Enforcement is live on the NATS-path leaf.
+        assert!(
+            strike
+                .call()
+                .add_limit_order(OrderId::new(), Side::Buy, 99, 10)
+                .is_err(),
+            "below-band add must be rejected on the NATS path"
+        );
+        strike
+            .call()
+            .add_limit_order(OrderId::new(), Side::Buy, 500, 10)
+            .expect("within-band add on the NATS path");
     }
 }

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -381,8 +381,11 @@ impl UnderlyingOrderBook {
     /// Sets the contract specifications for this underlying.
     ///
     /// Automatically derives and applies a [`ValidationConfig`] from the specs'
-    /// tick size, lot size, min/max order size fields. This validation config
-    /// is propagated to all future expirations and strikes.
+    /// tick size, lot size, min/max order size fields **and the optional
+    /// `[min_price, max_price]` price band** (via
+    /// [`ContractSpecs::to_validation_config`]). This validation config is
+    /// propagated to all future expirations and strikes, so a spec band set here
+    /// is enforced crate-side at every leaf created afterwards.
     ///
     /// Existing expiration books and strikes are not affected by the derived
     /// validation config.
@@ -3935,5 +3938,45 @@ mod tests {
         assert_eq!(manager.symbol_index().len(), 4);
         assert!(manager.symbol_index().contains(&btc_call));
         assert!(manager.symbol_index().contains(&eth_put));
+    }
+
+    #[test]
+    fn test_underlying_set_specs_band_reaches_vivified_leaf() {
+        // A price band on the underlying's contract specs must be derived into
+        // the validation config and enforced crate-side at every leaf vivified
+        // afterwards (the D5 zero-change derivation path).
+        let book = UnderlyingOrderBook::new("BTC");
+        let specs = ContractSpecs::builder()
+            .min_price(100)
+            .max_price(1_000)
+            .build()
+            .expect("valid specs");
+        book.set_specs(specs);
+
+        let leaf = book
+            .get_or_create_expiration(test_expiration())
+            .get_or_create_strike(50000);
+
+        // Within-band admitted; below and above the band rejected crate-side.
+        leaf.call()
+            .add_limit_order(OrderId::new(), Side::Buy, 500, 10)
+            .expect("within-band add");
+        assert!(
+            leaf.call()
+                .add_limit_order(OrderId::new(), Side::Buy, 99, 10)
+                .is_err(),
+            "below the band must be rejected"
+        );
+        assert!(
+            leaf.call()
+                .add_limit_order(OrderId::new(), Side::Buy, 1_001, 10)
+                .is_err(),
+            "above the band must be rejected"
+        );
+
+        // The band round-trips through the leaf's validation readback.
+        let config = leaf.call().validation_config().expect("config present");
+        assert_eq!(config.min_price(), Some(100));
+        assert_eq!(config.max_price(), Some(1_000));
     }
 }

--- a/src/orderbook/validation.rs
+++ b/src/orderbook/validation.rs
@@ -13,6 +13,7 @@ use crate::error::{Error, Result};
 /// - **Lot size**: quantities must be exact multiples of the lot size
 /// - **Min order size**: orders below this quantity are rejected
 /// - **Max order size**: orders above this quantity are rejected
+/// - **Min price**: orders priced below this bound are rejected crate-side
 /// - **Max price**: orders priced above this bound are rejected crate-side
 ///
 /// All fields default to `None`, which disables the corresponding validation.
@@ -50,6 +51,11 @@ pub struct ValidationConfig {
     /// are rejected crate-side (the upstream engine has no price-bound hook);
     /// `None` disables.
     max_price: Option<u128>,
+    /// Minimum allowed order price in smallest price units; orders priced below
+    /// are rejected crate-side (the upstream engine has no price-bound hook);
+    /// `None` disables. Together with [`max_price`](Self::max_price) this forms
+    /// an inclusive `[min_price, max_price]` band.
+    min_price: Option<u128>,
 }
 
 impl ValidationConfig {
@@ -163,6 +169,31 @@ impl ValidationConfig {
         self
     }
 
+    /// Sets the minimum order price (in smallest price units).
+    ///
+    /// Orders priced below `min_price` are rejected crate-side, because the
+    /// upstream matching engine has no price-bound hook to delegate to. Together
+    /// with [`with_max_price`](Self::with_max_price) this forms an inclusive
+    /// `[min_price, max_price]` band.
+    ///
+    /// # Arguments
+    ///
+    /// * `min_price` - Minimum allowed order price in smallest price units
+    ///
+    /// # Footgun
+    ///
+    /// This setter is infallible. Setting `Some(0)` is a no-op bound (every
+    /// price is `>= 0`); to disable the lower bound leave it unset (`None`), and
+    /// call [`validate`](Self::validate) to reject a zero bound as an error. A
+    /// `min_price` above the configured `max_price` is an inverted band that
+    /// rejects every order; [`validate`](Self::validate) rejects that too.
+    #[must_use]
+    #[inline]
+    pub const fn with_min_price(mut self, min_price: u128) -> Self {
+        self.min_price = Some(min_price);
+        self
+    }
+
     /// Returns the configured tick size, if any.
     #[must_use]
     #[inline]
@@ -198,6 +229,55 @@ impl ValidationConfig {
         self.max_price
     }
 
+    /// Returns the configured minimum order price, if any.
+    #[must_use]
+    #[inline]
+    pub const fn min_price(&self) -> Option<u128> {
+        self.min_price
+    }
+
+    /// Returns a copy with the price band tightened against an incoming
+    /// `[min, max]` band, applying the canonical **tightest-wins** policy.
+    ///
+    /// This is the single source of truth for merging two price bands that come
+    /// from different sources (for example a `ValidationConfig` slot and a
+    /// [`ContractSpecs`](super::contract_specs::ContractSpecs) band) into one
+    /// effective band at leaf creation:
+    ///
+    /// - the resulting **upper** bound is the *smaller* of the two `max_price`
+    ///   values (the tighter cap wins);
+    /// - the resulting **lower** bound is the *larger* of the two `min_price`
+    ///   values (the tighter floor wins);
+    /// - when one side is unset on one input, the value from the other input is
+    ///   carried through unchanged.
+    ///
+    /// Only the two band fields are affected; tick / lot / order-size fields are
+    /// left as-is.
+    ///
+    /// This merge is deliberately *not* self-validating: two individually
+    /// coherent bands from different sources can still combine into an inverted
+    /// `min_price > max_price` band that rejects every order. That incoherence is
+    /// intended to surface (via [`validate`](Self::validate) or a caller-side
+    /// warning), not to be silently repaired here.
+    #[must_use]
+    pub const fn tightened_price_band(mut self, min: Option<u128>, max: Option<u128>) -> Self {
+        self.max_price = match (self.max_price, max) {
+            // Tighter cap wins: the smaller upper bound.
+            (Some(a), Some(b)) => Some(if a < b { a } else { b }),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+        self.min_price = match (self.min_price, min) {
+            // Tighter floor wins: the larger lower bound.
+            (Some(a), Some(b)) => Some(if a > b { a } else { b }),
+            (Some(a), None) => Some(a),
+            (None, Some(b)) => Some(b),
+            (None, None) => None,
+        };
+        self
+    }
+
     /// Returns `true` if no validation rules are configured.
     #[must_use]
     #[inline]
@@ -207,6 +287,7 @@ impl ValidationConfig {
             && self.min_order_size.is_none()
             && self.max_order_size.is_none()
             && self.max_price.is_none()
+            && self.min_price.is_none()
     }
 
     /// Validates the configured rules, rejecting structurally-broken settings.
@@ -225,8 +306,11 @@ impl ValidationConfig {
     /// - `lot_size` is set to zero
     /// - `min_order_size` is set to zero
     /// - `max_price` is set to zero
+    /// - `min_price` is set to zero
     /// - both `min_order_size` and `max_order_size` are set and
     ///   `max_order_size < min_order_size`
+    /// - both `min_price` and `max_price` are set and `min_price > max_price`
+    ///   (an inverted band; `min_price == max_price` is a valid single-price band)
     pub fn validate(&self) -> Result<()> {
         if self.tick_size == Some(0) {
             return Err(Error::configuration(
@@ -248,11 +332,23 @@ impl ValidationConfig {
                 "max_price must be at least 1 (got 0); leave it unset to disable the price bound",
             ));
         }
+        if self.min_price == Some(0) {
+            return Err(Error::configuration(
+                "min_price must be at least 1 (got 0); leave it unset to disable the price bound",
+            ));
+        }
         if let (Some(min), Some(max)) = (self.min_order_size, self.max_order_size)
             && max < min
         {
             return Err(Error::configuration(format!(
                 "max_order_size ({max}) must be greater than or equal to min_order_size ({min})"
+            )));
+        }
+        if let (Some(min), Some(max)) = (self.min_price, self.max_price)
+            && min > max
+        {
+            return Err(Error::configuration(format!(
+                "min_price ({min}) must be less than or equal to max_price ({max})"
             )));
         }
         Ok(())
@@ -289,6 +385,13 @@ impl std::fmt::Display for ValidationConfig {
                 write!(f, ", ")?;
             }
             write!(f, "max={max}")?;
+            first = false;
+        }
+        if let Some(min_price) = self.min_price {
+            if !first {
+                write!(f, ", ")?;
+            }
+            write!(f, "min_price={min_price}")?;
             first = false;
         }
         if let Some(max_price) = self.max_price {
@@ -486,5 +589,141 @@ mod tests {
         let display = format!("{config}");
         assert!(display.contains("tick=100"));
         assert!(display.contains("max_price=999"));
+    }
+
+    // ========== ValidationConfig::min_price / price band tests ==========
+
+    #[test]
+    fn test_validation_config_with_min_price_builder() {
+        let config = ValidationConfig::new().with_min_price(100);
+        assert_eq!(config.min_price(), Some(100));
+    }
+
+    #[test]
+    fn test_validation_config_is_empty_false_with_only_min_price() {
+        let config = ValidationConfig::new().with_min_price(50);
+        assert!(!config.is_empty());
+        assert_eq!(config.tick_size(), None);
+        assert_eq!(config.max_price(), None);
+    }
+
+    #[test]
+    fn test_validation_config_validate_zero_min_price_rejected() {
+        let config = ValidationConfig::new().with_min_price(0);
+        let err = match config.validate() {
+            Ok(()) => panic!("expected zero min_price to be rejected"),
+            Err(e) => e,
+        };
+        assert!(err.to_string().contains("min_price"));
+        assert!(err.to_string().contains('0'));
+    }
+
+    #[test]
+    fn test_validation_config_validate_min_price_set_ok() {
+        let config = ValidationConfig::new()
+            .with_min_price(100)
+            .with_max_price(1_000);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validation_config_validate_inverted_price_band_rejected() {
+        // min_price above max_price is an inverted band that rejects everything.
+        let config = ValidationConfig::new()
+            .with_min_price(1_000)
+            .with_max_price(500);
+        let err = match config.validate() {
+            Ok(()) => panic!("expected an inverted price band to be rejected"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("min_price"));
+        assert!(msg.contains("500"));
+        assert!(msg.contains("1000"));
+    }
+
+    #[test]
+    fn test_validation_config_validate_degenerate_price_band_ok() {
+        // A single-price band (min == max) is valid: it admits exactly one price.
+        let config = ValidationConfig::new()
+            .with_min_price(750)
+            .with_max_price(750);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validation_config_display_min_price_before_max_price() {
+        let config = ValidationConfig::new()
+            .with_min_price(100)
+            .with_max_price(900);
+        let display = format!("{config}");
+        let min_at = display
+            .find("min_price=100")
+            .expect("min_price segment present");
+        let max_at = display
+            .find("max_price=900")
+            .expect("max_price segment present");
+        assert!(
+            min_at < max_at,
+            "min_price must render before max_price: {display}"
+        );
+    }
+
+    #[test]
+    fn test_tightened_price_band_takes_min_of_maxes() {
+        // Two upper bounds: the tighter (smaller) one wins.
+        let config = ValidationConfig::new()
+            .with_max_price(1_000)
+            .tightened_price_band(None, Some(800));
+        assert_eq!(config.max_price(), Some(800));
+    }
+
+    #[test]
+    fn test_tightened_price_band_takes_max_of_mins() {
+        // Two lower bounds: the tighter (larger) one wins.
+        let config = ValidationConfig::new()
+            .with_min_price(100)
+            .tightened_price_band(Some(250), None);
+        assert_eq!(config.min_price(), Some(250));
+    }
+
+    #[test]
+    fn test_tightened_price_band_fills_unset_side_from_other() {
+        // Each side is unset on exactly one input; the merge carries both through.
+        let config = ValidationConfig::new()
+            .with_max_price(1_000)
+            .tightened_price_band(Some(100), None);
+        assert_eq!(config.min_price(), Some(100));
+        assert_eq!(config.max_price(), Some(1_000));
+    }
+
+    #[test]
+    fn test_tightened_price_band_preserves_non_band_fields() {
+        // Only the two band fields change; tick/lot/order-size are untouched.
+        let config = ValidationConfig::new()
+            .with_tick_size(10)
+            .with_lot_size(2)
+            .with_min_order_size(1)
+            .with_max_order_size(500)
+            .tightened_price_band(Some(100), Some(900));
+        assert_eq!(config.tick_size(), Some(10));
+        assert_eq!(config.lot_size(), Some(2));
+        assert_eq!(config.min_order_size(), Some(1));
+        assert_eq!(config.max_order_size(), Some(500));
+        assert_eq!(config.min_price(), Some(100));
+        assert_eq!(config.max_price(), Some(900));
+    }
+
+    #[test]
+    fn test_tightened_price_band_incoherent_yields_inverted_that_fails_validate() {
+        // Two individually-coherent bands can merge into an inverted band:
+        // floor from one source (600) above cap from the other (500). The merge
+        // does not repair it; validate() surfaces the incoherence.
+        let config = ValidationConfig::new()
+            .with_min_price(600)
+            .tightened_price_band(None, Some(500));
+        assert_eq!(config.min_price(), Some(600));
+        assert_eq!(config.max_price(), Some(500));
+        assert!(config.validate().is_err());
     }
 }

--- a/tests/unit/orderbook_tests.rs
+++ b/tests/unit/orderbook_tests.rs
@@ -1,7 +1,7 @@
 //! Integration tests for the orderbook module.
 
 use option_chain_orderbook::orderbook::{
-    OptionOrderBook, UnderlyingOrderBookManager, ValidationConfig,
+    ContractSpecs, OptionOrderBook, UnderlyingOrderBookManager, ValidationConfig,
 };
 use optionstratlib::prelude::pos_or_panic;
 use optionstratlib::{ExpirationDate, OptionStyle};
@@ -266,5 +266,77 @@ fn test_replace_order_through_hierarchy_handles() {
         .unwrap_or_else(|err| panic!("replace failed: {err}"));
     assert!(replaced, "replace should report a hit");
     assert_eq!(strike.call().best_bid(), Some(110));
+    assert_eq!(strike.call().order_count(), 1);
+}
+
+#[test]
+fn test_hierarchy_set_specs_price_band_propagates_to_new_strikes() {
+    let manager = UnderlyingOrderBookManager::new();
+    let exp_date = ExpirationDate::Days(pos_or_panic!(30.0));
+
+    let btc = manager.get_or_create("BTC");
+    // A contract-spec band set at the underlying level is derived into the
+    // validation config and reaches every leaf vivified afterwards.
+    let specs = ContractSpecs::builder()
+        .min_price(100)
+        .max_price(1_000)
+        .build()
+        .expect("valid specs");
+    btc.set_specs(specs);
+
+    let exp = btc.get_or_create_expiration(exp_date);
+    let strike = exp.get_or_create_strike(50000);
+
+    // Within-band add succeeds; out-of-band adds are rejected crate-side.
+    strike
+        .call()
+        .add_limit_order(OrderId::new(), Side::Buy, 500, 10)
+        .unwrap_or_else(|err| panic!("within-band add failed: {err}"));
+    assert!(
+        strike
+            .call()
+            .add_limit_order(OrderId::new(), Side::Buy, 1_001, 10)
+            .is_err(),
+        "above-band add must be rejected"
+    );
+    assert!(
+        strike
+            .call()
+            .add_limit_order(OrderId::new(), Side::Buy, 99, 10)
+            .is_err(),
+        "below-band add must be rejected"
+    );
+    assert_eq!(strike.call().order_count(), 1);
+}
+
+#[test]
+fn test_hierarchy_chain_set_specs_band_activates_at_leaf() {
+    let manager = UnderlyingOrderBookManager::new();
+    let exp_date = ExpirationDate::Days(pos_or_panic!(30.0));
+
+    let btc = manager.get_or_create("BTC");
+    let exp = btc.get_or_create_expiration(exp_date);
+    let chain = exp.chain();
+
+    // Setting specs directly on the chain (not through the underlying
+    // derivation) still activates the band at leaves via effective_validation.
+    let specs = ContractSpecs::builder()
+        .max_price(2_000)
+        .build()
+        .expect("valid specs");
+    chain.set_specs(specs);
+
+    let strike = chain.get_or_create_strike(50000);
+    strike
+        .call()
+        .add_limit_order(OrderId::new(), Side::Buy, 1_500, 10)
+        .unwrap_or_else(|err| panic!("within-band add failed: {err}"));
+    assert!(
+        strike
+            .call()
+            .add_limit_order(OrderId::new(), Side::Buy, 2_001, 10)
+            .is_err(),
+        "above-band add must be rejected once the chain-level band is set"
+    );
     assert_eq!(strike.call().order_count(), 1);
 }


### PR DESCRIPTION
## Stack

- **Stack: #152 → #151 → #153 (this PR is 1 of 3, the bottom of the stack).**
- Base branch: `main`.
- Blocks: the upcoming #151 PR (`stack/2-151-order-kinds`), branched off this PR's HEAD once CI is green.
- Merge bottom-up.

## Summary

Real venues band prices per contract, but `ContractSpecs` had no price-band field and the only price bound was the chain-wide `ValidationConfig::max_price` from 0.8.0, plumbed manually. This PR gives `ContractSpecs` an inclusive `[min_price, max_price]` band that flows to every lazily vivified leaf and merges tightest-wins with the chain-wide config — groundwork the rest of the stack builds on (#151's new order-kind add paths run this band check from day one).

## Changes

- `ContractSpecs` gains optional inclusive `min_price` / `max_price` (smallest price units) with builder setters, `validate()` coherence (nonzero, min ≤ max), Display segments, and serde that preserves the exact 0.8.0 wire shape for band-free specs.
- `ValidationConfig` gains `min_price` (mirroring the 0.8.0 `max_price` plumbing exactly) and the canonical merge primitive `tightened_price_band` — effective max = min of the set maxes, effective min = max of the set mins, an unset side is filled by the other source.
- The merge runs once per leaf creation in `StrikeOrderBookManager::effective_validation()`, consumed by both `BookConfig` assembly sites (plain + NATS). An incoherent cross-source band warns at creation and rejects every order rather than being silently repaired.
- Leaf enforcement: `check_max_price` → `check_price_band` (max then min, two `Option<u128>` compares, `#[cold]` error builders) across all 8 add paths + `replace_order`; readback merges both bounds.
- `to_validation_config()` carries the band, so the existing `UnderlyingOrderBook::set_specs` derivation picks it up with zero change; a band set via specs at chain/expiry level now takes effect on future leaves (the deliberate, documented exception to specs being validation-inert).

## Technical decisions

- Absolute band, no strike-derived collar: the crate has no price-decimals scale (strike→price-unit mapping is venue knowledge), and reference-price collars would need the mark-price subsystem — a layering inversion. A collar policy remains a purely additive future extension.
- Tightest-wins applies to the band fields only; tick/lot/order-size slots keep last-writer-wins semantics — zero behavior change for band-free configs (guarded by test).
- `skip_serializing_if` on the specs band is coherent with the sequencer's no-skip rule: `ContractSpecs` is config, never a journaled event or NATS payload. A 0.8.0 reader silently ignores the band fields (no `deny_unknown_fields` on this DTO) — documented.

## Public API impact

- New: `ValidationConfig::{with_min_price, min_price, tightened_price_band}`; `ContractSpecs::{min_price, max_price}`; `ContractSpecsBuilder::{min_price, max_price}`.
- No new re-exports; no version bump (release decided at stack end). `src/lib.rs` "Order policy hooks" bullet updated; `README.md` regenerated via `make readme`.

## Testing

- [x] Unit tests added or updated
- [x] Round-trip serde tests for new event / DTO shapes
- [x] Integration tests under `tests/unit/` added or updated (if applicable)
- [x] `make pre-push` run locally and clean

40 new tests: 12 validation.rs (builder, validate zero/inverted/degenerate, Display, 4× tightened-band incl. non-band-fields-preserved), 11 contract_specs.rs (incl. the 0.8.0-shape serde regression guard both directions), 7 book.rs (below-bound across all 8 add paths, inclusive at-bound, unset, within-band, replace, readback ×2), 7 strike.rs (6 precedence + NATS-gated leaf band readback), 1 underlying.rs derivation, 2 hierarchy tests. Totals: **899 lib + 38 integration + 110 doctests, 0 failures.** Internal reviews: hotpath-reviewer CLEAN (band check ≤2 compares, merge leaf-creation-only), architect PASS.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No `unsafe` introduced
- [x] Layering respected (one-way leaf-up; merge lives in strike.rs which owns both config slots; leaf knows nothing of specs)
- [x] Matching delegated to `orderbook-rs`; Greeks delegated to `optionstratlib`
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) updated if the public surface changed

Closes #152
