### PR TITLE
Order-kind variety through the sequenced path: post-only and iceberg (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.4`. A full upgrade walkthrough lives in
 > [`MIGRATING-0.5.0.md`](./MIGRATING-0.5.0.md).
 
+## [Unreleased]
+
+### Added
+
+- **Per-contract price banding on `ContractSpecs` (#152).** `ContractSpecs` and
+  `ValidationConfig` gained an inclusive absolute `[min_price, max_price]` band
+  (`Option<u128>` each, smallest price units). The engine has no price-bound
+  hook, so the band is enforced crate-side on every add and replace, after the
+  active check. When both a `ContractSpecs` band and a validation band apply to
+  the same contract they merge tightest-wins (`ValidationConfig::tightened_price_band`).
+  The `ContractSpecs` band fields carry `#[serde(default, skip_serializing_if)]`,
+  so band-free specs keep their pre-0.8.0 wire shape; specs that DO carry a band
+  are unreadable by 0.8.0 consumers (documented asymmetry).
+- **Order-kind variety through the sequenced path (#151).** New
+  `OrderKind` enum (`Limit` / `PostOnly` / `Iceberg`, `#[non_exhaustive]`),
+  re-exported from the crate root. `OptionChainCommand::AddOrder` gained
+  `kind: OrderKind` and `hidden_quantity: Option<u64>` (both `#[serde(default)]`,
+  always emitted). New `SequencedUnderlyingOrderBook::submit_add_order_kind`
+  wrapper carries the kind and hidden reserve into the journal so replay
+  reconstructs the exact order shape; `submit_add_order` / `submit_add_order_with`
+  now delegate through it (their 0.8.0 signatures are unchanged). For an iceberg,
+  `quantity` is the visible tranche and `hidden_quantity` the reserve behind it;
+  an iceberg with a missing/zero hidden reserve, or a limit/post-only add with a
+  hidden reserve, is a deterministic `Rejected`. A post-only add that would cross
+  is journaled as a deterministic `PriceCrossing` rejection.
+
+### Wire compatibility
+
+- The new `AddOrder` fields (`kind` / `hidden_quantity`) are backward-compatible
+  **for self-describing encodings (JSON)**: they carry `#[serde(default)]`, so a
+  pre-#151 JSON journal decodes to a plain limit add (`OrderKind::Limit`, no
+  hidden reserve) and replays identically (pinned by the frozen v0.5.0 and v0.8.0
+  fixture tests, which patch these defaults in). Positional codecs such as
+  bincode cannot apply a missing-field default, so pre-#151 *binary* journal
+  records must be re-journaled or migrated. An unknown `OrderKind` variant tag
+  written by a newer binary is rejected by an older one — the same additive
+  forward-compat asymmetry as the command/result enums.
+
 ## [0.8.0] - 2026-07-12
 
 ### ⚠️ Breaking Changes

--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ matching engine itself is `orderbook-rs`. On top of that engine it provides:
   [`orderbook::ContractSpecs`] band and a validation band apply to the same
   contract, they are merged tightest-wins.
 - **Optional eventing**: NATS publishing (`nats` feature) and a
-  command/event/journal/replay sequencer (`sequencer` feature).
+  command/event/journal/replay sequencer (`sequencer` feature). The
+  sequenced add path carries order-kind variety — limit, post-only, and
+  iceberg ([`orderbook::OrderKind`]) — through the journal so replay
+  reconstructs the exact order shape.
 
 ### Limitations
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,10 @@
 //!   [`orderbook::ContractSpecs`] band and a validation band apply to the same
 //!   contract, they are merged tightest-wins.
 //! - **Optional eventing**: NATS publishing (`nats` feature) and a
-//!   command/event/journal/replay sequencer (`sequencer` feature).
+//!   command/event/journal/replay sequencer (`sequencer` feature). The
+//!   sequenced add path carries order-kind variety — limit, post-only, and
+//!   iceberg ([`orderbook::OrderKind`]) — through the journal so replay
+//!   reconstructs the exact order shape.
 //!
 //! ## Limitations
 //!
@@ -367,7 +370,7 @@ pub use orderbook::{
 #[cfg(feature = "sequencer")]
 pub use orderbook::{
     InMemoryOptionChainJournal, MassCancelScope, MassCancelType, OptionChainCommand,
-    OptionChainEvent, OptionChainJournal, OptionChainReceipt, OptionChainResult,
+    OptionChainEvent, OptionChainJournal, OptionChainReceipt, OptionChainResult, OrderKind,
     SequencedUnderlyingOrderBook,
 };
 

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -1069,6 +1069,17 @@ impl OptionOrderBook {
         ))
     }
 
+    /// Builds the iceberg `visible + hidden` overflow error. Cold + un-inlined
+    /// so the common in-range path carries none of the formatting code.
+    #[cold]
+    #[inline(never)]
+    fn iceberg_size_overflow(&self, visible: u64, hidden: u64) -> Error {
+        Error::validation(format!(
+            "iceberg visible_quantity ({visible}) + hidden_quantity ({hidden}) overflows u64 for {}",
+            self.symbol
+        ))
+    }
+
     /// Adds a limit order to the book.
     ///
     /// # Arguments
