### PR TITLE
Deterministic trade-ID namespace and replace fills in OrderReplaced (#153)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,18 +36,45 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   an iceberg with a missing/zero hidden reserve, or a limit/post-only add with a
   hidden reserve, is a deterministic `Rejected`. A post-only add that would cross
   is journaled as a deterministic `PriceCrossing` rejection.
+- **Deterministic trade-ID namespace + replace fills (#153).** The upstream
+  namespace seam (orderbook-rs 0.11, upstream #199/#200) is now threaded end to
+  end: `SequencedUnderlyingOrderBook::set_trade_id_namespace(root)` propagates a
+  root namespace down the hierarchy, and each leaf derives its own
+  `UUIDv5(root, symbol)` at construction (call and put get distinct namespaces).
+  With a root namespace and an injected clock (`set_clock`) both set before the
+  first submit, two identically-seeded sequenced runs on fresh instances produce
+  identical trade payloads — trade ids, engine trade timestamps, and `engine_seq`
+  included (the sequencer's wall-clock event-envelope `timestamp_ns` is the one
+  exception). `uuid` is now a direct dependency and `Uuid` is re-exported from
+  the crate root. New leaf `OptionOrderBook::replace_order_full` recovers a
+  replacement's on-entry fills via a dedicated capture slot (taker-id filtered,
+  missing-never-wrong); `OptionChainResult::OrderReplaced` gained
+  `trade: Option<TradeResult>` (`#[serde(default)]`, always emitted), and
+  `execute_replace_order` now carries the replacement's fills.
+
+### Changed
+
+- **Breaking for co-pinners: `orderbook-rs` public dependency `0.10` → `0.11`.**
+  `orderbook-rs` is a public dependency, so this pin move is breaking for
+  downstream crates that co-pin it (same precedent as the 0.6.0 `0.9` → `0.10`
+  bump). The only breaking changes in orderbook-rs 0.11 are in
+  `ReplayBookConfig` / `ReplayError`, which this crate does not use, so the
+  hierarchy and sequencer surface is otherwise unchanged.
 
 ### Wire compatibility
 
-- The new `AddOrder` fields (`kind` / `hidden_quantity`) are backward-compatible
-  **for self-describing encodings (JSON)**: they carry `#[serde(default)]`, so a
-  pre-#151 JSON journal decodes to a plain limit add (`OrderKind::Limit`, no
-  hidden reserve) and replays identically (pinned by the frozen v0.5.0 and v0.8.0
-  fixture tests, which patch these defaults in). Positional codecs such as
-  bincode cannot apply a missing-field default, so pre-#151 *binary* journal
-  records must be re-journaled or migrated. An unknown `OrderKind` variant tag
-  written by a newer binary is rejected by an older one — the same additive
-  forward-compat asymmetry as the command/result enums.
+- The new `AddOrder` fields (`kind` / `hidden_quantity`) and the
+  `OrderReplaced.trade` field are backward-compatible **for self-describing
+  encodings (JSON)**: they carry `#[serde(default)]`, so a pre-#151/#153 JSON
+  journal decodes to a plain limit add (`OrderKind::Limit`, no hidden reserve)
+  and a trade-less `OrderReplaced` respectively, and replays identically (pinned
+  by the frozen v0.5.0 and v0.8.0 fixture tests, which patch these defaults in).
+  Positional codecs such as bincode cannot apply a missing-field default, so
+  pre-#151/#153 *binary* journal records must be re-journaled or migrated. An
+  unknown `OrderKind` variant tag written by a newer binary is rejected by an
+  older one — the same additive forward-compat asymmetry as the command/result
+  enums. A journal carrying `trade` on `OrderReplaced` is undecodable by a 0.8.0
+  binary that predates the field (documented asymmetry).
 
 ## [0.8.0] - 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,14 +47,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   included (the sequencer's wall-clock event-envelope `timestamp_ns` is the one
   exception). `uuid` is now a direct dependency and `Uuid` is re-exported from
   the crate root. New leaf `OptionOrderBook::replace_order_full` recovers a
-  replacement's on-entry fills via a dedicated capture slot (taker-id filtered,
-  missing-never-wrong); `OptionChainResult::OrderReplaced` gained
+  replacement's on-entry fills via a dedicated capture slot (taker-id filtered;
+  missing-never-wrong under the documented single-writer model — a concurrent
+  non-sequenced replace of the same order id sits outside that bound, see the
+  method docs); `OptionChainResult::OrderReplaced` gained
   `trade: Option<TradeResult>` (`#[serde(default)]`, always emitted), and
   `execute_replace_order` now carries the replacement's fills.
 
-### Changed
+### ⚠️ Breaking Changes
 
-- **Breaking for co-pinners: `orderbook-rs` public dependency `0.10` → `0.11`.**
+- **`orderbook-rs` public dependency `0.10` → `0.11` (breaking for co-pinners).**
   `orderbook-rs` is a public dependency, so this pin move is breaking for
   downstream crates that co-pin it (same precedent as the 0.6.0 `0.9` → `0.10`
   bump). The only breaking changes in orderbook-rs 0.11 are in

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ thiserror = { workspace = true }
 crossbeam-skiplist = { workspace = true }
 dashmap = "6.2"
 pricelevel = { workspace = true }
+uuid = { workspace = true }
 
 [features]
 default = []
@@ -69,7 +70,8 @@ crate-type = ["rlib"]
 
 [workspace.dependencies]
 optionstratlib = { version = "0.17", default-features = false }
-orderbook-rs = { version = "0.10", features = ["special_orders"] }
+orderbook-rs = { version = "0.11", features = ["special_orders"] }
+uuid = { version = "1.23", features = ["v5"] }
 async-nats = "0.49"
 bytes = "1.12"
 tokio = { version = "1.52", features = ["rt", "sync"] }

--- a/README.md
+++ b/README.md
@@ -173,11 +173,17 @@ matching engine itself is `orderbook-rs`. On top of that engine it provides:
 - **Mark price is a derived, non-journaled value.** It is computed from
   current inputs and is not part of the `sequencer` journal; replay
   reconstructs order-book state, not historical mark prices.
-- **Trade IDs are not replay-stable.** The upstream engine mints each
-  book's trade-ID namespace with a random `Uuid::new_v4()` and exposes no
-  injection seam, so trade IDs differ between a live run and its replay
-  even on identical command streams; the replay oracle compares book
-  state and excludes trade IDs (tracked upstream as OrderBook-rs#199).
+- **Deterministic trade IDs require an injected namespace + clock.** By
+  default each leaf's trade-ID namespace is a random `Uuid::new_v4()`, so
+  trade IDs and timestamps differ from run to run. Inject a root namespace
+  via the sequencer's `set_trade_id_namespace` (each leaf then derives
+  `UUIDv5(root, symbol)`) together with a deterministic clock via `set_clock`,
+  both before the first submit: two identically-seeded sequenced runs on
+  fresh instances then produce identical trade payloads (ids, engine trade
+  timestamps, `engine_seq`). Without them the old caveat applies. Either way
+  [`replay`](orderbook::SequencedUnderlyingOrderBook::replay) discards
+  journaled results, so the replay oracle compares book state and never diffs
+  trade payloads.
 - **Time-in-force replay determinism requires an injected clock.** `GTD` /
   `Day` admission is decided by each leaf's engine clock. Inject a
   deterministic clock (e.g. [`orderbook::StubClock`]) via the hierarchy's

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -358,7 +358,7 @@ pub use orderbook::{
     StrikeRangeConfigBuilder, StubClock, SubscriptionId, SymbolIndex, SymbolRef,
     TerminalOrderSummary, TimeInForce, TimestampMs, TradeResult, UnderlyingEvictExpiredResult,
     UnderlyingMassCancelResult, UnderlyingOrderBook, UnderlyingOrderBookManager, UnderlyingStats,
-    ValidationConfig, VolSurface, calculate_tte_years, wire_feed_to_calculator,
+    Uuid, ValidationConfig, VolSurface, calculate_tte_years, wire_feed_to_calculator,
 };
 
 #[cfg(feature = "nats")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,11 +159,17 @@
 //! - **Mark price is a derived, non-journaled value.** It is computed from
 //!   current inputs and is not part of the `sequencer` journal; replay
 //!   reconstructs order-book state, not historical mark prices.
-//! - **Trade IDs are not replay-stable.** The upstream engine mints each
-//!   book's trade-ID namespace with a random `Uuid::new_v4()` and exposes no
-//!   injection seam, so trade IDs differ between a live run and its replay
-//!   even on identical command streams; the replay oracle compares book
-//!   state and excludes trade IDs (tracked upstream as OrderBook-rs#199).
+//! - **Deterministic trade IDs require an injected namespace + clock.** By
+//!   default each leaf's trade-ID namespace is a random `Uuid::new_v4()`, so
+//!   trade IDs and timestamps differ from run to run. Inject a root namespace
+//!   via the sequencer's `set_trade_id_namespace` (each leaf then derives
+//!   `UUIDv5(root, symbol)`) together with a deterministic clock via `set_clock`,
+//!   both before the first submit: two identically-seeded sequenced runs on
+//!   fresh instances then produce identical trade payloads (ids, engine trade
+//!   timestamps, `engine_seq`). Without them the old caveat applies. Either way
+//!   [`replay`](orderbook::SequencedUnderlyingOrderBook::replay) discards
+//!   journaled results, so the replay oracle compares book state and never diffs
+//!   trade payloads.
 //! - **Time-in-force replay determinism requires an injected clock.** `GTD` /
 //!   `Day` admission is decided by each leaf's engine clock. Inject a
 //!   deterministic clock (e.g. [`orderbook::StubClock`]) via the hierarchy's

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -22,6 +22,7 @@ use std::hash::{Hash, Hasher};
 use std::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+use uuid::Uuid;
 
 /// Pre-built NATS publisher listeners to install on the inner order book
 /// *before* it is wrapped in `Arc`.
@@ -153,6 +154,15 @@ pub(crate) struct BookConfig {
     /// Inject a deterministic clock (e.g. `StubClock`) to make time-in-force
     /// admission (`GTD`/`Day`) reproducible for sequencer replay.
     pub clock: Option<Arc<dyn Clock>>,
+    /// Root trade-ID namespace from which the per-leaf namespace is derived.
+    ///
+    /// `None` keeps the upstream default (a random per-book namespace).
+    /// When set, [`new_with_config`](OptionOrderBook::new_with_config) derives
+    /// the leaf's own namespace as `UUIDv5(root, symbol_bytes)` before the inner
+    /// book is frozen in `Arc`, so call and put — with distinct symbols — receive
+    /// distinct namespaces. Combined with an injected deterministic clock this
+    /// makes trade IDs byte-identical across runs sharing the same root.
+    pub trade_id_root_namespace: Option<Uuid>,
     /// Pre-built NATS publisher listeners installed before the inner book is
     /// wrapped in `Arc` (feature `nats`). `None` for every non-NATS path.
     #[cfg(feature = "nats")]
@@ -167,7 +177,8 @@ impl std::fmt::Debug for BookConfig {
             .field("stp_mode", &self.stp_mode)
             .field("fee_schedule", &self.fee_schedule)
             .field("enable_state_tracking", &self.enable_state_tracking)
-            .field("clock", &self.clock);
+            .field("clock", &self.clock)
+            .field("trade_id_root_namespace", &self.trade_id_root_namespace);
         // The NATS listeners are boxed closures and carry no `Debug`; surface
         // only whether they are present so the impl stays informative.
         #[cfg(feature = "nats")]
@@ -185,6 +196,7 @@ impl Default for BookConfig {
             fee_schedule: None,
             enable_state_tracking: true,
             clock: None,
+            trade_id_root_namespace: None,
             #[cfg(feature = "nats")]
             nats_listeners: None,
         }
@@ -351,6 +363,23 @@ pub struct OptionOrderBook {
     /// `[min_price, max_price]` band checked in
     /// [`check_price_band`](Self::check_price_band).
     min_price: Option<u128>,
+    /// Dedicated single-slot capture used only by
+    /// [`replace_order_full`](Self::replace_order_full) to recover the fills a
+    /// crossing replacement produces (the engine's `update_order` returns the
+    /// resting order, not a `TradeResult`).
+    ///
+    /// Independent of [`last_trade_result`](Self::last_trade_result): a replace
+    /// clears, arms, runs, disarms, and takes this slot around the single
+    /// `update_order` call so continuous capture is never disturbed.
+    replace_capture: Arc<Mutex<Option<TradeResult>>>,
+    /// Cheap armed flag gating the [`replace_capture`](Self::replace_capture)
+    /// clone+lock on the match hot path.
+    ///
+    /// Disarmed by default: the shared trade listener performs one extra relaxed
+    /// atomic load per match and, when disarmed, returns without touching the
+    /// replace slot. Armed only for the duration of a single
+    /// [`replace_order_full`](Self::replace_order_full) call.
+    replace_capture_armed: Arc<AtomicBool>,
 }
 
 impl OptionOrderBook {
@@ -401,6 +430,19 @@ impl OptionOrderBook {
         if let Some(clock) = config.clock.clone() {
             book.set_clock(clock);
         }
+        // Derive this leaf's trade-ID namespace from the configured root, while
+        // the book is still owned mutably (pre-`Arc`). The derivation contract is
+        // `UUIDv5(root, leaf_symbol_bytes)`: because call and put carry distinct
+        // symbols, they receive distinct namespaces from the same root, and the
+        // same (root, symbol) pair always yields the same namespace across runs.
+        // Combined with a deterministic clock this makes the leaf's trade IDs
+        // byte-identical run-to-run. The upstream counter-restart caveat on
+        // `set_trade_id_namespace` is moot here: it is applied exactly once, at
+        // construction, before any order is submitted. `None` keeps the upstream
+        // default random namespace.
+        if let Some(root) = config.trade_id_root_namespace {
+            book.set_trade_id_namespace(Uuid::new_v5(&root, symbol.as_bytes()));
+        }
 
         // Install the continuous-capture listener backing the opt-in
         // `arm_trade_capture` / `last_trade_result` accessor. The clone+lock is
@@ -411,10 +453,24 @@ impl OptionOrderBook {
         // `add_*_with_result` return value.
         let capture: Arc<Mutex<Option<TradeResult>>> = Arc::new(Mutex::new(None));
         let armed: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
+        // Dedicated replace-capture slot, wired into the SAME listener so a
+        // crossing `replace_order_full` can recover its fills. Disarmed by
+        // default: the branch below is one relaxed load on the match path.
+        let replace_capture: Arc<Mutex<Option<TradeResult>>> = Arc::new(Mutex::new(None));
+        let replace_armed: Arc<AtomicBool> = Arc::new(AtomicBool::new(false));
         let capture_clone = Arc::clone(&capture);
         let armed_clone = Arc::clone(&armed);
+        let replace_capture_clone = Arc::clone(&replace_capture);
+        let replace_armed_clone = Arc::clone(&replace_armed);
         let capture_listener: TradeListener = Arc::new(move |tr: &TradeResult| {
-            // Record only while continuous capture is armed.
+            // Record into the replace slot only while a replace is in flight.
+            if replace_armed_clone.load(Ordering::Relaxed) {
+                let mut guard = replace_capture_clone
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner());
+                *guard = Some(tr.clone());
+            }
+            // Record into the continuous-capture slot only while it is armed.
             if !armed_clone.load(Ordering::Relaxed) {
                 return;
             }
@@ -478,6 +534,8 @@ impl OptionOrderBook {
             terminal_counters,
             max_price,
             min_price,
+            replace_capture,
+            replace_capture_armed: replace_armed,
         }
     }
 
@@ -1619,7 +1677,9 @@ impl OptionOrderBook {
     /// crosses the book, the replacement may rematch and fill immediately;
     /// those fills reach only the installed trade listener (and thus the NATS
     /// publisher / order-state tracker), **never this return value** — this call
-    /// reports placement, not fills.
+    /// reports placement, not fills. Use
+    /// [`replace_order_full`](Self::replace_order_full) to also recover the
+    /// crossing fills as a [`TradeResult`].
     ///
     /// # Arguments
     ///
@@ -1662,6 +1722,114 @@ impl OptionOrderBook {
         }) {
             Ok(Some(_)) => Ok(true),
             Ok(None) => Ok(false),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Atomically replaces a resting order and reports any fills the replacement
+    /// produced on entry.
+    ///
+    /// Identical placement semantics to [`replace_order`](Self::replace_order)
+    /// (validate-first: the original survives any rejection; queue priority is
+    /// lost). The difference is the return value: when the repriced order crosses
+    /// the book, the engine's `update_order` still returns only the resting
+    /// order — not a [`TradeResult`] — so this method recovers the fills from a
+    /// **dedicated single-slot capture** wired into the book's trade listener.
+    ///
+    /// The capture is cleared, then armed for exactly the one `update_order`
+    /// call, then disarmed on every exit path (a drop guard disarms even when an
+    /// engine error propagates, so the armed flag never leaks). The captured
+    /// trade is returned **only** when its taker order id equals `order_id` and
+    /// it carries fills; otherwise the trade component is `None`.
+    ///
+    /// # Attribution & contamination contract
+    ///
+    /// When called from the sequenced path, the capture runs inside the
+    /// sequencer's submit gate, so within the sequenced command stream there is
+    /// no concurrent writer and attribution is exact. A concurrent **non**-
+    /// sequenced direct add on the same book is the only contamination source,
+    /// and it is bounded to **missing-never-wrong**: such a trade is either
+    /// discarded by the taker-id filter (never mis-attributed to this replace),
+    /// or it overwrites this replace's own capture so the fills are reported as
+    /// `None` despite having reached the listener. The operating model is
+    /// therefore single-writer per book. The upstream `update_order_with_result`
+    /// primitive would remove the caveat entirely; it does not exist yet.
+    ///
+    /// # Returns
+    ///
+    /// - `Ok((true, Some(trade)))` — replaced, and the replacement's own fills;
+    /// - `Ok((true, None))` — replaced but rested without crossing (no fills);
+    /// - `Ok((false, None))` — no order with `order_id` was resting;
+    ///
+    /// # Errors
+    ///
+    /// - [`InstrumentNotActive`](crate::Error::InstrumentNotActive) if the instrument is not
+    ///   [`Active`](InstrumentStatus::Active).
+    /// - [`ValidationError`](crate::Error::ValidationError) if `price` falls outside
+    ///   the configured `[min_price, max_price]` band.
+    /// - [`OrderBookEngine`](crate::Error::OrderBookEngine) if the upstream engine rejects the
+    ///   replacement; the original order survives.
+    pub fn replace_order_full(
+        &self,
+        order_id: OrderId,
+        price: u128,
+        quantity: u64,
+        side: Side,
+    ) -> Result<(bool, Option<TradeResult>)> {
+        self.check_active()?;
+        self.check_price_band(price)?;
+
+        // Clear any stale capture before arming, so we only observe fills from
+        // this call.
+        {
+            let mut guard = self
+                .replace_capture
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            *guard = None;
+        }
+
+        // Arm for exactly this call. The drop guard disarms on EVERY exit path —
+        // including the `?`-propagated error below — so the armed flag can never
+        // leak past the call (the classic arm-leak bug).
+        struct DisarmGuard<'a>(&'a AtomicBool);
+        impl Drop for DisarmGuard<'_> {
+            #[inline]
+            fn drop(&mut self) {
+                self.0.store(false, Ordering::Relaxed);
+            }
+        }
+        self.replace_capture_armed.store(true, Ordering::Relaxed);
+        let _disarm = DisarmGuard(&self.replace_capture_armed);
+
+        let outcome = self.book.update_order(OrderUpdate::Replace {
+            order_id,
+            price: Price::new(price),
+            quantity: Quantity::new(quantity),
+            side,
+        });
+
+        // Take whatever the listener recorded during the call, regardless of the
+        // outcome (a rejection leaves the slot empty).
+        let captured = {
+            let mut guard = self
+                .replace_capture
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            guard.take()
+        };
+
+        match outcome {
+            Ok(Some(_)) => {
+                // Keep the trade only if it is THIS replacement's own fills:
+                // taker id matches and there were actual trades. This is the
+                // missing-never-wrong filter.
+                let trade = captured.filter(|tr| {
+                    tr.match_result.order_id() == order_id && !tr.match_result.trades().is_empty()
+                });
+                Ok((true, trade))
+            }
+            Ok(None) => Ok((false, None)),
             Err(e) => Err(e.into()),
         }
     }
@@ -4042,6 +4210,7 @@ mod tests {
                 fee_schedule: Some(schedule),
                 enable_state_tracking: true,
                 clock: None,
+                trade_id_root_namespace: None,
                 #[cfg(feature = "nats")]
                 nats_listeners: None,
             },
@@ -5204,5 +5373,195 @@ mod tests {
         assert!(res.is_ok(), "post-only convenience should rest: {res:?}");
         assert_eq!(book.best_bid(), Some(100));
         assert_eq!(book.order_count(), 1);
+    }
+
+    // ── replace_order_full (dedicated capture) + trade-ID namespace ─────
+
+    #[test]
+    fn test_replace_order_full_rematch_returns_own_fills() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 10)
+            .expect("rest sell");
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 90, 5)
+            .expect("rest buy");
+
+        let (replaced, trade) = book
+            .replace_order_full(id, 100, 5, Side::Buy)
+            .expect("replace");
+        assert!(replaced);
+        let trade = trade.expect("a crossing replace returns its own fills");
+        assert_eq!(trade.match_result.order_id(), id);
+        assert!(!trade.match_result.trades().is_empty());
+    }
+
+    #[test]
+    fn test_replace_order_full_no_cross_returns_none_trade() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 100, 10)
+            .expect("rest buy");
+
+        // Reprice up with no opposite liquidity: rests, no fills.
+        let (replaced, trade) = book
+            .replace_order_full(id, 105, 20, Side::Buy)
+            .expect("replace");
+        assert!(replaced);
+        assert!(trade.is_none(), "a non-crossing replace reports no fills");
+        assert_eq!(book.best_bid(), Some(105));
+    }
+
+    #[test]
+    fn test_replace_order_full_unknown_id_returns_false_none() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        let (replaced, trade) = book
+            .replace_order_full(OrderId::new(), 100, 10, Side::Buy)
+            .expect("replace");
+        assert!(!replaced);
+        assert!(trade.is_none());
+    }
+
+    #[test]
+    fn test_replace_order_full_engine_reject_preserves_original_and_disarms() {
+        let book = OptionOrderBook::new_with_config(
+            "BTC-20240329-50000-C",
+            OptionStyle::Call,
+            BookConfig {
+                validation: Some(ValidationConfig::new().with_tick_size(10)),
+                ..BookConfig::default()
+            },
+        );
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 100, 10)
+            .expect("add at valid tick");
+
+        // 105 is not a multiple of the tick: the engine rejects the replacement.
+        let res = book.replace_order_full(id, 105, 10, Side::Buy);
+        assert!(
+            matches!(res, Err(Error::OrderBookEngine(_))),
+            "a tick violation must be an engine rejection: {res:?}"
+        );
+        // The drop guard disarmed the capture even on the error path.
+        assert!(
+            !book.replace_capture_armed.load(Ordering::Relaxed),
+            "the replace-capture flag must be disarmed after an error"
+        );
+        // Validate-first: the original survives untouched.
+        assert_eq!(book.best_bid(), Some(100));
+        assert_eq!(book.order_count(), 1);
+    }
+
+    #[test]
+    fn test_replace_order_full_does_not_disturb_continuous_capture() {
+        let book = OptionOrderBook::new("BTC-20240329-50000-C", OptionStyle::Call);
+        book.add_limit_order(OrderId::new(), Side::Sell, 100, 10)
+            .expect("rest sell");
+        let id = OrderId::new();
+        book.add_limit_order(id, Side::Buy, 90, 5)
+            .expect("rest buy");
+
+        // Continuous capture is DISARMED (default). A crossing replace uses its
+        // own dedicated slot and must not leak into the continuous slot.
+        let (_, trade) = book
+            .replace_order_full(id, 100, 5, Side::Buy)
+            .expect("replace");
+        assert!(
+            trade.is_some(),
+            "the crossing replace captured its own fills"
+        );
+        assert!(
+            book.last_trade_result().is_none(),
+            "the replace capture must not populate the continuous-capture slot"
+        );
+
+        // Continuous capture still works normally afterward.
+        book.arm_trade_capture(true);
+        book.add_limit_order(OrderId::new(), Side::Sell, 95, 5)
+            .expect("rest sell");
+        book.add_limit_order(OrderId::new(), Side::Buy, 95, 5)
+            .expect("cross");
+        assert!(
+            book.take_trade_result().is_some(),
+            "continuous capture is unaffected by the replace path"
+        );
+    }
+
+    /// Builds a leaf with a fixed trade-ID root namespace and a fresh StubClock,
+    /// so its trade IDs and timestamps are deterministic run-to-run.
+    fn deterministic_leaf(symbol: &str, style: OptionStyle, root: Uuid) -> OptionOrderBook {
+        use orderbook_rs::StubClock;
+        OptionOrderBook::new_with_config(
+            symbol,
+            style,
+            BookConfig {
+                clock: Some(Arc::new(StubClock::new()) as Arc<dyn Clock>),
+                trade_id_root_namespace: Some(root),
+                ..BookConfig::default()
+            },
+        )
+    }
+
+    /// Drives a fixed crossing sequence and returns the serialized TradeResult.
+    fn crossing_trade_json(book: &OptionOrderBook) -> String {
+        book.add_limit_order(OrderId::from_u64(1), Side::Sell, 100, 10)
+            .expect("rest sell");
+        let trade = book
+            .add_limit_order_full(OrderId::from_u64(2), Side::Buy, 100, 5)
+            .expect("crossing buy");
+        serde_json::to_string(&trade).expect("serialize trade result")
+    }
+
+    /// Drives a fixed crossing sequence and returns the first fill's trade ID.
+    fn crossing_first_trade_id(book: &OptionOrderBook) -> pricelevel::Id {
+        book.add_limit_order(OrderId::from_u64(1), Side::Sell, 100, 10)
+            .expect("rest sell");
+        let trade = book
+            .add_limit_order_full(OrderId::from_u64(2), Side::Buy, 100, 5)
+            .expect("crossing buy");
+        trade
+            .match_result
+            .trades()
+            .as_vec()
+            .first()
+            .expect("at least one fill")
+            .trade_id()
+    }
+
+    #[test]
+    fn test_book_config_namespace_derives_per_leaf_v5() {
+        let root = Uuid::from_u128(0x00C0_FFEE);
+        // Two independently-built, identically-configured leaves (same root, a
+        // fresh StubClock each) driven through the same crossing sequence must
+        // produce byte-identical serialized TradeResults — including trade IDs.
+        let first = crossing_trade_json(&deterministic_leaf(
+            "BTC-20240329-50000-C",
+            OptionStyle::Call,
+            root,
+        ));
+        let second = crossing_trade_json(&deterministic_leaf(
+            "BTC-20240329-50000-C",
+            OptionStyle::Call,
+            root,
+        ));
+        assert_eq!(
+            first, second,
+            "same root + clock + order ids must yield byte-identical trade results"
+        );
+    }
+
+    #[test]
+    fn test_leaf_namespaces_differ_between_call_and_put() {
+        let root = Uuid::from_u128(0x00C0_FFEE);
+        // Call and put carry distinct symbols, so `UUIDv5(root, symbol)` gives
+        // them distinct namespaces and therefore distinct trade IDs — compared
+        // directly (the serialized results also differ by symbol, which would not
+        // by itself prove the IDs diverge).
+        let call = deterministic_leaf("BTC-20240329-50000-C", OptionStyle::Call, root);
+        let put = deterministic_leaf("BTC-20240329-50000-P", OptionStyle::Put, root);
+        assert_ne!(
+            crossing_first_trade_id(&call),
+            crossing_first_trade_id(&put),
+            "call and put must derive distinct trade-ID namespaces from distinct symbols"
+        );
     }
 }