@@ -1484,12 +1495,9 @@ impl OptionOrderBook {
         // The combined size is what an unmatched-rest empty result reports and
         // what upstream's min/max size check uses; guard the addition so an
         // overflow becomes a typed error rather than a wrap.
-        let total = visible_quantity.checked_add(hidden_quantity).ok_or_else(|| {
-            Error::validation(format!(
-                "iceberg visible_quantity ({visible_quantity}) + hidden_quantity ({hidden_quantity}) overflows u64 for {}",
-                self.symbol
-            ))
-        })?;
+        let total = visible_quantity
+            .checked_add(hidden_quantity)
+            .ok_or_else(|| self.iceberg_size_overflow(visible_quantity, hidden_quantity))?;
         let order = OrderType::IcebergOrder {
             id: order_id,
             price: Price::new(price),

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -13,7 +13,8 @@ use optionstratlib::OptionStyle;
 use orderbook_rs::PriceLevelChangedListener;
 use orderbook_rs::{
     Clock, DefaultOrderBook, FeeSchedule, MassCancelResult, OrderBookSnapshot, OrderId,
-    OrderStateTracker, OrderStatus, STPMode, Side, TimeInForce, TradeListener, TradeResult,
+    OrderStateTracker, OrderStatus, OrderType, STPMode, Side, TimeInForce, TradeListener,
+    TradeResult,
 };
 use pricelevel::{Hash32, MatchResult, OrderUpdate, Price, Quantity, TimestampMs};
 use std::collections::hash_map::DefaultHasher;
@@ -1369,6 +1370,202 @@ impl OptionOrderBook {
             order_id, price, quantity, side, tif, user_id, None,
         )?;
         Ok(trade.unwrap_or_else(|| self.empty_trade_result(order_id, quantity)))
+    }
+
+    // ── Order-kind methods (post-only / iceberg) ────────────────────────
+
+    /// Adds a post-only order and returns the full [`TradeResult`].
+    ///
+    /// A post-only order **never trades on entry**: if it would cross the
+    /// opposite side, the upstream engine's shape validation rejects it with
+    /// [`OrderBookEngine`](crate::Error::OrderBookEngine) wrapping
+    /// `OrderBookError::PriceCrossing { price, side, opposite_price }` *before*
+    /// any matching. The only outcomes are therefore: the order rests (an empty
+    /// [`TradeResult`] carrying `order_id` is returned), a `PriceCrossing`
+    /// rejection, or another validation rejection (tick / lot / risk / STP).
+    ///
+    /// The leaf builds the [`OrderType::PostOnly`] value directly and submits it
+    /// through the engine's generic `add_order_with_result` primitive, because
+    /// `orderbook_rs` exposes no typed post-only `_with_result` helper. The
+    /// order timestamp is drawn from this book's installed engine clock, so an
+    /// injected deterministic clock keeps the stamp reproducible.
+    ///
+    /// # Arguments
+    ///
+    /// * `order_id` - Unique identifier for the order
+    /// * `side` - Buy or Sell side
+    /// * `price` - Limit price in smallest units (u128)
+    /// * `quantity` - Order quantity in smallest units (u64)
+    /// * `tif` - Time-in-force (GTC, IOC, FOK, etc.)
+    /// * `user_id` - Owner identity for STP checks
+    ///
+    /// # Errors
+    ///
+    /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
+    ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
+    /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream engine rejects the
+    ///   order, including `PriceCrossing` when a post-only order would cross.
+    pub fn add_post_only_order_with_tif_and_user_full(
+        &self,
+        order_id: OrderId,
+        side: Side,
+        price: u128,
+        quantity: u64,
+        tif: TimeInForce,
+        user_id: Hash32,
+    ) -> Result<TradeResult> {
+        self.check_active()?;
+        self.check_price_band(price)?;
+        let order = OrderType::PostOnly {
+            id: order_id,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
+            side,
+            user_id,
+            timestamp: self.book.clock().now_millis(),
+            time_in_force: tif,
+            extra_fields: (),
+        };
+        let (_order, trade) = self.book.add_order_with_result(order)?;
+        Ok(trade.unwrap_or_else(|| self.empty_trade_result(order_id, quantity)))
+    }
+
+    /// Adds an iceberg order and returns the full [`TradeResult`].
+    ///
+    /// Unlike a post-only order, an iceberg **can cross and trade on entry**: it
+    /// is matched like a standard limit order, exposing only `visible_quantity`
+    /// at a time while `hidden_quantity` is replenished behind it. When it rests
+    /// without matching, an empty [`TradeResult`] carrying `order_id` is
+    /// returned.
+    ///
+    /// Upstream lot-size validation applies to the visible **and** hidden
+    /// quantities independently, while the min/max order-size checks apply to the
+    /// combined total. The resting order's `quantity()` accessor reports the
+    /// *visible* tranche, not the total. As with the post-only path, the leaf
+    /// builds the [`OrderType::IcebergOrder`] value directly and submits it via
+    /// the generic `add_order_with_result` primitive (no typed iceberg
+    /// `_with_result` helper exists upstream); the timestamp comes from this
+    /// book's engine clock.
+    ///
+    /// # Arguments
+    ///
+    /// * `order_id` - Unique identifier for the order
+    /// * `side` - Buy or Sell side
+    /// * `price` - Limit price in smallest units (u128)
+    /// * `visible_quantity` - Visible tranche in smallest units (u64)
+    /// * `hidden_quantity` - Hidden reserve in smallest units (u64)
+    /// * `tif` - Time-in-force (GTC, IOC, FOK, etc.)
+    /// * `user_id` - Owner identity for STP checks
+    ///
+    /// # Errors
+    ///
+    /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
+    ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band, or if
+    ///   `visible_quantity + hidden_quantity` overflows `u64`.
+    /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream engine rejects the
+    ///   order (tick / lot / size / risk / STP).
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_iceberg_order_with_tif_and_user_full(
+        &self,
+        order_id: OrderId,
+        side: Side,
+        price: u128,
+        visible_quantity: u64,
+        hidden_quantity: u64,
+        tif: TimeInForce,
+        user_id: Hash32,
+    ) -> Result<TradeResult> {
+        self.check_active()?;
+        self.check_price_band(price)?;
+        // The combined size is what an unmatched-rest empty result reports and
+        // what upstream's min/max size check uses; guard the addition so an
+        // overflow becomes a typed error rather than a wrap.
+        let total = visible_quantity.checked_add(hidden_quantity).ok_or_else(|| {
+            Error::validation(format!(
+                "iceberg visible_quantity ({visible_quantity}) + hidden_quantity ({hidden_quantity}) overflows u64 for {}",
+                self.symbol
+            ))
+        })?;
+        let order = OrderType::IcebergOrder {
+            id: order_id,
+            price: Price::new(price),
+            visible_quantity: Quantity::new(visible_quantity),
+            hidden_quantity: Quantity::new(hidden_quantity),
+            side,
+            user_id,
+            timestamp: self.book.clock().now_millis(),
+            time_in_force: tif,
+            extra_fields: (),
+        };
+        let (_order, trade) = self.book.add_order_with_result(order)?;
+        Ok(trade.unwrap_or_else(|| self.empty_trade_result(order_id, total)))
+    }
+
+    /// Adds a post-only order, discarding the [`TradeResult`].
+    ///
+    /// Convenience wrapper over
+    /// [`add_post_only_order_with_tif_and_user_full`](Self::add_post_only_order_with_tif_and_user_full):
+    /// it delegates to the `_full` method (the single construction site) and
+    /// drops the result. Note the `_with_result` engine path always consumes an
+    /// `engine_seq` tick where a plain add may not; this is irrelevant for
+    /// replay, since `engine_seq` is per-instance and not replay-comparable.
+    ///
+    /// # Errors
+    ///
+    /// Identical to
+    /// [`add_post_only_order_with_tif_and_user_full`](Self::add_post_only_order_with_tif_and_user_full).
+    pub fn add_post_only_order_with_tif_and_user(
+        &self,
+        order_id: OrderId,
+        side: Side,
+        price: u128,
+        quantity: u64,
+        tif: TimeInForce,
+        user_id: Hash32,
+    ) -> Result<()> {
+        self.add_post_only_order_with_tif_and_user_full(
+            order_id, side, price, quantity, tif, user_id,
+        )
+        .map(|_| ())
+    }
+
+    /// Adds an iceberg order, discarding the [`TradeResult`].
+    ///
+    /// Convenience wrapper over
+    /// [`add_iceberg_order_with_tif_and_user_full`](Self::add_iceberg_order_with_tif_and_user_full):
+    /// it delegates to the `_full` method (the single construction site) and
+    /// drops the result. The same `engine_seq` note as the post-only convenience
+    /// applies.
+    ///
+    /// # Errors
+    ///
+    /// Identical to
+    /// [`add_iceberg_order_with_tif_and_user_full`](Self::add_iceberg_order_with_tif_and_user_full).
+    #[allow(clippy::too_many_arguments)]
+    pub fn add_iceberg_order_with_tif_and_user(
+        &self,
+        order_id: OrderId,
+        side: Side,
+        price: u128,
+        visible_quantity: u64,
+        hidden_quantity: u64,
+        tif: TimeInForce,
+        user_id: Hash32,
+    ) -> Result<()> {
+        self.add_iceberg_order_with_tif_and_user_full(
+            order_id,
+            side,
+            price,
+            visible_quantity,
+            hidden_quantity,
+            tif,
+            user_id,
+        )
+        .map(|_| ())
     }
 
     /// Cancels an order by its ID.
@@ -4753,6 +4950,251 @@ mod tests {
         );
         // The bound is checked before the engine, so the original is untouched.
         assert_eq!(book.best_bid(), Some(500));
+        assert_eq!(book.order_count(), 1);
+    }
+
+    // ── post-only / iceberg order kinds ─────────────────────────────────
+
+    /// Fixed non-zero owner for the order-kind tests.
+    fn kind_user() -> Hash32 {
+        Hash32::from([7u8; 32])
+    }
+
+    #[test]
+    fn test_add_post_only_order_rests_when_not_crossing() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        // Empty book: a post-only buy has nothing to cross and rests.
+        let res = book.add_post_only_order_with_tif_and_user_full(
+            OrderId::new(),
+            Side::Buy,
+            100,
+            10,
+            TimeInForce::Gtc,
+            kind_user(),
+        );
+        assert!(
+            res.is_ok(),
+            "post-only should rest on an empty book: {res:?}"
+        );
+        assert_eq!(book.best_bid(), Some(100));
+        assert!(book.best_ask().is_none());
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_add_post_only_order_would_cross_rejected_original_book_untouched() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        // Seed a resting sell; a post-only buy at the same price would cross.
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 10)
+            .expect("rest sell");
+
+        let res = book.add_post_only_order_with_tif_and_user_full(
+            OrderId::new(),
+            Side::Buy,
+            100,
+            5,
+            TimeInForce::Gtc,
+            kind_user(),
+        );
+        let err = match res {
+            Ok(_) => panic!("a crossing post-only must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().to_lowercase().contains("cross"),
+            "the rejection should mention crossing: {err}"
+        );
+        // Validate-first shape check: the book is untouched — no bid rested.
+        assert_eq!(book.order_count(), 1);
+        assert_eq!(book.best_ask(), Some(100));
+        assert!(book.best_bid().is_none());
+    }
+
+    #[test]
+    fn test_add_post_only_order_full_returns_empty_trade_when_rested() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let id = OrderId::new();
+        let trade = book
+            .add_post_only_order_with_tif_and_user_full(
+                id,
+                Side::Buy,
+                100,
+                10,
+                TimeInForce::Gtc,
+                kind_user(),
+            )
+            .expect("post-only rests");
+        // A rested post-only produced no fills; the empty result carries the
+        // taker's own order id.
+        assert!(trade.match_result.trades().is_empty());
+        assert_eq!(trade.match_result.order_id(), id);
+    }
+
+    #[test]
+    fn test_add_iceberg_order_full_rests_with_visible_and_hidden() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let trade = book
+            .add_iceberg_order_with_tif_and_user_full(
+                OrderId::new(),
+                Side::Buy,
+                100,
+                3,
+                7,
+                TimeInForce::Gtc,
+                kind_user(),
+            )
+            .expect("iceberg rests");
+        assert!(
+            trade.match_result.trades().is_empty(),
+            "resting iceberg has no fills"
+        );
+        assert_eq!(book.order_count(), 1);
+        assert_eq!(book.best_bid(), Some(100));
+
+        // The level exposes the visible tranche and hides the reserve.
+        let snapshot = book.snapshot(8);
+        let level = snapshot.bids.first().expect("one resting bid level");
+        assert_eq!(level.visible_quantity().as_u64(), 3, "visible tranche");
+        assert_eq!(level.hidden_quantity().as_u64(), 7, "hidden reserve");
+    }
+
+    #[test]
+    fn test_add_iceberg_order_full_crossing_returns_fills() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        // Resting sell to cross into.
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 10)
+            .expect("rest sell");
+
+        // Iceberg buy at the ask crosses and trades on entry (visible 3 + hidden 5).
+        let trade = book
+            .add_iceberg_order_with_tif_and_user_full(
+                OrderId::new(),
+                Side::Buy,
+                100,
+                3,
+                5,
+                TimeInForce::Gtc,
+                kind_user(),
+            )
+            .expect("iceberg crosses");
+        assert!(
+            !trade.match_result.trades().is_empty(),
+            "a crossing iceberg must trade on entry"
+        );
+    }
+
+    #[test]
+    fn test_add_iceberg_order_visible_plus_hidden_overflow_rejected() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let res = book.add_iceberg_order_with_tif_and_user_full(
+            OrderId::new(),
+            Side::Buy,
+            100,
+            u64::MAX,
+            1,
+            TimeInForce::Gtc,
+            kind_user(),
+        );
+        assert!(
+            matches!(res, Err(Error::ValidationError { .. })),
+            "visible + hidden overflow must be a typed ValidationError: {res:?}"
+        );
+        assert_eq!(book.order_count(), 0);
+    }
+
+    #[test]
+    fn test_add_post_only_order_out_of_band_rejected_before_engine() {
+        let book = max_price_book(1_000);
+        // An above-band post-only is rejected by the crate-side band check before
+        // the order is ever built or handed to the engine.
+        let res = book.add_post_only_order_with_tif_and_user_full(
+            OrderId::new(),
+            Side::Buy,
+            1_001,
+            10,
+            TimeInForce::Gtc,
+            kind_user(),
+        );
+        assert!(
+            matches!(res, Err(Error::ValidationError { .. })),
+            "out-of-band post-only must be a ValidationError, not an engine error: {res:?}"
+        );
+        assert_eq!(book.order_count(), 0);
+    }
+
+    #[test]
+    fn test_add_iceberg_order_out_of_band_rejected_before_engine() {
+        let book = max_price_book(1_000);
+        let res = book.add_iceberg_order_with_tif_and_user_full(
+            OrderId::new(),
+            Side::Buy,
+            1_001,
+            3,
+            7,
+            TimeInForce::Gtc,
+            kind_user(),
+        );
+        assert!(
+            matches!(res, Err(Error::ValidationError { .. })),
+            "out-of-band iceberg must be a ValidationError, not an engine error: {res:?}"
+        );
+        assert_eq!(book.order_count(), 0);
+    }
+
+    #[test]
+    fn test_add_post_only_order_rejected_when_halted() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.halt().expect("halt");
+        let res = book.add_post_only_order_with_tif_and_user_full(
+            OrderId::new(),
+            Side::Buy,
+            100,
+            10,
+            TimeInForce::Gtc,
+            kind_user(),
+        );
+        assert!(
+            matches!(res, Err(Error::InstrumentNotActive { .. })),
+            "post-only on a halted book must be rejected: {res:?}"
+        );
+        assert_eq!(book.order_count(), 0);
+    }
+
+    #[test]
+    fn test_add_iceberg_order_rejected_when_halted() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.halt().expect("halt");
+        let res = book.add_iceberg_order_with_tif_and_user_full(
+            OrderId::new(),
+            Side::Buy,
+            100,
+            3,
+            7,
+            TimeInForce::Gtc,
+            kind_user(),
+        );
+        assert!(
+            matches!(res, Err(Error::InstrumentNotActive { .. })),
+            "iceberg on a halted book must be rejected: {res:?}"
+        );
+        assert_eq!(book.order_count(), 0);
+    }
+
+    #[test]
+    fn test_add_post_only_convenience_delegates() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        // The non-`_full` convenience delegates to the `_full` method and drops
+        // the result; a resting post-only still succeeds and rests.
+        let res = book.add_post_only_order_with_tif_and_user(
+            OrderId::new(),
+            Side::Buy,
+            100,
+            10,
+            TimeInForce::Gtc,
+            kind_user(),
+        );
+        assert!(res.is_ok(), "post-only convenience should rest: {res:?}");
+        assert_eq!(book.best_bid(), Some(100));
         assert_eq!(book.order_count(), 1);
     }
 }

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -140,7 +140,7 @@ pub use nats::{
 #[cfg(feature = "sequencer")]
 pub use sequencer::{
     InMemoryOptionChainJournal, MassCancelScope, MassCancelType, OptionChainCommand,
-    OptionChainEvent, OptionChainJournal, OptionChainReceipt, OptionChainResult,
+    OptionChainEvent, OptionChainJournal, OptionChainReceipt, OptionChainResult, OrderKind,
     SequencedUnderlyingOrderBook,
 };
 

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -134,6 +134,46 @@ fn default_add_order_tif() -> TimeInForce {
     TimeInForce::Gtc
 }
 
+/// The kind of add a journaled [`OptionChainCommand::AddOrder`] performs.
+///
+/// A single `AddOrder` command carries one of these to select the leaf add path:
+/// a plain limit add, a post-only (maker-only) add, or an iceberg add. This is a
+/// journaled (on-disk) type: variant tags are pinned to `PascalCase`, and the
+/// enum is `#[non_exhaustive]` so future kinds can be appended without a source
+/// break (a `match` on it outside this crate must carry a wildcard arm).
+///
+/// # Wire compatibility
+///
+/// `AddOrder` gained this field in #151 with `#[serde(default)]`, so a journal
+/// written before then decodes to [`OrderKind::Limit`] — the only kind that
+/// existed. As with the other defaulted `AddOrder` fields, that missing-field
+/// default only applies in self-describing encodings (JSON); a positional codec
+/// such as bincode cannot detect an absent trailing field, so pre-#151 *binary*
+/// records must be re-journaled or migrated rather than decoded against the new
+/// shape. An unknown variant tag (a kind a newer binary wrote) is rejected by a
+/// binary that predates it — the same forward-compat asymmetry as the command
+/// enum itself.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[repr(u8)]
+#[non_exhaustive]
+pub enum OrderKind {
+    /// A standard limit order: rests if it does not cross, matches if it does.
+    #[default]
+    Limit,
+    /// A post-only (maker-only) order: rejected with a `PriceCrossing` engine
+    /// error if it would cross and take liquidity, so it can only ever rest.
+    PostOnly,
+    /// An iceberg order: only a visible tranche ([`AddOrder::quantity`] — see the
+    /// field's note) is exposed at a time while a hidden reserve
+    /// ([`AddOrder::hidden_quantity`]) is replenished behind it. Can cross and
+    /// trade on entry like a limit order.
+    ///
+    /// [`AddOrder::quantity`]: OptionChainCommand::AddOrder
+    /// [`AddOrder::hidden_quantity`]: OptionChainCommand::AddOrder
+    Iceberg,
+}
+
 /// Command for the option chain sequencer with hierarchy routing.
 ///
 /// Each variant represents an operation that can be sequenced through
@@ -202,6 +242,31 @@ pub enum OptionChainCommand {
         /// every add was attributed to the zero user. Serializes as a hex string.
         #[serde(default)]
         user_id: Hash32,
+        /// The kind of add to perform: limit, post-only, or iceberg.
+        ///
+        /// Defaults to [`OrderKind::Limit`] (via `#[serde(default)]`, which
+        /// `OrderKind` derives) when absent, so a journal written before #151
+        /// decodes and replays as a plain limit add — the only kind that then
+        /// existed. Same JSON-only default caveat as `tif`: a positional binary
+        /// codec cannot supply the missing trailing field, so pre-#151 binary
+        /// records must be re-journaled instead.
+        #[serde(default)]
+        kind: OrderKind,
+        /// Hidden reserve for an iceberg add, in quantity units.
+        ///
+        /// **For an iceberg add, `quantity` above is the VISIBLE tranche and this
+        /// is the hidden reserve behind it — the resting order's total size is
+        /// `quantity + hidden_quantity`, and its `quantity()` accessor reports
+        /// only the visible tranche.** Required as `Some(h)` with `h >= 1` when
+        /// `kind` is [`Iceberg`](OrderKind::Iceberg); MUST be `None` for
+        /// [`Limit`](OrderKind::Limit) / [`PostOnly`](OrderKind::PostOnly). A
+        /// mismatch is a deterministic [`Rejected`](OptionChainResult::Rejected),
+        /// never a silent field drop (see the validation in `execute_add_order`).
+        /// Defaults to `None` (via `#[serde(default)]`) when absent, so pre-#151
+        /// journals decode as non-iceberg. Same JSON-only default caveat as the
+        /// other appended fields.
+        #[serde(default)]
+        hidden_quantity: Option<u64>,
     },
     /// Cancel an order in a specific option book.
     CancelOrder {
@@ -1087,12 +1152,13 @@ impl SequencedUnderlyingOrderBook {
     /// Submits an add order command with an explicit time-in-force and user
     /// identity.
     ///
-    /// This is the full-fidelity add: it carries the `tif` and `user_id` into the
-    /// journaled [`OptionChainCommand::AddOrder`] so replay reproduces the same
-    /// eviction behavior (for `Gtd`/`Day`, in concert with the injected engine
-    /// clock) and the same by-user attribution. On success the receipt's
+    /// This is the full-fidelity limit add: it carries the `tif` and `user_id`
+    /// into the journaled [`OptionChainCommand::AddOrder`] so replay reproduces
+    /// the same eviction behavior (for `Gtd`/`Day`, in concert with the injected
+    /// engine clock) and the same by-user attribution. On success the receipt's
     /// [`OptionChainResult::OrderAdded`] carries the fills the add produced (see
-    /// that variant's replay caveat).
+    /// that variant's replay caveat). For a post-only or iceberg add, use
+    /// [`submit_add_order_kind`](Self::submit_add_order_kind).
     ///
     /// # Arguments
     ///
@@ -1121,6 +1187,73 @@ impl SequencedUnderlyingOrderBook {
         tif: TimeInForce,
         user_id: Hash32,
     ) -> Result<OptionChainReceipt, Error> {
+        // Delegate with the pre-#151 defaults (a plain limit add, no hidden
+        // reserve) so the 0.8.0 signature stays a convenience wrapper and cannot
+        // drift from the full order-kind path.
+        self.submit_add_order_kind(
+            symbol,
+            order_id,
+            side,
+            price,
+            quantity,
+            tif,
+            user_id,
+            OrderKind::Limit,
+            None,
+        )
+    }
+
+    /// Submits an add order command with an explicit order kind (limit,
+    /// post-only, or iceberg).
+    ///
+    /// This is the widest add entry point: beyond `tif` and `user_id`, it carries
+    /// the [`OrderKind`] and, for an iceberg, the `hidden_quantity` into the
+    /// journaled [`OptionChainCommand::AddOrder`], so replay reconstructs the
+    /// exact same order shape.
+    ///
+    /// # `quantity` vs `hidden_quantity`
+    ///
+    /// For an [`Iceberg`](OrderKind::Iceberg) add, `quantity` is the VISIBLE
+    /// tranche and `hidden_quantity` (`Some(h)`, `h >= 1`) is the hidden reserve;
+    /// the resting order's total size is `quantity + hidden_quantity`. For a
+    /// [`Limit`](OrderKind::Limit) or [`PostOnly`](OrderKind::PostOnly) add,
+    /// `hidden_quantity` MUST be `None`. A mismatched pairing is journaled as a
+    /// deterministic [`Rejected`](OptionChainResult::Rejected) rather than
+    /// silently dropping the field.
+    ///
+    /// A post-only add that would cross the book is rejected by the engine with a
+    /// `PriceCrossing` error and journaled as `Rejected` (deterministic).
+    ///
+    /// # Arguments
+    ///
+    /// * `symbol` - Target option symbol (e.g., "BTC-20240329-50000-C")
+    /// * `order_id` - Unique order identifier
+    /// * `side` - Buy or Sell
+    /// * `price` - Limit price
+    /// * `quantity` - Order quantity (the visible tranche for an iceberg)
+    /// * `tif` - Time-in-force policy for the order
+    /// * `user_id` - Owning user identity
+    /// * `kind` - The kind of add: limit, post-only, or iceberg
+    /// * `hidden_quantity` - Hidden reserve for an iceberg add; `None` otherwise
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if journaling fails.
+    // The order kind and hidden reserve are two more intrinsic order attributes on
+    // top of the full add; a struct would only obscure the call site.
+    #[allow(clippy::too_many_arguments)]
+    pub fn submit_add_order_kind(
+        &self,
+        symbol: &str,
+        order_id: OrderId,
+        side: Side,
+        price: u128,
+        quantity: u64,
+        tif: TimeInForce,
+        user_id: Hash32,
+        kind: OrderKind,
+        hidden_quantity: Option<u64>,
+    ) -> Result<OptionChainReceipt, Error> {
         let command = OptionChainCommand::AddOrder {
             symbol: symbol.to_string(),
             order_id,
@@ -1129,6 +1262,8 @@ impl SequencedUnderlyingOrderBook {
             quantity,
             tif,
             user_id,
+            kind,
+            hidden_quantity,
         };
         self.submit(command)
     }
@@ -1289,9 +1424,19 @@ impl SequencedUnderlyingOrderBook {
                 quantity,
                 tif,
                 user_id,
-            } => {
-                self.execute_add_order(symbol, *order_id, *side, *price, *quantity, *tif, *user_id)
-            }
+                kind,
+                hidden_quantity,
+            } => self.execute_add_order(
+                symbol,
+                *order_id,
+                *side,
+                *price,
+                *quantity,
+                *tif,
+                *user_id,
+                *kind,
+                *hidden_quantity,
+            ),
             OptionChainCommand::CancelOrder { symbol, order_id } => {
                 self.execute_cancel_order(symbol, *order_id)
             }
@@ -1324,6 +1469,23 @@ impl SequencedUnderlyingOrderBook {
     /// symbol still yields [`OptionChainResult::BookNotFound`]; a cross-underlying
     /// symbol is rejected before anything is created.
     ///
+    /// # Order kind and `hidden_quantity`
+    ///
+    /// The [`OrderKind`] selects the leaf add path: [`Limit`](OrderKind::Limit)
+    /// and [`PostOnly`](OrderKind::PostOnly) take `quantity` alone;
+    /// [`Iceberg`](OrderKind::Iceberg) treats `quantity` as the visible tranche
+    /// and requires `hidden_quantity` to be `Some(h)` with `h >= 1`. The pairing
+    /// is validated strictly and deterministically BEFORE the book is resolved,
+    /// so an invalid pairing is journaled as [`OptionChainResult::Rejected`] with
+    /// no book mutation and never silently drops the field:
+    ///
+    /// - Iceberg with `hidden_quantity` `None` or `Some(0)` → rejected.
+    /// - Limit / PostOnly with `hidden_quantity` `Some(_)` → rejected.
+    ///
+    /// A post-only add that would cross is rejected by the engine with a
+    /// `PriceCrossing` error and surfaced as `Rejected` — deterministic, so it
+    /// replays identically.
+    ///
     /// # Fills and the error-after-fills caveat
     ///
     /// On success the result's `trade` is `Some` iff the add crossed and executed
@@ -1335,8 +1497,8 @@ impl SequencedUnderlyingOrderBook {
     /// only; they are deterministic, so replay reproduces the same rejection and
     /// the same fills, but a venue consumer must not read `Rejected` as "nothing
     /// happened".
-    // Mirrors the full add attribute set (see `submit_add_order_with`); the count
-    // is intrinsic to a limit-order add, not accidental.
+    // Mirrors the full add attribute set (see `submit_add_order_kind`); the count
+    // is intrinsic to a full add, not accidental.
     #[allow(clippy::too_many_arguments)]
     fn execute_add_order(
         &self,
@@ -1347,7 +1509,28 @@ impl SequencedUnderlyingOrderBook {
         quantity: u64,
         tif: TimeInForce,
         user_id: Hash32,
+        kind: OrderKind,
+        hidden_quantity: Option<u64>,
     ) -> OptionChainResult {
+        // Strict kind/hidden validation runs first, before any book resolution or
+        // mutation, so an invalid pairing is a pure deterministic rejection. This
+        // exhaustive match is over this crate's own `#[non_exhaustive]` enum, so
+        // it is exhaustive here even though downstream matches need a wildcard.
+        let resolved_hidden = match (kind, hidden_quantity) {
+            (OrderKind::Iceberg, Some(h)) if h >= 1 => Some(h),
+            (OrderKind::Iceberg, _) => {
+                return OptionChainResult::Rejected {
+                    reason: "iceberg add requires hidden_quantity >= 1".to_string(),
+                };
+            }
+            (OrderKind::Limit | OrderKind::PostOnly, Some(_)) => {
+                return OptionChainResult::Rejected {
+                    reason: "hidden_quantity is only valid for iceberg adds".to_string(),
+                };
+            }
+            (OrderKind::Limit | OrderKind::PostOnly, None) => None,
+        };
+
         let book = match self.find_or_create_book_by_symbol(symbol) {
             Ok(book) => book,
             // A cross-underlying command must be rejected with the typed reason,
@@ -1366,9 +1549,31 @@ impl SequencedUnderlyingOrderBook {
             }
         };
 
-        match book
-            .add_limit_order_with_tif_and_user_full(order_id, side, price, quantity, tif, user_id)
-        {
+        // Dispatch to the leaf add path for the requested kind. Each returns the
+        // same `Result<TradeResult, _>` shape, so fill attribution is uniform.
+        let outcome = match kind {
+            OrderKind::Limit => book.add_limit_order_with_tif_and_user_full(
+                order_id, side, price, quantity, tif, user_id,
+            ),
+            OrderKind::PostOnly => book.add_post_only_order_with_tif_and_user_full(
+                order_id, side, price, quantity, tif, user_id,
+            ),
+            OrderKind::Iceberg => {
+                // `resolved_hidden` is `Some(h >= 1)` for Iceberg by construction
+                // above; fall back to the same typed rejection defensively rather
+                // than unwrap.
+                let Some(hidden) = resolved_hidden else {
+                    return OptionChainResult::Rejected {
+                        reason: "iceberg add requires hidden_quantity >= 1".to_string(),
+                    };
+                };
+                book.add_iceberg_order_with_tif_and_user_full(
+                    order_id, side, price, quantity, hidden, tif, user_id,
+                )
+            }
+        };
+
+        match outcome {
             Ok(trade) => OptionChainResult::OrderAdded {
                 order_id,
                 // Carry the fills only when the add actually crossed; an empty
@@ -2732,6 +2937,8 @@ mod tests {
                 quantity: 10,
                 tif: TimeInForce::Gtc,
                 user_id: Hash32::zero(),
+                kind: OrderKind::Limit,
+                hidden_quantity: None,
             },
             result: OptionChainResult::OrderAdded {
                 order_id: OrderId::new(),
@@ -2982,7 +3189,7 @@ mod tests {
             .expect("canonical expiry");
 
         vec![
-            // AddOrder + OrderAdded (default tif/user, rested unfilled → trade None)
+            // AddOrder + OrderAdded (default tif/user/kind, rested → trade None)
             OptionChainEvent {
                 sequence_num: 1,
                 timestamp_ns: 1_700_000_000_000_000_000,
@@ -2994,6 +3201,8 @@ mod tests {
                     quantity: 10,
                     tif: TimeInForce::Gtc,
                     user_id: Hash32::zero(),
+                    kind: OrderKind::Limit,
+                    hidden_quantity: None,
                 },
                 result: OptionChainResult::OrderAdded {
                     order_id: oid,
@@ -3085,7 +3294,7 @@ mod tests {
             },
             // AddOrder with a NON-default tif (Gtd) + nonzero user_id, and an
             // OrderAdded carrying deterministic fills (#148). Exercises the
-            // enriched wire shape end to end.
+            // enriched wire shape end to end. Kind defaults to Limit.
             OptionChainEvent {
                 sequence_num: 9,
                 timestamp_ns: 1_700_000_000_000_000_008,
@@ -3097,6 +3306,8 @@ mod tests {
                     quantity: 4,
                     tif: TimeInForce::Gtd(1_700_000_000_000),
                     user_id: user,
+                    kind: OrderKind::Limit,
+                    hidden_quantity: None,
                 },
                 result: OptionChainResult::OrderAdded {
                     order_id: oid,
@@ -3115,6 +3326,47 @@ mod tests {
                     side: Side::Buy,
                 },
                 result: OptionChainResult::OrderReplaced { order_id: oid },
+            },
+            // PostOnly AddOrder that rested (#151): non-default kind, trade None.
+            OptionChainEvent {
+                sequence_num: 11,
+                timestamp_ns: 1_700_000_000_000_000_010,
+                command: OptionChainCommand::AddOrder {
+                    symbol: "BTC-20240329-50000-C".to_string(),
+                    order_id: oid,
+                    side: Side::Buy,
+                    price: 90,
+                    quantity: 6,
+                    tif: TimeInForce::Gtc,
+                    user_id: Hash32::zero(),
+                    kind: OrderKind::PostOnly,
+                    hidden_quantity: None,
+                },
+                result: OptionChainResult::OrderAdded {
+                    order_id: oid,
+                    trade: None,
+                },
+            },
+            // Iceberg AddOrder (#151): non-default kind + Some(hidden). quantity is
+            // the visible tranche, hidden_quantity the reserve behind it.
+            OptionChainEvent {
+                sequence_num: 12,
+                timestamp_ns: 1_700_000_000_000_000_011,
+                command: OptionChainCommand::AddOrder {
+                    symbol: "BTC-20240329-50000-C".to_string(),
+                    order_id: oid,
+                    side: Side::Sell,
+                    price: 130,
+                    quantity: 5,
+                    tif: TimeInForce::Gtc,
+                    user_id: user,
+                    kind: OrderKind::Iceberg,
+                    hidden_quantity: Some(20),
+                },
+                result: OptionChainResult::OrderAdded {
+                    order_id: oid,
+                    trade: Some(deterministic_trade_result()),
+                },
             },
         ]
     }
@@ -3148,6 +3400,102 @@ mod tests {
             .add_trade(trade)
             .expect("pinned trade must not overfill the match result");
         TradeResult::new("BTC-20240329-50000-C".to_string(), match_result)
+    }
+
+    /// The exact reason string the leaf surfaces when a post-only add would
+    /// cross the book (empirically pinned against orderbook-rs 0.10.3). Kept as a
+    /// named constant so the v0.9.0 fixture and the determinism unit test assert
+    /// against one source of truth.
+    const POST_ONLY_CROSS_REASON: &str =
+        "order-book engine error: Price crossing: SELL 100 would cross opposite at 100";
+
+    /// The #151-schema (v0.9.0) fixture events: the order-kind variety a v0.8.0
+    /// journal could not express. Post-only rest, post-only would-cross reject,
+    /// iceberg add with a deterministic fill, and an iceberg missing-hidden
+    /// reject. Built with deterministic ids so the encoding is byte-stable.
+    fn v0_9_0_fixture_events() -> Vec<OptionChainEvent> {
+        let oid = OrderId::sequential(42);
+        let user = Hash32::from([7u8; 32]);
+        vec![
+            // Post-only add that rested (did not cross) → OrderAdded, trade None.
+            OptionChainEvent {
+                sequence_num: 1,
+                timestamp_ns: 1_700_000_000_000_000_100,
+                command: OptionChainCommand::AddOrder {
+                    symbol: "BTC-20240329-50000-C".to_string(),
+                    order_id: oid,
+                    side: Side::Buy,
+                    price: 90,
+                    quantity: 6,
+                    tif: TimeInForce::Gtc,
+                    user_id: Hash32::zero(),
+                    kind: OrderKind::PostOnly,
+                    hidden_quantity: None,
+                },
+                result: OptionChainResult::OrderAdded {
+                    order_id: oid,
+                    trade: None,
+                },
+            },
+            // Post-only add that would cross → Rejected (pinned PriceCrossing).
+            OptionChainEvent {
+                sequence_num: 2,
+                timestamp_ns: 1_700_000_000_000_000_101,
+                command: OptionChainCommand::AddOrder {
+                    symbol: "BTC-20240329-50000-C".to_string(),
+                    order_id: OrderId::sequential(43),
+                    side: Side::Sell,
+                    price: 100,
+                    quantity: 3,
+                    tif: TimeInForce::Gtc,
+                    user_id: Hash32::zero(),
+                    kind: OrderKind::PostOnly,
+                    hidden_quantity: None,
+                },
+                result: OptionChainResult::Rejected {
+                    reason: POST_ONLY_CROSS_REASON.to_string(),
+                },
+            },
+            // Iceberg add carrying deterministic fills → OrderAdded, trade Some.
+            OptionChainEvent {
+                sequence_num: 3,
+                timestamp_ns: 1_700_000_000_000_000_102,
+                command: OptionChainCommand::AddOrder {
+                    symbol: "BTC-20240329-50000-C".to_string(),
+                    order_id: oid,
+                    side: Side::Sell,
+                    price: 130,
+                    quantity: 5,
+                    tif: TimeInForce::Gtc,
+                    user_id: user,
+                    kind: OrderKind::Iceberg,
+                    hidden_quantity: Some(20),
+                },
+                result: OptionChainResult::OrderAdded {
+                    order_id: oid,
+                    trade: Some(deterministic_trade_result()),
+                },
+            },
+            // Iceberg add with no hidden reserve → deterministic Rejected.
+            OptionChainEvent {
+                sequence_num: 4,
+                timestamp_ns: 1_700_000_000_000_000_103,
+                command: OptionChainCommand::AddOrder {
+                    symbol: "BTC-20240329-50000-C".to_string(),
+                    order_id: OrderId::sequential(44),
+                    side: Side::Buy,
+                    price: 95,
+                    quantity: 5,
+                    tif: TimeInForce::Gtc,
+                    user_id: Hash32::zero(),
+                    kind: OrderKind::Iceberg,
+                    hidden_quantity: None,
+                },
+                result: OptionChainResult::Rejected {
+                    reason: "iceberg add requires hidden_quantity >= 1".to_string(),
+                },
+            },
+        ]
     }
 
     /// Back-compat / format-pin guard: a checked-in journal sample written under
@@ -3190,17 +3538,19 @@ mod tests {
             }
         ));
 
-        // Re-encoding: the #148 additive fields (`tif` / `user_id` on `AddOrder`,
-        // `trade` on `OrderAdded`) are absent from the frozen v0.5.0 fixture but
-        // are ALWAYS emitted by the current schema (no `skip_serializing_if`), so
-        // a naive `to_value(decoded) == fixture` comparison would fail purely on
-        // the new fields. That is expected and correct: the additive-field
-        // precedent is that an old journal decodes to the field DEFAULTS, and
-        // re-encoding then materializes those defaults. To keep this test a true
-        // wire-stability pin (nothing OTHER than the known additive fields
-        // changed), we patch the parsed fixture with exactly those defaults —
-        // `"tif":"GTC"`, the zero-hex `user_id`, `"trade":null` — and require the
-        // patched fixture to match the re-encode byte-for-byte. Any drift in a
+        // Re-encoding: the additive fields — #148 (`tif` / `user_id` on
+        // `AddOrder`, `trade` on `OrderAdded`) and #151 (`kind` /
+        // `hidden_quantity` on `AddOrder`) — are absent from the frozen v0.5.0
+        // fixture but are ALWAYS emitted by the current schema (no
+        // `skip_serializing_if`), so a naive `to_value(decoded) == fixture`
+        // comparison would fail purely on the new fields. That is expected and
+        // correct: the additive-field precedent is that an old journal decodes to
+        // the field DEFAULTS, and re-encoding then materializes those defaults. To
+        // keep this test a true wire-stability pin (nothing OTHER than the known
+        // additive fields changed), we patch the parsed fixture with exactly those
+        // defaults — `"tif":"GTC"`, the zero-hex `user_id`, `"kind":"Limit"`,
+        // `"hidden_quantity":null`, `"trade":null` — and require the patched
+        // fixture to match the re-encode byte-for-byte. Any drift in a
         // pre-existing field still fails loudly. The frozen fixture file itself
         // is NOT edited.
         let reencoded: serde_json::Value =
@@ -3217,6 +3567,8 @@ mod tests {
             "user_id".to_string(),
             serde_json::json!(Hash32::zero().to_hex()),
         );
+        add_cmd.insert("kind".to_string(), serde_json::json!("Limit"));
+        add_cmd.insert("hidden_quantity".to_string(), serde_json::Value::Null);
         let added_result = on_disk[0]["result"]["OrderAdded"]
             .as_object_mut()
             .expect("fixture event 0 result is OrderAdded");
@@ -3225,7 +3577,92 @@ mod tests {
         assert_eq!(
             reencoded, on_disk,
             "re-encoded journal diverged from the checked-in v0.5.0 wire format \
-             (beyond the known #148 additive fields)"
+             (beyond the known #148/#151 additive fields)"
+        );
+    }
+
+    /// Format-pin guard for the #151 schema, exercising the order-kind variety a
+    /// v0.8.0 journal could not express: a post-only rest (`OrderAdded` with
+    /// `trade: null`), a post-only would-cross rejection (with the pinned
+    /// `PriceCrossing` reason), an iceberg add carrying a deterministic fill, and
+    /// an iceberg missing-hidden rejection. The fixture is the current schema, so
+    /// the re-encode is strict with no patching.
+    ///
+    /// NOTE: this fixture is **unfrozen** until the release that ships #151 — it
+    /// tracks the in-development schema and may be regenerated. #153 will append
+    /// its `trade`-on-`OrderReplaced` events here; once released it freezes like
+    /// v0.5.0 / v0.8.0, and later schema additions patch defaults instead.
+    ///
+    /// The fixture lives at `tests/fixtures/journal_event_v0.9.0.json`.
+    #[test]
+    fn test_journal_event_v0_9_0_fixture_decodes_and_is_stable() {
+        const FIXTURE: &str = include_str!("../../tests/fixtures/journal_event_v0.9.0.json");
+
+        let decoded: Vec<OptionChainEvent> =
+            serde_json::from_str(FIXTURE).expect("v0.9.0 journal fixture must decode");
+        assert_eq!(decoded.len(), 4, "fixture should hold four events");
+
+        // Spot-check the #151 shapes.
+        assert!(matches!(
+            decoded[0].command,
+            OptionChainCommand::AddOrder {
+                kind: OrderKind::PostOnly,
+                hidden_quantity: None,
+                ..
+            }
+        ));
+        assert!(matches!(
+            decoded[0].result,
+            OptionChainResult::OrderAdded { trade: None, .. }
+        ));
+        match &decoded[1].result {
+            OptionChainResult::Rejected { reason } => {
+                assert_eq!(
+                    reason, POST_ONLY_CROSS_REASON,
+                    "PriceCrossing reason drifted"
+                )
+            }
+            other => panic!("event 1 must be a Rejected post-only cross, got {other:?}"),
+        }
+        assert!(matches!(
+            decoded[2].command,
+            OptionChainCommand::AddOrder {
+                kind: OrderKind::Iceberg,
+                hidden_quantity: Some(20),
+                ..
+            }
+        ));
+        assert!(matches!(
+            decoded[2].result,
+            OptionChainResult::OrderAdded { trade: Some(_), .. }
+        ));
+        assert!(matches!(
+            decoded[3].command,
+            OptionChainCommand::AddOrder {
+                kind: OrderKind::Iceberg,
+                hidden_quantity: None,
+                ..
+            }
+        ));
+
+        // Strict re-encode: the current schema is fully materialized in the
+        // fixture, so no additive-field patching is needed.
+        let reencoded: serde_json::Value =
+            serde_json::to_value(&decoded).expect("re-encode decoded events");
+        let on_disk: serde_json::Value =
+            serde_json::from_str(FIXTURE).expect("parse fixture as value");
+        assert_eq!(
+            reencoded, on_disk,
+            "re-encoded journal diverged from the checked-in v0.9.0 wire format"
+        );
+
+        // The frozen file must also match what the code-side builder produces, so
+        // the fixture cannot silently drift from `v0_9_0_fixture_events`.
+        let from_builder: serde_json::Value =
+            serde_json::to_value(v0_9_0_fixture_events()).expect("serialize builder events");
+        assert_eq!(
+            from_builder, on_disk,
+            "the v0.9.0 fixture file diverged from v0_9_0_fixture_events()"
         );
     }
 
@@ -3246,14 +3683,16 @@ mod tests {
 
     /// Format-pin guard for the CURRENT (#148) schema: a checked-in journal
     /// sample written under the enriched schema MUST decode into
-    /// `OptionChainEvent` and re-encode value-identically. Unlike the v0.5.0
-    /// fixture (which predates the additive fields and therefore needs the
-    /// defaults patched in), this fixture already carries `tif` / `user_id` /
-    /// `trade` and the `ReplaceOrder` / `OrderReplaced` variants, so the
-    /// comparison is strict with no patching. It covers `AddOrder` with the
-    /// default and with a non-default `Gtd` tif + nonzero user, `OrderAdded` both
-    /// with `trade: null` and with a deterministic fill payload, and the replace
-    /// pair.
+    /// `OptionChainEvent` and re-encode value-identically. The frozen v0.8.0
+    /// fixture carries the #148 fields (`tif` / `user_id` / `trade`) and the
+    /// `ReplaceOrder` / `OrderReplaced` variants, but predates the #151
+    /// `kind` / `hidden_quantity` fields on `AddOrder`. So — exactly as the
+    /// v0.5.0 test does for the #148 fields — this test patches the #151 defaults
+    /// (`"kind":"Limit"`, `"hidden_quantity":null`) into the parsed fixture's
+    /// AddOrder command objects before the strict compare; the frozen fixture
+    /// file itself is NOT edited. It covers `AddOrder` with the default and with a
+    /// non-default `Gtd` tif + nonzero user, `OrderAdded` both with `trade: null`
+    /// and with a deterministic fill payload, and the replace pair.
     ///
     /// The fixture lives at `tests/fixtures/journal_event_v0.8.0.json`.
     #[test]
@@ -3264,15 +3703,26 @@ mod tests {
             serde_json::from_str(FIXTURE).expect("v0.8.0 journal fixture must decode");
         assert_eq!(decoded.len(), 10, "fixture should hold ten events");
 
-        // Spot-check the #148 shapes landed as expected.
+        // Spot-check the #148 shapes landed as expected, plus that the #151
+        // fields defaulted (the fixture predates them).
         assert!(matches!(
             decoded[0].result,
             OptionChainResult::OrderAdded { trade: None, .. }
         ));
         assert!(matches!(
+            decoded[0].command,
+            OptionChainCommand::AddOrder {
+                kind: OrderKind::Limit,
+                hidden_quantity: None,
+                ..
+            }
+        ));
+        assert!(matches!(
             decoded[8].command,
             OptionChainCommand::AddOrder {
                 tif: TimeInForce::Gtd(1_700_000_000_000),
+                kind: OrderKind::Limit,
+                hidden_quantity: None,
                 ..
             }
         ));
@@ -3289,15 +3739,27 @@ mod tests {
             OptionChainResult::OrderReplaced { .. }
         ));
 
-        // Strict re-encode: the current schema is fully materialized in the
-        // fixture, so no additive-field patching is needed.
+        // Patch-defaults re-encode: the frozen v0.8.0 fixture predates the #151
+        // `kind` / `hidden_quantity` fields, which the current schema always
+        // emits. Inject those defaults into the two AddOrder command objects
+        // (events 0 and 8) before comparing byte-for-byte — same sanctioned
+        // pattern the v0.5.0 test uses for the #148 fields. The frozen file is
+        // untouched.
         let reencoded: serde_json::Value =
             serde_json::to_value(&decoded).expect("re-encode decoded events");
-        let on_disk: serde_json::Value =
+        let mut on_disk: serde_json::Value =
             serde_json::from_str(FIXTURE).expect("parse fixture as value");
+        for idx in [0usize, 8] {
+            let add_cmd = on_disk[idx]["command"]["AddOrder"]
+                .as_object_mut()
+                .unwrap_or_else(|| panic!("fixture event {idx} command must be AddOrder"));
+            add_cmd.insert("kind".to_string(), serde_json::json!("Limit"));
+            add_cmd.insert("hidden_quantity".to_string(), serde_json::Value::Null);
+        }
         assert_eq!(
             reencoded, on_disk,
-            "re-encoded journal diverged from the checked-in v0.8.0 wire format"
+            "re-encoded journal diverged from the checked-in v0.8.0 wire format \
+             (beyond the known #151 additive fields)"
         );
     }
 
@@ -3440,6 +3902,51 @@ mod tests {
             serde_json::from_str::<OptionChainEvent>(in_replaced_result).is_err(),
             "unknown field inside OrderReplaced must be rejected"
         );
+
+        // Extra field alongside the #151 kind / hidden_quantity fields must be
+        // rejected (proving they did not weaken deny_unknown_fields).
+        let in_kinded_add = r#"{
+            "sequence_num": 1,
+            "timestamp_ns": 2,
+            "command": { "AddOrder": {
+                "symbol": "BTC-20240329-50000-C",
+                "order_id": "42",
+                "side": "BUY",
+                "price": 100,
+                "quantity": 10,
+                "tif": "GTC",
+                "user_id": "0000000000000000000000000000000000000000000000000000000000000000",
+                "kind": "Iceberg",
+                "hidden_quantity": 20,
+                "extra": 1
+            } },
+            "result": { "OrderAdded": { "order_id": "42", "trade": null } }
+        }"#;
+        assert!(
+            serde_json::from_str::<OptionChainEvent>(in_kinded_add).is_err(),
+            "unknown field alongside kind/hidden_quantity must be rejected"
+        );
+
+        // An unknown OrderKind variant tag (a kind a newer binary wrote) must
+        // fail to decode — the same old-binary-rejects-new-tag asymmetry as the
+        // command/result enums, and independent of deny_unknown_fields.
+        let unknown_kind = r#"{
+            "sequence_num": 1,
+            "timestamp_ns": 2,
+            "command": { "AddOrder": {
+                "symbol": "BTC-20240329-50000-C",
+                "order_id": "42",
+                "side": "BUY",
+                "price": 100,
+                "quantity": 10,
+                "kind": "TrailingStop"
+            } },
+            "result": { "OrderAdded": { "order_id": "42" } }
+        }"#;
+        assert!(
+            serde_json::from_str::<OptionChainEvent>(unknown_kind).is_err(),
+            "an unknown OrderKind variant tag must be rejected"
+        );
     }
 
     /// Pins the 0.7.0 wire format of the appended `EvictExpiredOrders` /
@@ -3497,15 +4004,16 @@ mod tests {
         );
     }
 
-    /// Pins the #148 enriched `AddOrder` wire shape: the appended `tif` /
-    /// `user_id` fields, the pricelevel casing of the `Gtd` payload
-    /// (`{"GTD": ms}`, not `snake_case`), and the hex-string `user_id`. Also pins
-    /// that the default `tif`/`user` still serialize explicitly (no
+    /// Pins the enriched `AddOrder` wire shape: the #148 `tif` / `user_id`
+    /// fields, the pricelevel casing of the `Gtd` payload (`{"GTD": ms}`, not
+    /// `snake_case`), the hex-string `user_id`, and the #151 `kind` /
+    /// `hidden_quantity` fields (`PascalCase` kind tag, `null`/number hidden).
+    /// Also pins that the defaults still serialize explicitly (no
     /// `skip_serializing_if`), which is what keeps the JSON/bincode encodings
     /// symmetric across a decode/encode round-trip.
     #[test]
     fn test_add_order_wire_format_pinned() {
-        // Non-default tif (Gtd) + nonzero user.
+        // Non-default tif (Gtd) + nonzero user, default (Limit / None) kind.
         let gtd = OptionChainCommand::AddOrder {
             symbol: "BTC-20240329-50000-C".to_string(),
             order_id: OrderId::sequential(42),
@@ -3514,6 +4022,8 @@ mod tests {
             quantity: 4,
             tif: TimeInForce::Gtd(1_700_000_000_000),
             user_id: Hash32::from([7u8; 32]),
+            kind: OrderKind::Limit,
+            hidden_quantity: None,
         };
         let value = serde_json::to_value(&gtd).expect("serialize");
         let expected = serde_json::json!({
@@ -3524,12 +4034,39 @@ mod tests {
                 "price": 100,
                 "quantity": 4,
                 "tif": { "GTD": 1_700_000_000_000_u64 },
-                "user_id": "0707070707070707070707070707070707070707070707070707070707070707"
+                "user_id": "0707070707070707070707070707070707070707070707070707070707070707",
+                "kind": "Limit",
+                "hidden_quantity": null
             }
         });
         assert_eq!(value, expected, "enriched AddOrder wire format drifted");
 
-        // Default tif/user still serialize explicitly.
+        // An iceberg add pins the PascalCase kind tag and the numeric hidden
+        // reserve (quantity here is the visible tranche).
+        let iceberg = OptionChainCommand::AddOrder {
+            symbol: "BTC-20240329-50000-C".to_string(),
+            order_id: OrderId::sequential(42),
+            side: Side::Sell,
+            price: 130,
+            quantity: 5,
+            tif: TimeInForce::Gtc,
+            user_id: Hash32::zero(),
+            kind: OrderKind::Iceberg,
+            hidden_quantity: Some(20),
+        };
+        let iceberg_value = serde_json::to_value(&iceberg).expect("serialize iceberg");
+        assert_eq!(
+            iceberg_value["AddOrder"]["kind"],
+            serde_json::json!("Iceberg"),
+            "iceberg kind tag must serialize as \"Iceberg\""
+        );
+        assert_eq!(
+            iceberg_value["AddOrder"]["hidden_quantity"],
+            serde_json::json!(20),
+            "hidden_quantity must serialize as a plain number"
+        );
+
+        // Defaults (tif / user / kind / hidden) still serialize explicitly.
         let default = OptionChainCommand::AddOrder {
             symbol: "BTC-20240329-50000-C".to_string(),
             order_id: OrderId::sequential(42),
@@ -3538,6 +4075,8 @@ mod tests {
             quantity: 5,
             tif: TimeInForce::Gtc,
             user_id: Hash32::zero(),
+            kind: OrderKind::Limit,
+            hidden_quantity: None,
         };
         let default_value = serde_json::to_value(&default).expect("serialize default");
         assert_eq!(
@@ -3549,6 +4088,16 @@ mod tests {
             default_value["AddOrder"]["user_id"],
             serde_json::json!(Hash32::zero().to_hex()),
             "default user_id must serialize as the zero hex string"
+        );
+        assert_eq!(
+            default_value["AddOrder"]["kind"],
+            serde_json::json!("Limit"),
+            "default kind must serialize as \"Limit\""
+        );
+        assert_eq!(
+            default_value["AddOrder"]["hidden_quantity"],
+            serde_json::Value::Null,
+            "default hidden_quantity must serialize as null"
         );
     }
 
@@ -3939,6 +4488,33 @@ mod tests {
     }
 
     #[test]
+    fn test_add_order_without_kind_decodes_as_limit() {
+        // A pre-#151 AddOrder command has no kind / hidden_quantity fields. It
+        // must decode to a plain limit add (kind Limit, hidden None) so old
+        // journals replay as they did before order-kind variety existed.
+        let no_kind = r#"{ "AddOrder": {
+            "symbol": "BTC-20240329-50000-C",
+            "order_id": "1",
+            "side": "BUY",
+            "price": 100,
+            "quantity": 10
+        } }"#;
+        let command: OptionChainCommand =
+            serde_json::from_str(no_kind).expect("kindless AddOrder wire must decode");
+        match command {
+            OptionChainCommand::AddOrder {
+                kind,
+                hidden_quantity,
+                ..
+            } => {
+                assert_eq!(kind, OrderKind::Limit);
+                assert_eq!(hidden_quantity, None);
+            }
+            other => panic!("expected AddOrder, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_order_added_carries_trade_when_add_fills() {
         // The fixture seeds a resting call sell@110 qty5; a marketable buy@110
         // crosses it and executes a fill, so OrderAdded carries the trade.
@@ -4082,6 +4658,157 @@ mod tests {
                 );
             }
             other => panic!("expected Rejected, got {other:?}"),
+        }
+    }
+
+    // ── Submit: order kinds (#151) ───────────────────────────────────────
+
+    #[test]
+    fn test_execute_add_order_iceberg_missing_hidden_rejected() {
+        // An iceberg add with no hidden reserve is a deterministic rejection,
+        // caught by the strict validation before any book resolution — so the
+        // hierarchy is not even vivified.
+        let book = SequencedUnderlyingOrderBook::new("BTC");
+        for hidden in [None, Some(0)] {
+            let receipt = book
+                .submit_add_order_kind(
+                    "BTC-20240329-50000-C",
+                    OrderId::sequential(1),
+                    Side::Buy,
+                    100,
+                    5,
+                    TimeInForce::Gtc,
+                    Hash32::zero(),
+                    OrderKind::Iceberg,
+                    hidden,
+                )
+                .expect("submit");
+            match &receipt.result {
+                OptionChainResult::Rejected { reason } => assert_eq!(
+                    reason, "iceberg add requires hidden_quantity >= 1",
+                    "unexpected reason for hidden={hidden:?}"
+                ),
+                other => panic!("expected Rejected for hidden={hidden:?}, got {other:?}"),
+            }
+        }
+        // Validation runs before resolution, so nothing was materialized.
+        assert_eq!(book.expiration_count(), 0);
+        assert_eq!(book.total_order_count(), 0);
+    }
+
+    #[test]
+    fn test_execute_add_order_hidden_on_limit_rejected() {
+        // A hidden reserve is only meaningful for an iceberg; supplying it on a
+        // limit or post-only add is a deterministic rejection, never a silent
+        // field drop.
+        let book = SequencedUnderlyingOrderBook::new("BTC");
+        for kind in [OrderKind::Limit, OrderKind::PostOnly] {
+            let receipt = book
+                .submit_add_order_kind(
+                    "BTC-20240329-50000-C",
+                    OrderId::sequential(1),
+                    Side::Buy,
+                    100,
+                    5,
+                    TimeInForce::Gtc,
+                    Hash32::zero(),
+                    kind,
+                    Some(10),
+                )
+                .expect("submit");
+            match &receipt.result {
+                OptionChainResult::Rejected { reason } => assert_eq!(
+                    reason, "hidden_quantity is only valid for iceberg adds",
+                    "unexpected reason for kind={kind:?}"
+                ),
+                other => panic!("expected Rejected for kind={kind:?}, got {other:?}"),
+            }
+        }
+        assert_eq!(book.total_order_count(), 0);
+    }
+
+    #[test]
+    fn test_execute_add_order_post_only_would_cross_rejected_deterministic() {
+        // A post-only add that would cross is rejected by the engine with a
+        // `PriceCrossing` error. Two identically-prepared books must produce the
+        // byte-identical rejection reason — the determinism the journal relies on.
+        fn run() -> OptionChainResult {
+            let book = SequencedUnderlyingOrderBook::new("BTC");
+            let symbol = "BTC-20240329-50000-C";
+            // Resting bid at 100; a post-only SELL at 100 would cross it.
+            book.submit_add_order(symbol, OrderId::sequential(1), Side::Buy, 100, 5)
+                .expect("seed bid");
+            book.submit_add_order_kind(
+                symbol,
+                OrderId::sequential(2),
+                Side::Sell,
+                100,
+                3,
+                TimeInForce::Gtc,
+                Hash32::zero(),
+                OrderKind::PostOnly,
+                None,
+            )
+            .expect("submit post-only")
+            .result
+        }
+
+        let (first, second) = (run(), run());
+        let first_reason = match &first {
+            OptionChainResult::Rejected { reason } => reason.clone(),
+            other => panic!("expected Rejected post-only cross, got {other:?}"),
+        };
+        let second_reason = match &second {
+            OptionChainResult::Rejected { reason } => reason.clone(),
+            other => panic!("expected Rejected post-only cross, got {other:?}"),
+        };
+        assert_eq!(
+            first_reason, second_reason,
+            "post-only would-cross rejection reason must be deterministic across runs"
+        );
+        assert!(
+            first_reason.contains("Price crossing"),
+            "reason should be a PriceCrossing error, got {first_reason:?}"
+        );
+    }
+
+    #[test]
+    fn test_submit_add_order_kind_journals_kind_and_hidden() {
+        // The order kind and hidden reserve are carried verbatim into the
+        // journaled command so replay reconstructs the exact order shape.
+        let journal: Arc<dyn OptionChainJournal> = Arc::new(InMemoryOptionChainJournal::new());
+        let book = SequencedUnderlyingOrderBook::with_journal("BTC", Arc::clone(&journal));
+
+        let receipt = book
+            .submit_add_order_kind(
+                "BTC-20240329-50000-C",
+                OrderId::sequential(1),
+                Side::Sell,
+                130,
+                5,
+                TimeInForce::Gtc,
+                Hash32::zero(),
+                OrderKind::Iceberg,
+                Some(20),
+            )
+            .expect("submit iceberg");
+        assert!(receipt.result.is_success(), "got {:?}", receipt.result);
+
+        let events = journal.read_from(0).expect("read journal");
+        assert_eq!(events.len(), 1);
+        match &events[0].command {
+            OptionChainCommand::AddOrder {
+                kind,
+                hidden_quantity,
+                quantity,
+                ..
+            } => {
+                assert_eq!(*kind, OrderKind::Iceberg);
+                assert_eq!(*hidden_quantity, Some(20));
+                // quantity is the visible tranche for an iceberg.
+                assert_eq!(*quantity, 5);
+            }
+            other => panic!("expected AddOrder, got {other:?}"),
         }
     }
 

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -4770,6 +4770,13 @@ mod tests {
             first_reason.contains("Price crossing"),
             "reason should be a PriceCrossing error, got {first_reason:?}"
         );
+        // Tie the fixture constant to live engine output: if upstream rewords
+        // the PriceCrossing message, this fails here rather than letting the
+        // v0.9.0 fixture silently diverge from reality.
+        assert_eq!(
+            first_reason, POST_ONLY_CROSS_REASON,
+            "POST_ONLY_CROSS_REASON must match the live engine rejection string"
+        );
     }
 
     #[test]

--- a/tests/fixtures/journal_event_v0.9.0.json
+++ b/tests/fixtures/journal_event_v0.9.0.json
@@ -1,0 +1,118 @@
+[
+  {
+    "sequence_num": 1,
+    "timestamp_ns": 1700000000000000100,
+    "command": {
+      "AddOrder": {
+        "symbol": "BTC-20240329-50000-C",
+        "order_id": "42",
+        "side": "BUY",
+        "price": 90,
+        "quantity": 6,
+        "tif": "GTC",
+        "user_id": "0000000000000000000000000000000000000000000000000000000000000000",
+        "kind": "PostOnly",
+        "hidden_quantity": null
+      }
+    },
+    "result": {
+      "OrderAdded": {
+        "order_id": "42",
+        "trade": null
+      }
+    }
+  },
+  {
+    "sequence_num": 2,
+    "timestamp_ns": 1700000000000000101,
+    "command": {
+      "AddOrder": {
+        "symbol": "BTC-20240329-50000-C",
+        "order_id": "43",
+        "side": "SELL",
+        "price": 100,
+        "quantity": 3,
+        "tif": "GTC",
+        "user_id": "0000000000000000000000000000000000000000000000000000000000000000",
+        "kind": "PostOnly",
+        "hidden_quantity": null
+      }
+    },
+    "result": {
+      "Rejected": {
+        "reason": "order-book engine error: Price crossing: SELL 100 would cross opposite at 100"
+      }
+    }
+  },
+  {
+    "sequence_num": 3,
+    "timestamp_ns": 1700000000000000102,
+    "command": {
+      "AddOrder": {
+        "symbol": "BTC-20240329-50000-C",
+        "order_id": "42",
+        "side": "SELL",
+        "price": 130,
+        "quantity": 5,
+        "tif": "GTC",
+        "user_id": "0707070707070707070707070707070707070707070707070707070707070707",
+        "kind": "Iceberg",
+        "hidden_quantity": 20
+      }
+    },
+    "result": {
+      "OrderAdded": {
+        "order_id": "42",
+        "trade": {
+          "symbol": "BTC-20240329-50000-C",
+          "match_result": {
+            "order_id": "42",
+            "trades": {
+              "trades": [
+                {
+                  "trade_id": "9001",
+                  "taker_order_id": "42",
+                  "maker_order_id": "43",
+                  "price": 100,
+                  "quantity": 4,
+                  "taker_side": "BUY",
+                  "timestamp": 1700000000000
+                }
+              ]
+            },
+            "remaining_quantity": 0,
+            "is_complete": true,
+            "filled_order_ids": [],
+            "outcome": "filled"
+          },
+          "total_maker_fees": 0,
+          "total_taker_fees": 0,
+          "engine_seq": 0,
+          "quote_notional": 400
+        }
+      }
+    }
+  },
+  {
+    "sequence_num": 4,
+    "timestamp_ns": 1700000000000000103,
+    "command": {
+      "AddOrder": {
+        "symbol": "BTC-20240329-50000-C",
+        "order_id": "44",
+        "side": "BUY",
+        "price": 95,
+        "quantity": 5,
+        "tif": "GTC",
+        "user_id": "0000000000000000000000000000000000000000000000000000000000000000",
+        "kind": "Iceberg",
+        "hidden_quantity": null
+      }
+    },
+    "result": {
+      "Rejected": {
+        "reason": "iceberg add requires hidden_quantity >= 1"
+      }
+    }
+  }
+]

--- a/tests/unit/sequencer_tests.rs
+++ b/tests/unit/sequencer_tests.rs
@@ -37,7 +37,7 @@ use option_chain_orderbook::SymbolParser;
 use option_chain_orderbook::orderbook::{
     InMemoryOptionChainJournal, InstrumentRegistry, InstrumentStatus, MassCancelScope,
     MassCancelType, OptionChainEvent, OptionChainJournal, OptionChainResult, OptionOrderBook,
-    SequencedUnderlyingOrderBook, SymbolIndex,
+    OrderKind, SequencedUnderlyingOrderBook, SymbolIndex,
 };
 use optionstratlib::OptionStyle;
 use orderbook_rs::{Clock, OrderId, Side, StubClock, TimeInForce};
@@ -199,9 +199,62 @@ fn drive_command_prefix(book: &SequencedUnderlyingOrderBook) -> usize {
     book.submit_replace_order(c50c, oid(999), 100, 1, Side::Buy)
         .expect("replace unknown id (rejected)");
 
+    // ── #151 order kinds on a fresh expiration D (again kept off A/B/C): a
+    //    post-only that rests, a post-only that would cross (rejected, state
+    //    untouched), and an iceberg (visible 5 / hidden 20) that a crossing taker
+    //    > visible drains through a refill from the hidden reserve. All
+    //    deterministic, so replay rebuilds the identical visible/hidden split. ──
+    let d70c = "BTC-20241227-70000-C";
+
+    // Post-only bid that rests (no ask to cross).
+    book.submit_add_order_kind(
+        d70c,
+        oid(30),
+        Side::Buy,
+        300,
+        4,
+        TimeInForce::Gtc,
+        Hash32::zero(),
+        OrderKind::PostOnly,
+        None,
+    )
+    .expect("add d70c post-only rest");
+    // Post-only ask at the bid price would cross → rejected, resting state
+    // untouched.
+    book.submit_add_order_kind(
+        d70c,
+        oid(31),
+        Side::Sell,
+        300,
+        2,
+        TimeInForce::Gtc,
+        Hash32::zero(),
+        OrderKind::PostOnly,
+        None,
+    )
+    .expect("add d70c post-only would-cross (rejected)");
+    // Iceberg ask: visible 5, hidden 20 (total 25) at 310.
+    book.submit_add_order_kind(
+        d70c,
+        oid(32),
+        Side::Sell,
+        310,
+        5,
+        TimeInForce::Gtc,
+        Hash32::zero(),
+        OrderKind::Iceberg,
+        Some(20),
+    )
+    .expect("add d70c iceberg");
+    // A crossing taker of 8 (> visible 5) drains the tranche and refills from the
+    // hidden reserve, leaving the iceberg resting at visible 2 / hidden 15.
+    book.submit_add_order(d70c, oid(33), Side::Buy, 310, 8)
+        .expect("add d70c iceberg-crossing taker");
+
     // 15 adds + 2 cancels + 1 halt + 1 rejected add + 2 mass cancels (expirations
-    // A/B) plus the 7 #148 commands on expiration C (5 adds + 2 replaces).
-    28
+    // A/B), 7 #148 commands on expiration C (5 adds + 2 replaces), and 4 #151
+    // order-kind commands on expiration D.
+    32
 }
 
 // ── Comparable full-state snapshot (the oracle) ────────────────────────────
@@ -446,9 +499,11 @@ fn test_replay_equals_live_full_state_oracle() {
     // Expirations A/B leave 10 resting orders (the halted a55c keeps its 3; the
     // rejected add rested nothing). The #148 expiration C adds one net resting
     // order (c45c's partially-filled sell; c50c is cleared by its replace
-    // rematch), for 11 total across three expirations.
-    assert_eq!(live.expiration_count(), 3);
-    assert_eq!(live.total_order_count(), 11);
+    // rematch). The #151 expiration D adds two (the post-only bid and the
+    // partially-drained iceberg; the would-cross post-only rested nothing), for
+    // 13 total across four expirations.
+    assert_eq!(live.expiration_count(), 4);
+    assert_eq!(live.total_order_count(), 13);
     let exp_a = live
         .underlying()
         .get_expiration(
@@ -475,6 +530,42 @@ fn test_replay_equals_live_full_state_oracle() {
     );
     assert_eq!(a55c.call().bid_level_count(), 2, "two resting bid levels");
     assert_eq!(a55c.call().best_bid(), Some(120));
+
+    // #151 explicit post-refill hidden-quantity spot-check: the d70c iceberg
+    // (visible 5 / hidden 20) drained by a crossing taker of 8 must rest at
+    // visible 2 / hidden 15 on the 310 ask level. The `level_ladder` oracle
+    // already captures visible+hidden per level, but assert it here directly so
+    // the iceberg refill split is an explicit, load-bearing part of the prefix.
+    let exp_d = live
+        .underlying()
+        .get_expiration(
+            SymbolParser::parse("BTC-20241227-70000-C")
+                .expect("parse d70c")
+                .expiration(),
+        )
+        .expect("exp D present");
+    let d70c = exp_d.get_strike(70000).expect("strike 70000 present");
+    assert_eq!(d70c.call().best_ask(), Some(310), "iceberg rests at 310");
+    assert_eq!(
+        d70c.call().total_ask_depth(),
+        17,
+        "iceberg total (visible + hidden) after draining 8 of 25"
+    );
+    let d70c_asks = d70c.call().snapshot(SNAPSHOT_DEPTH).asks;
+    let ask_310 = d70c_asks
+        .iter()
+        .find(|l| l.price().as_u128() == 310)
+        .expect("310 ask level present");
+    assert_eq!(
+        ask_310.visible_quantity().as_u64(),
+        2,
+        "iceberg visible tranche after the refill"
+    );
+    assert_eq!(
+        ask_310.hidden_quantity().as_u64(),
+        15,
+        "iceberg hidden reserve after the refill"
+    );
 
     let live_snapshot = snapshot(&live);
 
@@ -544,9 +635,9 @@ fn test_replay_registry_ids_match_live() {
             "instrument symbol diverged for id {live_id}"
         );
     }
-    // Ten leaf books: 5 strikes × (call + put) — A 50000/55000, B 60000, and the
-    // #148 expiration C 45000/50000.
-    assert_eq!(live_ids.len(), 10);
+    // Twelve leaf books: 6 strikes × (call + put) — A 50000/55000, B 60000, the
+    // #148 expiration C 45000/50000, and the #151 expiration D 70000.
+    assert_eq!(live_ids.len(), 12);
 }
 
 #[test]
@@ -594,8 +685,8 @@ fn test_replay_into_empty_book_then_resume_is_consistent() {
         .submit_add_order("BTC-20240329-50000-C", new_oid, Side::Buy, 101, 2)
         .expect("post-replay add");
     assert_eq!(journal.len(), submitted + 1);
-    // 11 rebuilt resting orders + 1 new.
-    assert_eq!(resumed.total_order_count(), 12);
+    // 13 rebuilt resting orders + 1 new.
+    assert_eq!(resumed.total_order_count(), 14);
 }
 
 // ── Concurrent submit: gate ordering + replay-under-load oracle ─────────────


### PR DESCRIPTION
## Stack

- **Stack: #152 → #151 → #153 (this PR is 2 of 3).**
- Base branch: `stack/1-152-price-banding` — **already merged as #154**, so the diff against `main` shows only this PR's commits.
- Stacked on: #154 (merged). Blocks: the upcoming #153 PR (`stack/3-153-trade-id-namespace`).

## Summary

Only plain limit orders could ride the sequenced path: the journaled `AddOrder` had no order-kind field and the leaf exposed only `add_limit_order*`, so a venue supporting post-only or iceberg had to bypass the journal. This PR adds order-kind variety end-to-end — journaled, deterministic, and replay-covered.

## Changes

- New `OrderKind` enum (`Limit` default, `PostOnly`, `Iceberg`; `non_exhaustive`, `repr(u8)`); `AddOrder` gains `#[serde(default)] kind` and `#[serde(default)] hidden_quantity` (iceberg reserve; `quantity` stays the visible tranche). Old JSON journals decode to `Limit`/`None` and replay identically.
- Kind mismatches are rejected deterministically and journaled — an iceberg without a reserve, or a reserve on a non-iceberg add — never silently dropped.
- New leaf methods build the `OrderType` manually (timestamp from the injected book clock — upstream's typed helpers discard the trade result) and route through the generic per-call-attribution primitive: `add_post_only_order_with_tif_and_user_full`, `add_iceberg_order_with_tif_and_user_full`, plus delegating conveniences. All run the active check and the #152 price-band check before the engine.
- A crossing post-only never trades: the engine rejects it with `PriceCrossing` before matching; the journaled rejection string is pinned to live engine output by test.
- New `submit_add_order_kind(...)` wrapper; `submit_add_order` / `submit_add_order_with` keep their 0.8.0 signatures and delegate (single command-construction site).

## Technical decisions

- Single `AddOrder` variant + defaulted fields, not per-kind command variants: identical backward wire compat (serde-default precedent from #148), better forward compat for limit-only journals, one dispatch point. Future kinds needing richer parameters can still be appended variants.
- Fixture discipline: frozen v0.5.0/v0.8.0 files untouched — their strict tests convert to the sanctioned patch-defaults pattern; a new **unfrozen** `journal_event_v0.9.0.json` pins the enriched schema (post-only rest, pinned would-cross rejection, iceberg fill with the deterministic trade payload, missing-hidden rejection) and #153 appends to it before the release freeze.
- Iceberg semantics documented loudly: `quantity` = visible tranche; upstream validates lot on visible and hidden independently and size bounds on the total; icebergs can cross and trade on entry.

## Public API impact

- New: `OrderKind` (re-exported at crate root), `SequencedUnderlyingOrderBook::submit_add_order_kind`, `OptionOrderBook::{add_post_only_order_with_tif_and_user[_full], add_iceberg_order_with_tif_and_user[_full]}`.
- `AddOrder` variant field additions are wire-compatible (JSON) but source-breaking for literal constructors / full-field patterns — same class as #148, wildcard matches unaffected. No version bump (release decided at stack end).
- `src/lib.rs` sequencer bullet updated; `README.md` regenerated via `make readme`. CHANGELOG `[Unreleased]` covers #152 + #151.

## Testing

- [x] Unit tests added or updated
- [x] Round-trip serde tests for new event / DTO shapes
- [x] Integration tests under `tests/unit/` added or updated (if applicable)
- [x] Replay determinism covered for sequencer changes (replayed state == live)
- [x] `make pre-push` run locally and clean

11 leaf tests (rest/would-cross/fills/refill/overflow/band/halt/delegation) + sequencer unit tests (strict kind validation, would-cross determinism ×2 runs tied to the pinned constant, journals kind+hidden) + wire suite (patch-defaults conversions, strict v0.9.0 fixture, deny-unknown probes, unknown-kind-tag rejection, missing-field → Limit pin) + replay prefix expiration D (post-only rest, would-cross reject, iceberg visible 5 / hidden 20 drained by a taker of 8 → refill to visible 2 / hidden 15, asserted at the exact level) under the full-state oracle. Totals: **916 lib + 38 integration + 110 doctests, 0 failures.** Internal reviews: determinism-auditor clean (0 findings), hotpath-reviewer clean, architect PASS — both optional advisories applied.

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] Checked arithmetic on protocol counters — no `saturating_*` / `wrapping_*`
- [x] No `unsafe` introduced
- [x] Layering respected (leaf knows nothing of the sequencer; `OrderKind` lives in the sequencer and is re-exported upward only)
- [x] Matching delegated to `orderbook-rs`; Greeks delegated to `optionstratlib`
- [x] No new dependencies added without explicit approval
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) updated if the public surface changed

Closes #151