--- a/src/orderbook/book.rs
+++ b/src/orderbook/book.rs
@@ -1747,13 +1747,20 @@ impl OptionOrderBook {
     /// When called from the sequenced path, the capture runs inside the
     /// sequencer's submit gate, so within the sequenced command stream there is
     /// no concurrent writer and attribution is exact. A concurrent **non**-
-    /// sequenced direct add on the same book is the only contamination source,
-    /// and it is bounded to **missing-never-wrong**: such a trade is either
-    /// discarded by the taker-id filter (never mis-attributed to this replace),
-    /// or it overwrites this replace's own capture so the fills are reported as
-    /// `None` despite having reached the listener. The operating model is
-    /// therefore single-writer per book. The upstream `update_order_with_result`
-    /// primitive would remove the caveat entirely; it does not exist yet.
+    /// sequenced direct **add** on the same book is bounded to
+    /// **missing-never-wrong**: such a trade is either discarded by the
+    /// taker-id filter (its taker id differs from the replaced order's), or it
+    /// overwrites this replace's own capture so the fills are reported as
+    /// `None` despite having reached the listener. One case sits OUTSIDE that
+    /// bound: a concurrent non-sequenced **replace of the same `order_id`**
+    /// produces fills carrying the identical taker id, which the filter cannot
+    /// distinguish — such a race can mis-attribute the other call's fills to
+    /// this one. The operating model is therefore strictly single-writer per
+    /// book; do not mix sequenced and direct replaces of the same order. Book
+    /// state and the returned `bool` are never affected either way — only the
+    /// captured `TradeResult` audit payload. The upstream
+    /// `update_order_with_result` primitive would remove the caveat entirely;
+    /// it does not exist yet.
     ///
     /// # Returns
     ///

--- a/src/orderbook/chain.rs
+++ b/src/orderbook/chain.rs
@@ -19,6 +19,7 @@ use orderbook_rs::{Clock, FeeSchedule, OrderId, OrderStatus, STPMode, Side};
 use pricelevel::{Hash32, TimestampMs};
 use std::sync::Arc;
 use std::time::Duration;
+use uuid::Uuid;
 
 #[cfg(feature = "nats")]
 use super::book::ContractNatsListenerFactory;
@@ -278,6 +279,34 @@ impl OptionChainOrderBook {
     #[inline]
     pub fn clock(&self) -> Option<Arc<dyn Clock>> {
         self.strikes.clock()
+    }
+
+    /// Sets the root trade-ID namespace for all future option books created
+    /// within this chain.
+    ///
+    /// Delegates to [`StrikeOrderBookManager::set_trade_id_namespace`].
+    /// Existing books are not affected.
+    #[inline]
+    pub fn set_trade_id_namespace(&self, namespace: Uuid) {
+        self.strikes.set_trade_id_namespace(namespace);
+    }
+
+    /// Clears the root trade-ID namespace, so future option books use the
+    /// upstream default random namespace.
+    ///
+    /// Delegates to [`StrikeOrderBookManager::clear_trade_id_namespace`].
+    /// Existing books are not affected.
+    #[inline]
+    pub fn clear_trade_id_namespace(&self) {
+        self.strikes.clear_trade_id_namespace();
+    }
+
+    /// Returns the current root trade-ID namespace, or `None` when future books
+    /// use the upstream default random namespace.
+    #[must_use]
+    #[inline]
+    pub fn trade_id_namespace(&self) -> Option<Uuid> {
+        self.strikes.trade_id_namespace()
     }
 
     /// Propagates the per-contract NATS listener factory down to the strike
@@ -945,6 +974,10 @@ pub struct OptionChainOrderBookManager {
     /// upstream default `MonotonicClock`; a shared `Arc<dyn Clock>` makes
     /// time-in-force admission deterministic for replay.
     clock: Shared<Option<Arc<dyn Clock>>>,
+    /// Root trade-ID namespace propagated to newly created chains. `None` keeps
+    /// the upstream default random namespace; a set root makes trade IDs
+    /// reproducible across runs sharing the root.
+    trade_id_root_namespace: Shared<Option<Uuid>>,
 }
 
 impl OptionChainOrderBookManager {
@@ -965,6 +998,7 @@ impl OptionChainOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
         }
     }
 
@@ -993,6 +1027,7 @@ impl OptionChainOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
         }
     }
 
@@ -1030,6 +1065,7 @@ impl OptionChainOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
         }
     }
 
@@ -1135,6 +1171,35 @@ impl OptionChainOrderBookManager {
         self.clock.get()
     }
 
+    /// Sets the root trade-ID namespace for all future chains created by this
+    /// manager.
+    ///
+    /// Existing chains are not affected. Only newly created chains via
+    /// [`get_or_create`](Self::get_or_create) will have this root propagated down
+    /// to their strike manager, where each leaf derives `UUIDv5(root, symbol)`.
+    #[inline]
+    pub fn set_trade_id_namespace(&self, namespace: Uuid) {
+        self.trade_id_root_namespace.set(Some(namespace));
+    }
+
+    /// Clears the root trade-ID namespace so future chains use the upstream
+    /// default random namespace.
+    ///
+    /// Existing chains are not affected. Only newly created chains via
+    /// [`get_or_create`](Self::get_or_create) will be affected.
+    #[inline]
+    pub fn clear_trade_id_namespace(&self) {
+        self.trade_id_root_namespace.set(None);
+    }
+
+    /// Returns the current root trade-ID namespace, or `None` when future chains
+    /// use the upstream default random namespace.
+    #[must_use]
+    #[inline]
+    pub fn trade_id_namespace(&self) -> Option<Uuid> {
+        self.trade_id_root_namespace.get()
+    }
+
     /// Returns the underlying asset symbol.
     #[must_use]
     pub fn underlying(&self) -> &str {
@@ -1206,6 +1271,9 @@ impl OptionChainOrderBookManager {
         }
         if let Some(clock) = self.clock.get() {
             fresh.set_clock(clock);
+        }
+        if let Some(ns) = self.trade_id_root_namespace.get() {
+            fresh.set_trade_id_namespace(ns);
         }
         // Atomic, idempotent publish: first inserter wins and is never evicted.
         let entry = self.chains.get_or_insert(key, fresh);
@@ -2140,5 +2208,18 @@ mod tests {
 
         // The externally held index is never touched by a manager built via `new`.
         assert!(symbol_index.is_empty());
+    }
+
+    #[test]
+    fn test_chain_set_trade_id_namespace_delegates() {
+        let chain = OptionChainOrderBook::new("BTC", test_expiration());
+        assert!(chain.trade_id_namespace().is_none());
+
+        let root = Uuid::from_u128(0x0BAD_C0DE);
+        chain.set_trade_id_namespace(root);
+        assert_eq!(chain.trade_id_namespace(), Some(root));
+
+        chain.clear_trade_id_namespace();
+        assert!(chain.trade_id_namespace().is_none());
     }
 }

--- a/src/orderbook/expiration.rs
+++ b/src/orderbook/expiration.rs
@@ -19,6 +19,7 @@ use orderbook_rs::{Clock, FeeSchedule, OrderId, OrderStatus, STPMode, Side};
 use pricelevel::{Hash32, TimestampMs};
 use std::sync::Arc;
 use std::time::Duration;
+use uuid::Uuid;
 
 use super::book::TerminalOrderSummary;
 #[cfg(feature = "nats")]
@@ -262,6 +263,34 @@ impl ExpirationOrderBook {
     #[inline]
     pub fn clock(&self) -> Option<Arc<dyn Clock>> {
         self.chain.clock()
+    }
+
+    /// Sets the root trade-ID namespace for all future option books created
+    /// within this expiration.
+    ///
+    /// Delegates to [`OptionChainOrderBook::set_trade_id_namespace`](super::chain::OptionChainOrderBook::set_trade_id_namespace).
+    /// Existing books are not affected.
+    #[inline]
+    pub fn set_trade_id_namespace(&self, namespace: Uuid) {
+        self.chain.set_trade_id_namespace(namespace);
+    }
+
+    /// Clears the root trade-ID namespace, so future option books use the
+    /// upstream default random namespace.
+    ///
+    /// Delegates to [`OptionChainOrderBook::clear_trade_id_namespace`](super::chain::OptionChainOrderBook::clear_trade_id_namespace).
+    /// Existing books are not affected.
+    #[inline]
+    pub fn clear_trade_id_namespace(&self) {
+        self.chain.clear_trade_id_namespace();
+    }
+
+    /// Returns the current root trade-ID namespace, or `None` when future books
+    /// use the upstream default random namespace.
+    #[must_use]
+    #[inline]
+    pub fn trade_id_namespace(&self) -> Option<Uuid> {
+        self.chain.trade_id_namespace()
     }
 
     /// Propagates the per-contract NATS listener factory down to this
@@ -657,6 +686,10 @@ pub struct ExpirationOrderBookManager {
     /// the upstream default `MonotonicClock`; a shared `Arc<dyn Clock>` makes
     /// time-in-force admission deterministic for replay.
     clock: Shared<Option<Arc<dyn Clock>>>,
+    /// Root trade-ID namespace propagated to newly created expiration books.
+    /// `None` keeps the upstream default random namespace; a set root makes
+    /// trade IDs reproducible across runs sharing the root.
+    trade_id_root_namespace: Shared<Option<Uuid>>,
     /// Per-contract NATS listener factory propagated to newly created
     /// expiration books (and onward to their strikes). `None` (the default)
     /// reproduces the non-NATS path exactly.
@@ -682,6 +715,7 @@ impl ExpirationOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -712,6 +746,7 @@ impl ExpirationOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -740,6 +775,7 @@ impl ExpirationOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -845,6 +881,35 @@ impl ExpirationOrderBookManager {
     #[inline]
     pub fn clock(&self) -> Option<Arc<dyn Clock>> {
         self.clock.get()
+    }
+
+    /// Sets the root trade-ID namespace for all future expiration books created
+    /// by this manager.
+    ///
+    /// Existing books are not affected. Only newly created books via
+    /// [`get_or_create`](Self::get_or_create) will have this root propagated down
+    /// to their chains and strikes, where each leaf derives `UUIDv5(root, symbol)`.
+    #[inline]
+    pub fn set_trade_id_namespace(&self, namespace: Uuid) {
+        self.trade_id_root_namespace.set(Some(namespace));
+    }
+
+    /// Clears the root trade-ID namespace so future expiration books use the
+    /// upstream default random namespace.
+    ///
+    /// Existing books are not affected. Only newly created books via
+    /// [`get_or_create`](Self::get_or_create) will be affected.
+    #[inline]
+    pub fn clear_trade_id_namespace(&self) {
+        self.trade_id_root_namespace.set(None);
+    }
+
+    /// Returns the current root trade-ID namespace, or `None` when future books
+    /// use the upstream default random namespace.
+    #[must_use]
+    #[inline]
+    pub fn trade_id_namespace(&self) -> Option<Uuid> {
+        self.trade_id_root_namespace.get()
     }
 
     /// Stores the per-contract NATS listener factory propagated from the top of
@@ -961,6 +1026,9 @@ impl ExpirationOrderBookManager {
         }
         if let Some(clock) = self.clock.get() {
             fresh.set_clock(clock);
+        }
+        if let Some(ns) = self.trade_id_root_namespace.get() {
+            fresh.set_trade_id_namespace(ns);
         }
         // Propagate the per-contract NATS factory down to the fresh chain/strike
         // manager BEFORE publishing, so the configured-before-visible invariant
@@ -1945,5 +2013,18 @@ mod tests {
         thread::sleep(Duration::from_millis(10));
         let purged = book.purge_terminal_states(Duration::from_millis(1));
         assert_eq!(purged, 2);
+    }
+
+    #[test]
+    fn test_expiration_set_trade_id_namespace_delegates() {
+        let expiration = ExpirationOrderBook::new("BTC", test_expiration());
+        assert!(expiration.trade_id_namespace().is_none());
+
+        let root = Uuid::from_u128(0x0BAD_C0DE);
+        expiration.set_trade_id_namespace(root);
+        assert_eq!(expiration.trade_id_namespace(), Some(root));
+
+        expiration.clear_trade_id_namespace();
+        assert!(expiration.trade_id_namespace().is_none());
     }
 }

--- a/src/orderbook/mod.rs
+++ b/src/orderbook/mod.rs
@@ -154,3 +154,6 @@ pub use orderbook_rs::{
     OrderStatus, OrderType, STPMode, Side, StubClock, TimeInForce, TradeResult,
 };
 pub use pricelevel::{Hash32, Price, Quantity, TimestampMs};
+// Re-export `Uuid` so downstream consumers can set trade-ID namespaces without
+// taking their own direct `uuid` dependency (boundary-type policy).
+pub use uuid::Uuid;

--- a/src/orderbook/sequencer.rs
+++ b/src/orderbook/sequencer.rs
@@ -33,18 +33,41 @@
 //! deadlock against the journal. `execute_command` must never acquire the gate,
 //! since it runs while the gate is already held.
 //!
-//! # Known limitation — trade-ID determinism
+//! # Deterministic trade IDs
 //!
-//! The upstream `orderbook_rs::OrderBook` mints its trade/transaction-ID
-//! namespace internally with a random `Uuid::new_v4()` at construction, and
-//! offers no injection seam. Trade IDs therefore differ between a live run and
-//! its replay even when the command stream, the injected
-//! [`Clock`](orderbook_rs::Clock), and the matching are identical. The replay
-//! oracle intentionally compares order-book *state* (resting orders,
-//! top-of-book, instrument status) and excludes trade IDs. Tracked upstream as
-//! [OrderBook-rs#199](https://github.com/joaquinbejar/OrderBook-rs/issues/199);
-//! once a namespace seam ships, the hierarchy will thread a deterministic
-//! namespace alongside the clock.
+//! By default the upstream `orderbook_rs::OrderBook` mints each book's
+//! trade/transaction-ID namespace with a random `Uuid::new_v4()` at
+//! construction, so trade IDs differ between two runs even on an identical
+//! command stream. Since orderbook-rs 0.11 (upstream #199/#200) the namespace is
+//! injectable, and this crate threads it end to end: a single **root** namespace
+//! set via
+//! [`set_trade_id_namespace`](SequencedUnderlyingOrderBook::set_trade_id_namespace)
+//! propagates down the hierarchy, and each leaf derives its own
+//! `UUIDv5(root, symbol)` at construction (so a strike's call and put get
+//! distinct namespaces from their distinct symbols). Set the root — and an
+//! injected [`Clock`](orderbook_rs::Clock) via
+//! [`set_clock`](SequencedUnderlyingOrderBook::set_clock) — BEFORE the first
+//! [`submit`](SequencedUnderlyingOrderBook::submit).
+//!
+//! With both injected, **two independent `SequencedUnderlyingOrderBook`
+//! instances built on fresh hierarchies and driven through the identical
+//! sequenced command stream produce identical command + result payloads** —
+//! trade ids, engine trade timestamps, and `engine_seq` included. This run-to-
+//! run identity is scoped to sequenced-only traffic on fresh instances (a
+//! non-sequenced direct add on the same book is outside it). The one field that
+//! still differs run to run is each event's `timestamp_ns` envelope (see
+//! [`OptionChainEvent`]), which the sequencer stamps from the wall clock at
+//! ingestion (orthogonal to trade-ID determinism); the engine trade timestamps
+//! *inside* the results come from the injected clock and are stable.
+//!
+//! Note the guarantee is about two identical *live* runs, not about live-vs-
+//! replay payload equality: [`replay`](SequencedUnderlyingOrderBook::replay)
+//! deliberately discards the journaled results and keeps the freshly produced
+//! state, so the replay==live oracle compares order-book *state* (resting
+//! orders, top-of-book, instrument status) and does not diff `trade` payloads.
+//! When the clock and namespace are NOT injected, trade IDs and timestamps carry
+//! each leaf's per-instance random namespace and wall clock and are not
+//! run-to-run stable.
 //!
 //! # Feature Gate
 //!
@@ -68,6 +91,7 @@ use pricelevel::{Hash32, TimestampMs};
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard};
+use uuid::Uuid;
 
 /// Scope for mass cancel operations in the option chain hierarchy.
 ///
@@ -337,15 +361,16 @@ pub enum OptionChainCommand {
     /// live execution and replay both use the same non-creating resolver, so a
     /// replace against a book that was never created is rejected identically on
     /// both. The replacement carries validate-first atomic semantics from the
-    /// leaf [`replace_order`](crate::orderbook::OptionOrderBook::replace_order):
+    /// leaf
+    /// [`replace_order_full`](crate::orderbook::OptionOrderBook::replace_order_full):
     /// if the replacement's shape, risk, or self-cross check fails, the original
     /// order survives untouched.
     ///
-    /// Replace fills are NOT carried in the v1 result. If the new price crosses
-    /// the book the replacement can rematch and fill immediately; those fills
-    /// reach only the trade listener (and the NATS publisher), not the journaled
-    /// [`OptionChainResult::OrderReplaced`] — a follow-up will surface them once
-    /// OrderBook-rs#199 ships replay-stable ids.
+    /// If the new price crosses the book the replacement can rematch and fill
+    /// immediately; those fills are carried in the journaled
+    /// [`OptionChainResult::OrderReplaced::trade`] (as well as reaching the trade
+    /// listener / NATS publisher). See that field for the run-to-run trade-ID
+    /// stability caveat.
     ///
     /// Wire-compatible addition: appended after every prior variant, so existing
     /// journals replay unchanged and their bincode variant indices are
@@ -398,18 +423,23 @@ pub enum OptionChainResult {
         /// (JSON); positional codecs such as bincode cannot decode pre-#148
         /// binary records against the new shape.
         ///
-        /// # Replay caveat
+        /// # Trade-ID stability
         ///
         /// The payload's [`TradeResult::engine_seq`], the individual trade ids,
-        /// and the trade timestamps are NOT replay-stable: a replay into a fresh
-        /// book mints a fresh engine-seq / trade-id namespace (pending
-        /// OrderBook-rs#199). Replay discards journaled results by design (it
-        /// re-executes commands and keeps the freshly produced state), so the
-        /// replay==live *state* oracle is unaffected — but a consumer must not
-        /// diff `trade` payloads across a live run and a replay run and expect
-        /// them to match. There is deliberately no `skip_serializing_if` here:
-        /// the field is always emitted (as `null` when `None`) so the JSON and
-        /// bincode encodings stay symmetric across decode/encode round-trips.
+        /// and the trade timestamps are run-to-run stable **only when** the book
+        /// was configured with an injected clock and trade-ID namespace before the
+        /// first submit (see
+        /// [`set_trade_id_namespace`](SequencedUnderlyingOrderBook::set_trade_id_namespace)):
+        /// two identical sequenced runs on fresh instances then produce identical
+        /// trade payloads. Without those, each leaf uses its per-instance random
+        /// namespace and wall clock, so the payloads differ from run to run.
+        /// Either way, [`replay`](SequencedUnderlyingOrderBook::replay) discards
+        /// journaled results and keeps the freshly produced state, so the
+        /// replay==live *state* oracle is unaffected — a consumer must not diff
+        /// `trade` payloads across a live run and its replay. There is
+        /// deliberately no `skip_serializing_if` here: the field is always emitted
+        /// (as `null` when `None`) so the JSON and bincode encodings stay
+        /// symmetric across decode/encode round-trips.
         #[serde(default)]
         trade: Option<TradeResult>,
     },
@@ -457,13 +487,31 @@ pub enum OptionChainResult {
     },
     /// A resting order was atomically replaced.
     ///
-    /// The successful outcome of an [`OptionChainCommand::ReplaceOrder`]. The
-    /// replacement's fills, if the new price crossed the book, are NOT carried
-    /// here in v1 — they reach only the trade listener / NATS publisher (see the
-    /// command's doc). This variant reports placement, not fills.
+    /// The successful outcome of an [`OptionChainCommand::ReplaceOrder`].
     OrderReplaced {
         /// The identifier of the replaced order.
         order_id: OrderId,
+        /// The fills the replacement produced on entry, if any.
+        ///
+        /// `Some` iff the repriced order crossed the book and executed at least
+        /// one trade; `None` when it rested without crossing — which is also what
+        /// any pre-#153 journal (whose `OrderReplaced` had no `trade` field)
+        /// decodes to via `#[serde(default)]`.
+        ///
+        /// # Replay caveat
+        ///
+        /// Like [`OrderAdded::trade`](Self::OrderAdded), this payload's trade ids,
+        /// timestamps, and `engine_seq` are run-to-run stable only when the book
+        /// was configured with an injected clock and trade-ID namespace before the
+        /// first submit (see
+        /// [`set_trade_id_namespace`](SequencedUnderlyingOrderBook::set_trade_id_namespace));
+        /// without those they carry the leaf's per-instance namespace and clock.
+        /// Replay discards journaled results by design, so the replay==live *state*
+        /// oracle is unaffected either way. There is deliberately no
+        /// `skip_serializing_if`: the field is always emitted (as `null` when
+        /// `None`) so the JSON and bincode encodings stay symmetric.
+        #[serde(default)]
+        trade: Option<TradeResult>,
     },
 }
 
@@ -1024,6 +1072,40 @@ impl SequencedUnderlyingOrderBook {
         self.inner.set_clock(clock);
     }
 
+    /// Sets the root trade-ID namespace for leaves this book vivifies from later
+    /// commands.
+    ///
+    /// Delegates to [`UnderlyingOrderBook::set_trade_id_namespace`], so the root
+    /// is propagated to expirations, chains, and strikes created *after* this
+    /// call; each leaf derives its own `UUIDv5(root, symbol)` at construction
+    /// (call and put get distinct namespaces from their distinct symbols). Set it
+    /// BEFORE the first [`submit`](Self::submit): leaves vivified by earlier
+    /// commands keep whatever namespace they were built with (the upstream
+    /// default random `Uuid::new_v4()` when none was injected).
+    ///
+    /// # Deterministic trade IDs across runs
+    ///
+    /// With an injected clock ([`set_clock`](Self::set_clock)) AND a root
+    /// namespace both set before the first submit, two independent
+    /// `SequencedUnderlyingOrderBook` instances built on fresh hierarchies and
+    /// driven through the identical sequenced command stream produce
+    /// byte-identical trade-ID streams — trade ids, engine timestamps, and
+    /// `engine_seq` included. The namespace fixes the trade-ID root and the clock
+    /// fixes the timestamps; together they remove the two sources of run-to-run
+    /// divergence. This guarantee is scoped to sequenced-only traffic on fresh
+    /// instances; a non-sequenced direct add on the same book is outside it.
+    ///
+    /// This call takes the same serialization gate as
+    /// [`submit`](Self::submit), so the namespace change is linearized against
+    /// the sequenced command stream exactly as [`set_clock`](Self::set_clock) is.
+    #[inline]
+    pub fn set_trade_id_namespace(&self, namespace: Uuid) {
+        // Linearize the config change against submit/replay so a racing
+        // command deterministically sees either the old or the new namespace.
+        let _serialized = self.sequencer.acquire_gate();
+        self.inner.set_trade_id_namespace(namespace);
+    }
+
     /// Returns the current sequence number.
     #[must_use]
     #[inline]
@@ -1375,12 +1457,15 @@ impl SequencedUnderlyingOrderBook {
     /// replace against a book that does not exist is rejected. Replace semantics
     /// are validate-first and atomic — a rejected replacement leaves the original
     /// order untouched (see the leaf
-    /// [`replace_order`](crate::orderbook::OptionOrderBook::replace_order)).
+    /// [`replace_order_full`](crate::orderbook::OptionOrderBook::replace_order_full)).
     ///
     /// The receipt is [`OptionChainResult::OrderReplaced`] on success,
     /// [`OptionChainResult::BookNotFound`] when the symbol names no existing
     /// book, or [`OptionChainResult::Rejected`] when the order is not resting,
-    /// the symbol crosses underlyings, or the engine rejects the replacement.
+    /// the symbol crosses underlyings, or the engine rejects the replacement. On
+    /// success, [`OrderReplaced::trade`](OptionChainResult::OrderReplaced) carries
+    /// the replacement's own fills when the repriced order crossed the book (see
+    /// that field for the trade-ID stability caveat).
     ///
     /// # Arguments
     ///
@@ -1700,11 +1785,14 @@ impl SequencedUnderlyingOrderBook {
             }
         };
 
-        match book.replace_order(order_id, price, quantity, side) {
-            Ok(true) => OptionChainResult::OrderReplaced { order_id },
+        match book.replace_order_full(order_id, price, quantity, side) {
+            // Carry the replacement's own fills: `Some(trade)` when it rematched
+            // on entry, `None` when it rested without crossing. The leaf already
+            // filters the capture to this replacement's taker id.
+            Ok((true, trade)) => OptionChainResult::OrderReplaced { order_id, trade },
             // The book exists but no order with that id is resting: a
             // deterministic rejection (not a book-not-found).
-            Ok(false) => OptionChainResult::Rejected {
+            Ok((false, _)) => OptionChainResult::Rejected {
                 reason: format!("order not found: {order_id}"),
             },
             Err(e) => OptionChainResult::Rejected {
@@ -2165,14 +2253,17 @@ impl SequencedUnderlyingOrderBook {
     /// [`submit_replace_order`](Self::submit_replace_order)) replays through the
     /// SAME non-creating resolution and the same engine validate-first replace
     /// path (the leaf
-    /// [`replace_order`](crate::orderbook::OptionOrderBook::replace_order)) as
-    /// live, so a replace that re-priced an order to a crossing level and
+    /// [`replace_order_full`](crate::orderbook::OptionOrderBook::replace_order_full))
+    /// as live, so a replace that re-priced an order to a crossing level and
     /// rematched live rematches identically on replay, rebuilding the same
     /// resting book. Journaled `trade` payloads carried in
-    /// [`OptionChainResult::OrderAdded`] results are ignored by replay: replay
+    /// [`OptionChainResult::OrderAdded`] and
+    /// [`OptionChainResult::OrderReplaced`] results are ignored by replay: replay
     /// re-executes commands and keeps the freshly produced results, so the
-    /// non-replay-stable trade ids / engine-seqs in the journal never influence
-    /// the rebuilt state.
+    /// journaled trade ids / engine-seqs never influence the rebuilt state. (When
+    /// the clock and trade-ID namespace are injected, those payloads are stable
+    /// across identical live runs — see the fields' docs — but replay does not
+    /// depend on that.)
     ///
     /// Returns the number of events replayed.
     ///
@@ -3314,7 +3405,8 @@ mod tests {
                     trade: Some(deterministic_trade_result()),
                 },
             },
-            // ReplaceOrder + OrderReplaced (#148).
+            // ReplaceOrder + OrderReplaced that rested without crossing (#148;
+            // trade None on the #153 field).
             OptionChainEvent {
                 sequence_num: 10,
                 timestamp_ns: 1_700_000_000_000_000_009,
@@ -3325,7 +3417,10 @@ mod tests {
                     quantity: 7,
                     side: Side::Buy,
                 },
-                result: OptionChainResult::OrderReplaced { order_id: oid },
+                result: OptionChainResult::OrderReplaced {
+                    order_id: oid,
+                    trade: None,
+                },
             },
             // PostOnly AddOrder that rested (#151): non-default kind, trade None.
             OptionChainEvent {
@@ -3364,6 +3459,23 @@ mod tests {
                     hidden_quantity: Some(20),
                 },
                 result: OptionChainResult::OrderAdded {
+                    order_id: oid,
+                    trade: Some(deterministic_trade_result()),
+                },
+            },
+            // ReplaceOrder whose repriced order rematched on entry (#153): the
+            // OrderReplaced result carries the replacement's own fills.
+            OptionChainEvent {
+                sequence_num: 13,
+                timestamp_ns: 1_700_000_000_000_000_012,
+                command: OptionChainCommand::ReplaceOrder {
+                    symbol: "BTC-20240329-50000-C".to_string(),
+                    order_id: oid,
+                    price: 130,
+                    quantity: 4,
+                    side: Side::Buy,
+                },
+                result: OptionChainResult::OrderReplaced {
                     order_id: oid,
                     trade: Some(deterministic_trade_result()),
                 },
@@ -3495,6 +3607,23 @@ mod tests {
                     reason: "iceberg add requires hidden_quantity >= 1".to_string(),
                 },
             },
+            // Replace whose repriced order rematched on entry (#153): the
+            // OrderReplaced result carries the replacement's own fills.
+            OptionChainEvent {
+                sequence_num: 5,
+                timestamp_ns: 1_700_000_000_000_000_104,
+                command: OptionChainCommand::ReplaceOrder {
+                    symbol: "BTC-20240329-50000-C".to_string(),
+                    order_id: OrderId::sequential(42),
+                    price: 130,
+                    quantity: 4,
+                    side: Side::Buy,
+                },
+                result: OptionChainResult::OrderReplaced {
+                    order_id: OrderId::sequential(42),
+                    trade: Some(deterministic_trade_result()),
+                },
+            },
         ]
     }
 
@@ -3600,7 +3729,7 @@ mod tests {
 
         let decoded: Vec<OptionChainEvent> =
             serde_json::from_str(FIXTURE).expect("v0.9.0 journal fixture must decode");
-        assert_eq!(decoded.len(), 4, "fixture should hold four events");
+        assert_eq!(decoded.len(), 5, "fixture should hold five events");
 
         // Spot-check the #151 shapes.
         assert!(matches!(
@@ -3643,6 +3772,15 @@ mod tests {
                 hidden_quantity: None,
                 ..
             }
+        ));
+        // #153: a replace whose repriced order rematched carries its fills.
+        assert!(matches!(
+            decoded[4].command,
+            OptionChainCommand::ReplaceOrder { price: 130, .. }
+        ));
+        assert!(matches!(
+            decoded[4].result,
+            OptionChainResult::OrderReplaced { trade: Some(_), .. }
         ));
 
         // Strict re-encode: the current schema is fully materialized in the
@@ -3740,11 +3878,10 @@ mod tests {
         ));
 
         // Patch-defaults re-encode: the frozen v0.8.0 fixture predates the #151
-        // `kind` / `hidden_quantity` fields, which the current schema always
-        // emits. Inject those defaults into the two AddOrder command objects
-        // (events 0 and 8) before comparing byte-for-byte — same sanctioned
-        // pattern the v0.5.0 test uses for the #148 fields. The frozen file is
-        // untouched.
+        // `kind` / `hidden_quantity` fields on `AddOrder` and the #153 `trade`
+        // field on `OrderReplaced`, which the current schema always emits. Inject
+        // those defaults before comparing byte-for-byte — same sanctioned pattern
+        // the v0.5.0 test uses. The frozen file is untouched.
         let reencoded: serde_json::Value =
             serde_json::to_value(&decoded).expect("re-encode decoded events");
         let mut on_disk: serde_json::Value =
@@ -3756,10 +3893,16 @@ mod tests {
             add_cmd.insert("kind".to_string(), serde_json::json!("Limit"));
             add_cmd.insert("hidden_quantity".to_string(), serde_json::Value::Null);
         }
+        // Event 9 is the ReplaceOrder + OrderReplaced; inject the #153 trade
+        // default.
+        let replaced = on_disk[9]["result"]["OrderReplaced"]
+            .as_object_mut()
+            .expect("fixture event 9 result must be OrderReplaced");
+        replaced.insert("trade".to_string(), serde_json::Value::Null);
         assert_eq!(
             reencoded, on_disk,
             "re-encoded journal diverged from the checked-in v0.8.0 wire format \
-             (beyond the known #151 additive fields)"
+             (beyond the known #151/#153 additive fields)"
         );
     }
 
@@ -3892,11 +4035,13 @@ mod tests {
         );
 
         // Extra field inside the #148 OrderReplaced result struct-variant.
+        // Unknown field alongside the #153 `trade` field on OrderReplaced must be
+        // rejected (proving `trade` did not weaken deny_unknown_fields).
         let in_replaced_result = r#"{
             "sequence_num": 1,
             "timestamp_ns": 2,
             "command": { "CancelOrder": { "symbol": "BTC-20240329-50000-C", "order_id": "42" } },
-            "result": { "OrderReplaced": { "order_id": "42", "extra": 1 } }
+            "result": { "OrderReplaced": { "order_id": "42", "trade": null, "extra": 1 } }
         }"#;
         assert!(
             serde_json::from_str::<OptionChainEvent>(in_replaced_result).is_err(),
@@ -4146,10 +4291,11 @@ mod tests {
         assert_eq!(value, expected, "OrderAdded-with-trade wire format drifted");
     }
 
-    /// Pins the #148 `ReplaceOrder` / `OrderReplaced` wire format and proves the
-    /// old-binary-reads-new-journal asymmetry: a binary that predates the
-    /// variant rejects the new tag (unknown variant), independent of
-    /// `deny_unknown_fields`.
+    /// Pins the `ReplaceOrder` / `OrderReplaced` wire format — including the
+    /// #153 `trade` field on `OrderReplaced` (`null` when the replacement rested,
+    /// always emitted) — and proves the old-binary-reads-new-journal asymmetry: a
+    /// binary that predates the variant rejects the new tag (unknown variant),
+    /// independent of `deny_unknown_fields`.
     #[test]
     fn test_replace_order_wire_format_pinned() {
         let event = OptionChainEvent {
@@ -4164,6 +4310,7 @@ mod tests {
             },
             result: OptionChainResult::OrderReplaced {
                 order_id: OrderId::sequential(42),
+                trade: None,
             },
         };
         let value = serde_json::to_value(&event).expect("serialize");
@@ -4177,7 +4324,7 @@ mod tests {
                 "quantity": 7,
                 "side": "BUY"
             } },
-            "result": { "OrderReplaced": { "order_id": "42" } }
+            "result": { "OrderReplaced": { "order_id": "42", "trade": null } }
         });
         assert_eq!(value, expected, "ReplaceOrder wire format drifted");
 
@@ -4515,6 +4662,19 @@ mod tests {
     }
 
     #[test]
+    fn test_order_replaced_without_trade_decodes_as_none() {
+        // A pre-#153 OrderReplaced result has no trade field. It must decode to
+        // `trade: None` so old journals decode and replay unchanged.
+        let no_trade = r#"{ "OrderReplaced": { "order_id": "1" } }"#;
+        let result: OptionChainResult =
+            serde_json::from_str(no_trade).expect("tradeless OrderReplaced must decode");
+        match result {
+            OptionChainResult::OrderReplaced { trade, .. } => assert!(trade.is_none()),
+            other => panic!("expected OrderReplaced, got {other:?}"),
+        }
+    }
+
+    #[test]
     fn test_order_added_carries_trade_when_add_fills() {
         // The fixture seeds a resting call sell@110 qty5; a marketable buy@110
         // crosses it and executes a fill, so OrderAdded carries the trade.
@@ -4564,8 +4724,48 @@ mod tests {
             .submit_replace_order(symbol, oid, 105, 7, Side::Buy)
             .expect("submit replace");
         match &receipt.result {
-            OptionChainResult::OrderReplaced { order_id } => assert_eq!(*order_id, oid),
+            OptionChainResult::OrderReplaced { order_id, .. } => assert_eq!(*order_id, oid),
             other => panic!("expected OrderReplaced, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_sequenced_replace_with_fills_carries_trade_in_receipt() {
+        // A replace that re-prices a resting buy up to a crossing ask rematches on
+        // entry; the receipt's OrderReplaced carries the replacement's own fills,
+        // attributed to the replaced order id (the taker of the rematch).
+        let book = SequencedUnderlyingOrderBook::new("BTC");
+        let symbol = "BTC-20240329-50000-C";
+        let maker = OrderId::sequential(1);
+        let taker = OrderId::sequential(2);
+        book.submit_add_order(symbol, maker, Side::Sell, 100, 5)
+            .expect("seed resting ask");
+        book.submit_add_order(symbol, taker, Side::Buy, 90, 5)
+            .expect("seed resting buy below the ask");
+
+        // Re-price the buy up to the ask so it crosses and rematches.
+        let receipt = book
+            .submit_replace_order(symbol, taker, 100, 5, Side::Buy)
+            .expect("submit replace");
+        match &receipt.result {
+            OptionChainResult::OrderReplaced { order_id, trade } => {
+                assert_eq!(*order_id, taker);
+                let trade = trade
+                    .as_ref()
+                    .expect("a crossing replacement must carry its fills");
+                assert!(
+                    !trade.match_result.trades().is_empty(),
+                    "trade payload must record at least one fill"
+                );
+                // The fills are attributed to the replacement (the taker of the
+                // rematch), proving the leaf's taker-id filter kept the right trade.
+                assert_eq!(
+                    trade.match_result.order_id(),
+                    taker,
+                    "the captured trade's taker id must be the replaced order id"
+                );
+            }
+            other => panic!("expected OrderReplaced with fills, got {other:?}"),
         }
     }
 

--- a/src/orderbook/strike.rs
+++ b/src/orderbook/strike.rs
@@ -21,6 +21,7 @@ use orderbook_rs::{Clock, FeeSchedule, MassCancelResult, OrderId, OrderStatus, S
 use pricelevel::{Hash32, TimestampMs};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+use uuid::Uuid;
 
 use super::book::TerminalOrderSummary;
 
@@ -927,6 +928,11 @@ pub struct StrikeOrderBookManager {
     /// upstream default `MonotonicClock`; a shared `Arc<dyn Clock>` (e.g.
     /// `StubClock`) makes time-in-force admission deterministic for replay.
     clock: Shared<Option<Arc<dyn Clock>>>,
+    /// Root trade-ID namespace applied to newly created option books. `None`
+    /// keeps the upstream default (a random per-book namespace); a set root has
+    /// each future leaf derive `UUIDv5(root, symbol)` at construction, making
+    /// trade IDs reproducible across runs that share the root and clock.
+    trade_id_root_namespace: Shared<Option<Uuid>>,
     /// Per-contract NATS listener factory propagated from the top of the
     /// hierarchy. When present, each lazily created call/put book installs its
     /// own publishers pre-`Arc` in the [`get_or_create`](Self::get_or_create)
@@ -955,6 +961,7 @@ impl StrikeOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -987,6 +994,7 @@ impl StrikeOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -1018,6 +1026,7 @@ impl StrikeOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -1193,6 +1202,38 @@ impl StrikeOrderBookManager {
         self.clock.get()
     }
 
+    /// Sets the root trade-ID namespace for all future option books created by
+    /// this manager.
+    ///
+    /// Applies to option books created *after* this call via
+    /// [`get_or_create`](Self::get_or_create); existing books are unaffected
+    /// (same semantics as the engine clock). Each future leaf derives its own
+    /// namespace `UUIDv5(root, symbol)` at construction, so call and put receive
+    /// distinct namespaces and — together with a deterministic clock — produce
+    /// byte-identical trade IDs across runs sharing this root.
+    #[inline]
+    pub fn set_trade_id_namespace(&self, namespace: Uuid) {
+        self.trade_id_root_namespace.set(Some(namespace));
+    }
+
+    /// Clears the root trade-ID namespace so future option books use the upstream
+    /// default (a random per-book namespace).
+    ///
+    /// Existing books are not affected. Only newly created books via
+    /// [`get_or_create`](Self::get_or_create) will be affected.
+    #[inline]
+    pub fn clear_trade_id_namespace(&self) {
+        self.trade_id_root_namespace.set(None);
+    }
+
+    /// Returns the current root trade-ID namespace, or `None` when future books
+    /// use the upstream default random namespace.
+    #[must_use]
+    #[inline]
+    pub fn trade_id_namespace(&self) -> Option<Uuid> {
+        self.trade_id_root_namespace.get()
+    }
+
     /// Stores the per-contract NATS listener factory propagated from the top of
     /// the hierarchy.
     ///
@@ -1342,6 +1383,7 @@ impl StrikeOrderBookManager {
             stp_mode: self.stp_mode.get(),
             fee_schedule: self.fee_schedule.get(),
             clock: self.clock.get(),
+            trade_id_root_namespace: self.trade_id_root_namespace.get(),
             ..BookConfig::default()
         };
 
@@ -1470,6 +1512,7 @@ impl StrikeOrderBookManager {
             stp_mode: self.stp_mode.get(),
             fee_schedule: self.fee_schedule.get(),
             clock: self.clock.get(),
+            trade_id_root_namespace: self.trade_id_root_namespace.get(),
             nats_listeners: listeners,
             ..BookConfig::default()
         }
@@ -2936,5 +2979,56 @@ mod tests {
             .call()
             .add_limit_order(OrderId::new(), Side::Buy, 500, 10)
             .expect("within-band add on the NATS path");
+    }
+
+    #[test]
+    fn test_strike_manager_set_trade_id_namespace_applies_only_to_future_books() {
+        fn first_trade_id(book: &OptionOrderBook) -> pricelevel::Id {
+            book.add_limit_order(OrderId::from_u64(1), Side::Sell, 100, 10)
+                .expect("rest sell");
+            let trade = book
+                .add_limit_order_full(OrderId::from_u64(2), Side::Buy, 100, 5)
+                .expect("crossing buy");
+            trade
+                .match_result
+                .trades()
+                .as_vec()
+                .first()
+                .expect("one fill")
+                .trade_id()
+        }
+        fn reference_leaf(symbol: &str, root: Uuid) -> OptionOrderBook {
+            OptionOrderBook::new_with_config(
+                symbol,
+                OptionStyle::Call,
+                BookConfig {
+                    trade_id_root_namespace: Some(root),
+                    ..BookConfig::default()
+                },
+            )
+        }
+
+        let root = Uuid::from_u128(0x0BAD_C0DE);
+        let manager = StrikeOrderBookManager::new("BTC", test_expiration());
+        let before = manager.get_or_create(50000);
+        manager.set_trade_id_namespace(root);
+        let after = manager.get_or_create(51000);
+
+        // A book created AFTER the set derives its namespace from the root, so it
+        // matches an independently-derived reference leaf with the same symbol.
+        let after_symbol = after.call().symbol().to_string();
+        assert_eq!(
+            first_trade_id(after.call()),
+            first_trade_id(&reference_leaf(&after_symbol, root)),
+            "a book created after set_trade_id_namespace uses the derived namespace"
+        );
+        // A book created BEFORE the set kept the default random namespace, so it
+        // does NOT match its own root-derived reference.
+        let before_symbol = before.call().symbol().to_string();
+        assert_ne!(
+            first_trade_id(before.call()),
+            first_trade_id(&reference_leaf(&before_symbol, root)),
+            "a book created before set_trade_id_namespace keeps the default namespace"
+        );
     }
 }

--- a/src/orderbook/underlying.rs
+++ b/src/orderbook/underlying.rs
@@ -24,6 +24,7 @@ use pricelevel::{Hash32, TimestampMs};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
+use uuid::Uuid;
 
 use super::book::TerminalOrderSummary;
 #[cfg(feature = "nats")]
@@ -486,6 +487,35 @@ impl UnderlyingOrderBook {
     #[inline]
     pub fn clock(&self) -> Option<Arc<dyn Clock>> {
         self.expirations.clock()
+    }
+
+    /// Sets the root trade-ID namespace for future expirations created within
+    /// this underlying.
+    ///
+    /// Delegates to [`ExpirationOrderBookManager::set_trade_id_namespace`]. Only
+    /// expirations created after this call inherit the root; existing
+    /// expirations and their strikes are not affected.
+    #[inline]
+    pub fn set_trade_id_namespace(&self, namespace: Uuid) {
+        self.expirations.set_trade_id_namespace(namespace);
+    }
+
+    /// Clears the root trade-ID namespace, so future option books use the
+    /// upstream default random namespace.
+    ///
+    /// Delegates to [`ExpirationOrderBookManager::clear_trade_id_namespace`].
+    /// Existing books are not affected.
+    #[inline]
+    pub fn clear_trade_id_namespace(&self) {
+        self.expirations.clear_trade_id_namespace();
+    }
+
+    /// Returns the current root trade-ID namespace, or `None` when future books
+    /// use the upstream default random namespace.
+    #[must_use]
+    #[inline]
+    pub fn trade_id_namespace(&self) -> Option<Uuid> {
+        self.expirations.trade_id_namespace()
     }
 
     /// Propagates the per-contract NATS listener factory down to this
@@ -1141,6 +1171,10 @@ pub struct UnderlyingOrderBookManager {
     /// the upstream default `MonotonicClock`; a shared `Arc<dyn Clock>` makes
     /// time-in-force admission deterministic for replay.
     clock: Shared<Option<Arc<dyn Clock>>>,
+    /// Root trade-ID namespace propagated to newly created underlying books.
+    /// `None` keeps the upstream default random namespace; a set root makes
+    /// trade IDs reproducible across runs sharing the root.
+    trade_id_root_namespace: Shared<Option<Uuid>>,
     /// Per-contract NATS listener factory propagated to every underlying book
     /// (and onward to its expirations and strikes). Configured via
     /// [`with_nats_factory`](UnderlyingOrderBookManager::with_nats_factory);
@@ -1170,6 +1204,7 @@ impl UnderlyingOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -1193,6 +1228,7 @@ impl UnderlyingOrderBookManager {
             stp_mode: Shared::new(STPMode::None),
             fee_schedule: Shared::new(None),
             clock: Shared::new(None),
+            trade_id_root_namespace: Shared::new(None),
             #[cfg(feature = "nats")]
             nats_factory: SharedNatsFactory::new(),
         }
@@ -1270,6 +1306,9 @@ impl UnderlyingOrderBookManager {
         }
         if let Some(clock) = self.clock.get() {
             fresh.set_clock(clock);
+        }
+        if let Some(ns) = self.trade_id_root_namespace.get() {
+            fresh.set_trade_id_namespace(ns);
         }
         // Propagate the per-contract NATS factory down the fresh subtree BEFORE
         // publishing so it is configured-before-visible. Only when a factory is
@@ -1353,6 +1392,37 @@ impl UnderlyingOrderBookManager {
     #[inline]
     pub fn clock(&self) -> Option<Arc<dyn Clock>> {
         self.clock.get()
+    }
+
+    /// Sets the root trade-ID namespace for all future underlying books created
+    /// by this manager.
+    ///
+    /// Existing books are not affected. Only newly created books via
+    /// [`get_or_create`](Self::get_or_create) will have this root propagated down
+    /// to their expirations, chains, and strikes, where each leaf derives
+    /// `UUIDv5(root, symbol)` at construction. Set it before the first order for
+    /// deterministic trade IDs across runs sharing the root.
+    #[inline]
+    pub fn set_trade_id_namespace(&self, namespace: Uuid) {
+        self.trade_id_root_namespace.set(Some(namespace));
+    }
+
+    /// Clears the root trade-ID namespace so future underlying books use the
+    /// upstream default random namespace.
+    ///
+    /// Existing books are not affected. Only newly created books via
+    /// [`get_or_create`](Self::get_or_create) will be affected.
+    #[inline]
+    pub fn clear_trade_id_namespace(&self) {
+        self.trade_id_root_namespace.set(None);
+    }
+
+    /// Returns the current root trade-ID namespace, or `None` when future books
+    /// use the upstream default random namespace.
+    #[must_use]
+    #[inline]
+    pub fn trade_id_namespace(&self) -> Option<Uuid> {
+        self.trade_id_root_namespace.get()
     }
 
     /// Returns a reference to the symbol index.
@@ -3978,5 +4048,39 @@ mod tests {
         let config = leaf.call().validation_config().expect("config present");
         assert_eq!(config.min_price(), Some(100));
         assert_eq!(config.max_price(), Some(1_000));
+    }
+
+    #[test]
+    fn test_underlying_manager_set_trade_id_namespace_propagates_to_vivified_leaf() {
+        // Drives a fixed crossing sequence on a leaf vivified under a root and
+        // returns the first fill's trade ID.
+        fn run(root: Uuid) -> pricelevel::Id {
+            let manager = UnderlyingOrderBookManager::new();
+            manager.set_trade_id_namespace(root);
+            let leaf = manager
+                .get_or_create("BTC")
+                .get_or_create_expiration(test_expiration())
+                .get_or_create_strike(50000);
+            leaf.call()
+                .add_limit_order(OrderId::from_u64(1), Side::Sell, 100, 10)
+                .expect("rest sell");
+            let trade = leaf
+                .call()
+                .add_limit_order_full(OrderId::from_u64(2), Side::Buy, 100, 5)
+                .expect("crossing buy");
+            trade
+                .match_result
+                .trades()
+                .as_vec()
+                .first()
+                .expect("one fill")
+                .trade_id()
+        }
+
+        let root = Uuid::from_u128(0x0BAD_C0DE);
+        // The root propagates deterministically: same root → same leaf trade ID.
+        assert_eq!(run(root), run(root));
+        // The root genuinely reaches the leaf: a different root changes the ID.
+        assert_ne!(run(root), run(Uuid::from_u128(0xFEED_FACE)));
     }
 }

--- a/tests/fixtures/journal_event_v0.9.0.json
+++ b/tests/fixtures/journal_event_v0.9.0.json
@@ -114,5 +114,50 @@
         "reason": "iceberg add requires hidden_quantity >= 1"
       }
     }
+  },
+  {
+    "sequence_num": 5,
+    "timestamp_ns": 1700000000000000104,
+    "command": {
+      "ReplaceOrder": {
+        "symbol": "BTC-20240329-50000-C",
+        "order_id": "42",
+        "price": 130,
+        "quantity": 4,
+        "side": "BUY"
+      }
+    },
+    "result": {
+      "OrderReplaced": {
+        "order_id": "42",
+        "trade": {
+          "symbol": "BTC-20240329-50000-C",
+          "match_result": {
+            "order_id": "42",
+            "trades": {
+              "trades": [
+                {
+                  "trade_id": "9001",
+                  "taker_order_id": "42",
+                  "maker_order_id": "43",
+                  "price": 100,
+                  "quantity": 4,
+                  "taker_side": "BUY",
+                  "timestamp": 1700000000000
+                }
+              ]
+            },
+            "remaining_quantity": 0,
+            "is_complete": true,
+            "filled_order_ids": [],
+            "outcome": "filled"
+          },
+          "total_maker_fees": 0,
+          "total_taker_fees": 0,
+          "engine_seq": 0,
+          "quote_notional": 400
+        }
+      }
+    }
   }
 ]

--- a/tests/unit/sequencer_tests.rs
+++ b/tests/unit/sequencer_tests.rs
@@ -34,6 +34,7 @@
 //! asserted byte-for-byte equal to each other and to live.
 
 use option_chain_orderbook::SymbolParser;
+use option_chain_orderbook::orderbook::Uuid;
 use option_chain_orderbook::orderbook::{
     InMemoryOptionChainJournal, InstrumentRegistry, InstrumentStatus, MassCancelScope,
     MassCancelType, OptionChainEvent, OptionChainJournal, OptionChainResult, OptionOrderBook,
@@ -1073,5 +1074,115 @@ fn test_replay_rejected_after_fills_ioc_remainder_equals_live() {
         live_snapshot,
         snapshot(&replay),
         "replayed error-after-fills state must equal live"
+    );
+}
+
+// ── #153 deterministic trade-ID namespace ──────────────────────────────────
+
+/// A fixed root namespace for the determinism tests (any stable UUID works).
+fn trade_id_root() -> Uuid {
+    Uuid::from_u128(0x0153_0153_0153_0153_0153_0153_0153_0153)
+}
+
+/// Drives a small prefix that exercises every trade-ID-bearing result shape: a
+/// crossing add that fills (`OrderAdded.trade` Some) and a replace that reprices
+/// a resting order up to a crossing level so it rematches (`OrderReplaced.trade`
+/// Some).
+fn drive_trade_id_prefix(book: &SequencedUnderlyingOrderBook) {
+    let symbol = "BTC-20240329-50000-C";
+    // Crossing add that fills: rest an ask, then a marketable buy at the ask.
+    book.submit_add_order(symbol, oid(1), Side::Sell, 100, 5)
+        .expect("rest ask");
+    book.submit_add_order(symbol, oid(2), Side::Buy, 100, 5)
+        .expect("crossing buy fills");
+    // Rematching replace: rest an ask and a buy below it, then reprice the buy up.
+    book.submit_add_order(symbol, oid(3), Side::Sell, 120, 4)
+        .expect("rest ask 2");
+    book.submit_add_order(symbol, oid(4), Side::Buy, 110, 4)
+        .expect("rest buy below ask 2");
+    book.submit_replace_order(symbol, oid(4), 120, 4, Side::Buy)
+        .expect("replace reprices up and rematches");
+}
+
+#[test]
+fn test_sequenced_identical_runs_produce_identical_trade_ids() {
+    // HEADLINE: two fully independent sequenced instances, each configured BEFORE
+    // the first submit with a fresh `StubClock` and the SAME root trade-ID
+    // namespace, driven through the identical command stream, produce identical
+    // command + result payloads — trade ids, engine trade timestamps, and
+    // engine_seq included. The namespace fixes the trade-ID root (each leaf
+    // derives UUIDv5(root, symbol)) and the stub clock fixes the engine
+    // timestamps.
+    //
+    // The ONLY field excluded from the comparison is each event's envelope
+    // `timestamp_ns`: the sequencer stamps that from `nanos_since_epoch()` (wall
+    // clock) at ingestion — it is orthogonal to trade-ID determinism and is not
+    // driven by the injected engine clock. It is normalized to 0 below so the
+    // assertion targets exactly the payloads #153 makes deterministic.
+    fn run(root: Uuid) -> Vec<serde_json::Value> {
+        let journal: Arc<dyn OptionChainJournal> = Arc::new(InMemoryOptionChainJournal::new());
+        let book = SequencedUnderlyingOrderBook::with_journal("BTC", Arc::clone(&journal));
+        book.set_clock(Arc::new(StubClock::new()) as Arc<dyn Clock>);
+        book.set_trade_id_namespace(root);
+        drive_trade_id_prefix(&book);
+        journal
+            .read_from(0)
+            .expect("read journal")
+            .iter()
+            .map(|event| {
+                let mut value = serde_json::to_value(event).expect("serialize event");
+                value["timestamp_ns"] = serde_json::json!(0);
+                value
+            })
+            .collect()
+    }
+
+    let first = run(trade_id_root());
+    let second = run(trade_id_root());
+    assert!(!first.is_empty(), "the prefix must journal some events");
+    // The fill payloads must actually be present, or the test would pass
+    // vacuously without exercising trade ids.
+    assert!(
+        first
+            .iter()
+            .any(|e| serde_json::to_string(e).unwrap().contains("\"trade_id\"")),
+        "the prefix must produce at least one fill carrying a trade id"
+    );
+    assert_eq!(
+        first, second,
+        "two identically-seeded sequenced runs must produce identical command + \
+         result payloads (trade ids, engine trade timestamps, engine_seq included)"
+    );
+}
+
+#[test]
+fn test_replay_with_injected_clock_and_namespace_equals_live() {
+    // With both determinism seams injected on the live AND the replay instance
+    // (fresh StubClock + same root namespace, set before driving / replaying),
+    // the full-state oracle equality still holds: the seams do not perturb the
+    // rebuilt order-book state.
+    let journal = Arc::new(InMemoryOptionChainJournal::new());
+
+    let live = fresh_book(&journal);
+    live.set_clock(Arc::new(StubClock::new()) as Arc<dyn Clock>);
+    live.set_trade_id_namespace(trade_id_root());
+    let submitted = drive_command_prefix(&live);
+    let live_snapshot = snapshot(&live);
+
+    let replay = fresh_book(&journal);
+    replay.set_clock(Arc::new(StubClock::new()) as Arc<dyn Clock>);
+    replay.set_trade_id_namespace(trade_id_root());
+    let replayed = replay
+        .replay(0)
+        .expect("replay under injected clock + namespace");
+    assert_eq!(
+        replayed, submitted,
+        "replay must re-run every journaled command"
+    );
+
+    assert_eq!(
+        live_snapshot,
+        snapshot(&replay),
+        "replayed state under injected clock + namespace must equal live state"
     );
 }

--- a/tests/unit/sequencer_tests.rs
+++ b/tests/unit/sequencer_tests.rs
@@ -1143,9 +1143,9 @@ fn test_sequenced_identical_runs_produce_identical_trade_ids() {
     // The fill payloads must actually be present, or the test would pass
     // vacuously without exercising trade ids.
     assert!(
-        first
-            .iter()
-            .any(|e| serde_json::to_string(e).unwrap().contains("\"trade_id\"")),
+        first.iter().any(|e| serde_json::to_string(e)
+            .expect("serialize event")
+            .contains("\"trade_id\"")),
         "the prefix must produce at least one fill carrying a trade id"
     );
     assert_eq!(


### PR DESCRIPTION
## Stack

- **Stack: #152 → #151 → #153 (this PR is 3 of 3, the top of the stack).**
- Base branch: `stack/2-151-order-kinds` — **already merged as #155**, so the diff against `main` shows only this PR's commits.
- Stacked on: #155 (merged). Last PR of the chain — after this merges, all follow-up issues from the 0.8.0 release are closed.

## Summary

Trade IDs were the last non-deterministic output of the sequenced hierarchy: upstream minted each book's trade-ID namespace with a random `Uuid::new_v4()`, so identical runs produced different IDs, and `OrderReplaced` carried no fills. orderbook-rs 0.11 ships the injectable namespace we requested upstream ([#199](https://github.com/joaquinbejar/OrderBook-rs/issues/199)); this PR threads it end-to-end and closes the replace-fills gap — the fauxchange/IronCondor acceptance property (byte-identical trade payloads across identically-seeded runs) is now pinned by test.

## Changes

- **Deps**: `orderbook-rs` 0.10 → **0.11** (public dependency — breaking for downstream co-pinners, documented per the 0.6.0 precedent; the only upstream breaks are in `ReplayBookConfig`/`ReplayError`, which this crate does not use). `uuid` 1.23 becomes a direct dependency (user-approved); `Uuid` is re-exported so consumers need none of their own.
- **Namespace rails** (clock rails 1:1): `Shared<Option<Uuid>>` root on every manager with `set_trade_id_namespace`/`clear_trade_id_namespace`/getter, book-type delegations, propagation on `get_or_create`; `BookConfig` carries the root and `new_with_config` derives the per-leaf namespace as `UUIDv5(root, leaf_symbol)` on the mut book pre-freeze — call and put get distinct namespaces, and the upstream counter-restart caveat is structurally moot (applied exactly once at construction, enforced by `&mut self`). `SequencedUnderlyingOrderBook::set_trade_id_namespace` is linearized against the command stream via the submit gate.
- **Replace fills**: leaf `replace_order_full` recovers the replacement's on-entry fills through a dedicated capture slot wired into the constructor-installed listener (disarmed cost: one relaxed load on the match path; disarm-on-drop guard on every exit); the captured trade is kept only when the taker id matches and fills are non-empty. `OptionChainResult::OrderReplaced` gains `#[serde(default)] trade: Option<TradeResult>`; `execute_replace_order` carries it; the v1 listener-only caveats are dropped.
- **Docs**: the "Known limitation — trade-ID determinism" section becomes "Deterministic trade IDs" with the guarantee precisely scoped; lib.rs Limitations bullet updated; README regenerated.

## Technical decisions

- **Guarantee scope (stated honestly everywhere):** with clock + root namespace set before the first submit, two identical **live** sequenced runs on fresh instances produce byte-identical command/result payloads — trade ids, engine trade timestamps and `engine_seq` included. The per-event envelope `timestamp_ns` stays wall-clock (pre-existing #147 ingestion behavior; normalized in the headline test; candidate follow-up: inject a clock into `assign()`). Replay still discards journaled results by design — the replay==live **state** oracle is unchanged and now also covered with both seams injected.
- **Attribution contract scoped by the determinism audit:** contamination from a concurrent non-sequenced **add** is missing-never-wrong (taker-id filter); a concurrent non-sequenced **replace of the same order id** sits outside that bound (identical taker id — indistinguishable) and is documented as a violation of the single-writer operating model. Book state and the returned `bool` are never affected — only the audit payload. Upstream `update_order_with_result` remains the future zero-caveat path.
- The dedicated slot avoids perturbing the public `arm_trade_capture`/`last_trade_result` surface (covered by test).

## Public API impact

- New: `set_trade_id_namespace`/`clear_trade_id_namespace`/`trade_id_namespace()` on the four managers and three book types; `SequencedUnderlyingOrderBook::set_trade_id_namespace`; `OptionOrderBook::replace_order_full`; re-export `Uuid`.
- `OrderReplaced` field addition: wire-compatible (JSON, serde default), source-breaking only for literal constructors / full-field patterns. No version bump in-tree (release decided at stack end).
- CHANGELOG `[Unreleased]` covers #152 + #151 + #153 including the ⚠️ co-pinner dep break.

## Testing

- [x] Unit tests added or updated
- [x] Round-trip serde tests for new event / DTO shapes
- [x] Integration tests under `tests/unit/` added or updated (if applicable)
- [x] Replay determinism covered for sequencer changes (replayed state == live)
- [x] `make pre-push` run locally and clean

**Headline:** `test_sequenced_identical_runs_produce_identical_trade_ids` — two independent instances, same `StubClock` + root, identical prefix with crossing adds and a rematching replace → journals byte-identical (only the wall-clock envelope `timestamp_ns` normalized, documented); stable across reruns. Plus: `test_replay_with_injected_clock_and_namespace_equals_live`, per-leaf v5 derivation byte-identity, call≠put namespaces, rails future-books-only pins + propagation/delegation tests, replace_order_full suite (rematch own fills / none / unknown id / engine-reject preserves original **and disarms** / continuous capture undisturbed), receipt-carries-trade, old-journal `trade: None` pin, fixture patch extensions, deny-unknown probes. Totals: **929 lib + 40 integration + 110 doctests, 0 failures.**

Bench (leaf listener change): `add_limit_order` ~960 ns and `cancel_order` ~632 ns unchanged (p=0.15); small fixed per-book construction cost from the two capture-slot Arcs, amortized at realistic depths — no per-order regression. Internal reviews: hotpath CLEAN (disarmed delta = exactly one relaxed load), determinism-auditor replay-safe (its P2 contract-accuracy finding applied), architect PASS (nits applied).

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md`
- [x] All `pub` items have `///` documentation; `# Errors` on fallible functions
- [x] No `.unwrap()` / `.expect()` / unchecked indexing in production code
- [x] No `unsafe` introduced
- [x] Layering respected (rails mirror the clock seams; single per-leaf derivation point; no upward imports)
- [x] Matching delegated to `orderbook-rs`; Greeks delegated to `optionstratlib`
- [x] New dependency (`uuid`) added **with explicit approval**; public-dep bump documented as breaking for co-pinners
- [x] `tracing` only for logging — no `println!` / `eprintln!` / `dbg!` / `log` crate
- [x] `src/lib.rs` docs + `README.md` (via `make readme`) updated if the public surface changed

Closes #153
