### PR TITLE
deps: optionstratlib 0.18 -> 0.21 (unblocks IronCondor #128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`optionstratlib` public dependency `0.18` → `0.21` (breaking for
   co-pinners).** `optionstratlib` is a *public* dependency: `ExpirationDate`,
-  `Positive`, `Greek`, `OptionStyle`, `ExpirationDateError` and `DecimalError`
-  appear in this crate's public signatures and in the `Error` enum. Moving to
+  `Positive`, `Greek` and `OptionStyle` appear in this crate's public
+  signatures, and `ExpirationDateError` and `DecimalError` are carried by the
+  `Error::ExpirationDateError` and `Error::OptionStratLibDecimal` variants.
+  Moving to
   `0.21` pulls `expiration_date` `0.2` → `0.3` and `positive` `0.5` → `0.6`
   with it, so `ExpirationDate`, `Positive`, `Greek`, `ExpirationDateError` and
   `DecimalError` are new types from the point of view of a downstream crate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `0.4.4`. A full upgrade walkthrough lives in
 > [`MIGRATING-0.5.0.md`](./MIGRATING-0.5.0.md).
 
+## [Unreleased]
+
+### ⚠️ Breaking Changes
+
+- **`optionstratlib` public dependency `0.18` → `0.21` (breaking for
+  co-pinners).** `optionstratlib` is a *public* dependency: `ExpirationDate`,
+  `Positive`, `Greek`, `OptionStyle`, `ExpirationDateError` and `DecimalError`
+  appear in this crate's public signatures and in the `Error` enum. Moving to
+  `0.21` pulls `expiration_date` `0.2` → `0.3` and `positive` `0.5` → `0.6`
+  with it, so `ExpirationDate`, `Positive`, `Greek`, `ExpirationDateError` and
+  `DecimalError` are new types from the point of view of a downstream crate
+  still pinned to `optionstratlib 0.18`: the two copies will not unify, and
+  downstream must move its own pin to `0.21` in the same update (same
+  precedent as the `0.6.0` and `0.9.0` `orderbook-rs` bumps). `OptionStyle`
+  and `Side` are the one exception: both `optionstratlib` lines re-export them
+  from `financial_types 0.2`, so `OptionOrderBook::new(symbol, OptionStyle)`
+  keeps unifying across the bump. The next release must therefore be a minor,
+  `0.11.0`, not a patch. `cargo semver-checks` reports "no semver update
+  required" for this change because it only inspects this crate's own
+  rustdoc; the break lives in the identity of the upstream types, which is why
+  it is stated here rather than detected there.
+
+### Changed
+
+- No source changes were required by the bump. Every `optionstratlib` symbol
+  this crate uses exists unchanged in `0.21.1`, and the behaviour this crate
+  observes is identical: the `0.19` change that signs every Greek by `Side`
+  does not reach `GreeksEngine`, which prices `Side::Long` at quantity one;
+  the `positive 0.6` serde change (a `Positive` now serialises as a decimal
+  string) does not touch the journal wire format, because `ExpirationDate`'s
+  own serialiser is byte-identical between `expiration_date 0.2.1` and
+  `0.3.0` and no journaled type carries a bare `Positive`; and the `0.19`
+  vanna-at-expiry change is unreachable behind the engine's `tte > 0` guard.
+  The frozen `v0.5.0` / `v0.8.0` / `v0.9.0` journal fixtures decode unchanged.
+- Resolver side effects of the bump: `rand 0.8` leaves the graph (`rand 0.9`
+  via `proptest` / `pricelevel` and `rand 0.10` via `optionstratlib` remain,
+  neither on this crate's public surface), and `uuid` resolves to `1.26`
+  within the existing `1.24` requirement. `orderbook-rs 0.12`, `pricelevel
+  0.9` and `async-nats 0.49` are unchanged.
+
 ## [0.10.0] - 2026-07-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   required" for this change because it only inspects this crate's own
   rustdoc; the break lives in the identity of the upstream types, which is why
   it is stated here rather than detected there.
+- **`async-nats` public dependency `0.49` → `0.50`, and the `orderbook-rs`
+  floor raised to `0.12.1`.** `OptionChainNatsConfig::jetstream()` returns
+  `&async_nats::jetstream::Context`, and that `Context` must be the same type
+  `orderbook-rs`'s publishers accept. `orderbook-rs 0.12.1` moved to
+  `async-nats 0.50` in a patch release, so a fresh resolution (this repo does
+  not track `Cargo.lock`, and CI resolves from scratch) paired
+  `orderbook-rs 0.12.1` with this crate's `async-nats 0.49` pin and failed to
+  compile the `nats` feature with two copies of `jetstream::Context`. The
+  0.12.1 floor keeps the two lines paired. `async-nats 0.50` only adds an
+  optional `chrono` backend; the `connect`, `jetstream::new` and
+  `jetstream::Context` surface this crate uses is unchanged. Breaking for
+  downstream crates that co-pin `async-nats 0.49`, and covered by the same
+  `0.11.0` bump.
 
 ### Changed
 
@@ -45,11 +58,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `0.3.0` and no journaled type carries a bare `Positive`; and the `0.19`
   vanna-at-expiry change is unreachable behind the engine's `tte > 0` guard.
   The frozen `v0.5.0` / `v0.8.0` / `v0.9.0` journal fixtures decode unchanged.
-- Resolver side effects of the bump: `rand 0.8` leaves the graph (`rand 0.9`
-  via `proptest` / `pricelevel` and `rand 0.10` via `optionstratlib` remain,
-  neither on this crate's public surface), and `uuid` resolves to `1.26`
-  within the existing `1.24` requirement. `orderbook-rs 0.12`, `pricelevel
-  0.9` and `async-nats 0.49` are unchanged.
+- Resolver side effects of the bump (default features): `rand 0.8` leaves the
+  graph (`rand 0.9` via `proptest` / `pricelevel` and `rand 0.10` via
+  `optionstratlib` remain, neither on this crate's public surface), and
+  `uuid` resolves to `1.26` within the existing `1.24` requirement.
+  `pricelevel 0.9` is unchanged.
 
 ## [0.10.0] - 2026-07-23
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,11 +70,13 @@ crate-type = ["rlib"]
 
 [workspace.dependencies]
 optionstratlib = { version = "0.21", default-features = false }
-orderbook-rs = { version = "0.12", features = ["special_orders"] }
+orderbook-rs = { version = "0.12.1", features = ["special_orders"] }
 uuid = { version = "1.24", features = ["v5"] }
-# Pinned to 0.49 to share `jetstream::Context` with orderbook-rs 0.12 (which depends on
-# async-nats 0.49); bumping to 0.50 here duplicates the crate and breaks the publisher types.
-async-nats = "0.49"
+# Must track the `async-nats` line orderbook-rs uses, so both crates share one
+# `jetstream::Context`: orderbook-rs 0.12.1 moved to async-nats 0.50 (0.12.0 was on
+# 0.49), hence the 0.12.1 floor above. A mismatch duplicates the crate and breaks the
+# publisher types.
+async-nats = "0.50"
 bytes = "1.12"
 tokio = { version = "1.53", features = ["rt", "sync"] }
 tracing = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ path = "src/lib.rs"
 crate-type = ["rlib"]
 
 [workspace.dependencies]
-optionstratlib = { version = "0.18", default-features = false }
+optionstratlib = { version = "0.21", default-features = false }
 orderbook-rs = { version = "0.12", features = ["special_orders"] }
 uuid = { version = "1.24", features = ["v5"] }
 # Pinned to 0.49 to share `jetstream::Context` with orderbook-rs 0.12 (which depends on


### PR DESCRIPTION
## Summary

Move the workspace `optionstratlib` requirement from `0.18` to `0.21` (resolves to `0.21.1`). IronCondor is on `optionstratlib 0.21` and currently carries a second `0.18` copy only to talk to this crate; publishing this bump as `0.11.0` lets it drop that shim (joaquinbejar/IronCondor#128). No source changes were needed: every symbol this crate uses exists unchanged in `0.21.1`, and the behaviour this crate observes is identical.

A second, separate commit fixes a CI break that is unrelated to `optionstratlib` and that `main` would hit on any fresh run today: `orderbook-rs 0.12.1` moved to `async-nats 0.50` in a patch release, so the `nats` feature no longer compiles against this crate's `async-nats 0.49` pin. Details under "async-nats" below.

Downstream: joaquinbejar/IronCondor#128

## Changes

- `Cargo.toml` `[workspace.dependencies]`: `optionstratlib = { version = "0.21", default-features = false }`. `pricelevel 0.9` is untouched.
- `Cargo.toml` `[workspace.dependencies]` (second commit): `async-nats = "0.50"` and `orderbook-rs = { version = "0.12.1", ... }`, with the pin comment rewritten to say why the two lines must stay paired.
- `CHANGELOG.md`: `[Unreleased]` entry stating both bumps, why they are breaking for co-pinners, and that the next release must be `0.11.0`.
- No changes under `src/`, `tests/`, `benches/` or `examples/`. `README.md` is already in sync with `src/lib.rs` (`cargo readme` output is identical).
- `Cargo.lock` is gitignored in this repo, so the PR carries no lockfile. All results below were produced on a lockfile generated from scratch (`cargo generate-lockfile`), which is what CI does on every run.

## Symbol-by-symbol verification (against `optionstratlib-0.21.1` sources)

| Used here (count) | Where it lives in 0.21.1 | Result |
|---|---|---|
| `prelude::pos_or_panic` (32) | `prelude.rs:119`, re-export of `positive::pos_or_panic` | unchanged |
| `ExpirationDate` (30) | `lib.rs:1388` from `model::expiration`, backed by `expiration_date 0.3` | API unchanged; new type identity (`0.2` to `0.3`); its serde impl is byte-identical to `0.2.1` |
| `OptionStyle` (21) | `lib.rs:1390` from `model::types`, backed by `financial_types 0.2` | unchanged, and the same type on both optionstratlib lines |
| `prelude::{ExpirationDate, Positive}` (15) | `prelude.rs` | unchanged |
| `greeks::Greek` (10) | `greeks/equations.rs:44`, twelve `Decimal` fields | field set unchanged (this crate builds it as a struct literal and it compiles) |
| `greeks::{charm, color, delta, gamma, rho, theta, vanna, vega, veta, vomma}` | `greeks/equations.rs`, all `fn(&Options) -> Result<Decimal, GreeksError>` | signatures unchanged; see the semantics note below |
| `prelude::Positive` (7) | `positive 0.6` | new type identity (`0.5` to `0.6`); `Positive::new`, `Positive::ONE`, `to_f64`, `Mul` all present and not deprecated |
| `model::types::{OptionStyle, OptionType, Side}` | `model/types.rs:7-8` | `OptionType` now comes from `option_type 0.3`; used only inside `GreeksEngine`, not on the public surface |
| `Options` (struct literal, 12 fields) | `model/option.rs:152` | field set unchanged |
| `model::ExpirationDateError` | `model/mod.rs:134` | present; carried by `Error::ExpirationDateError` |
| `error::decimal::DecimalError` | `error/decimal.rs:61` | present; carried by `Error::OptionStratLibDecimal` |

### Upstream semantics reviewed (0.18.1 to 0.21.1 changelogs, plus `positive 0.6.0` and `expiration_date 0.3.0`)

- `optionstratlib 0.19`: every Greek is now signed by `Side`, and `vomma` / `veta` no longer apply quantity twice. `GreeksEngine` prices `Side::Long` at `quantity: Positive::ONE`, so every value it produces is the same as before.
- `optionstratlib 0.19`: `vanna` returns zero at expiry instead of an error. Unreachable here: the engine rejects `tte_years <= 0.0` before building `Options`.
- `positive 0.6`: serde now emits the exact decimal as a string, `==` against `Decimal` / `f64` is exact, `ln` / `log10` return `Decimal`, `new_unchecked` and `PositiveError::Other` are gone. This crate uses none of the changed operations, no journaled type carries a bare `Positive`, and `ExpirationDate::Days` still serialises through `to_f64()`, so the sequencer wire format is unchanged. The frozen `v0.5.0` / `v0.8.0` / `v0.9.0` journal fixtures decode unchanged.
- `expiration_date 0.3`: `get_date` and friends return `Err(PositiveError)` instead of panicking for a day count above `i64::MAX`. Strictly fewer panics; no call site here can hit it.
- `optionstratlib 0.20` / `0.21`: the breaking changes are in strategies, `PortfolioGreeks`, `LegAble`, `DecimalStats`, curves and volatility. None of those modules is used here.

## async-nats 0.49 to 0.50 (second commit, unrelated to optionstratlib)

- The first push of this branch failed `lint`, `run_tests` and `code_coverage_report` with four `E0308: mismatched types` in `src/orderbook/nats.rs` (lines 526, 534, 604, 612): `expected async_nats::jetstream::context::Context, found async_nats::jetstream::Context`, with rustc noting two versions of `async_nats` in the graph.
- Cause: `orderbook-rs 0.12.1` (published after this repo's last green run on 2026-07-23, which resolved `0.12.0`) depends on `async-nats = "0.50"`, while this crate pinned `"0.49"`. Because `Cargo.lock` is gitignored, CI resolves fresh and pairs `orderbook-rs 0.12.1` with `async-nats 0.49`, giving two `jetstream::Context` types. `main` would fail identically on any fresh run; reproduced locally with `cargo generate-lockfile` on the first commit alone.
- Fix: `async-nats = "0.50"` and `orderbook-rs = "0.12.1"` as the floor, so the two lines stay paired. `async-nats 0.50` only adds an optional `chrono` backend; `connect`, `jetstream::new` and `jetstream::Context`, the whole surface this crate uses, are unchanged.
- `async-nats` is a public dependency here (`OptionChainNatsConfig::jetstream()` returns `&async_nats::jetstream::Context`), so this move is breaking for downstream crates that co-pin `async-nats 0.49`. It is covered by the same `0.11.0` bump and recorded in the changelog.

## Duplicate-major report (fresh lockfile)

`cargo tree -d --all-features` shows exactly one `optionstratlib` (`0.21.1`), one `positive` (`0.6.0`), one `expiration_date` (`0.3.0`), one `rust_decimal` (`1.43.0`), one `option_type` (`0.3.0`), one `financial_types` (`0.2.2`), one `orderbook-rs` (`0.12.1`), one `pricelevel` (`0.9.1`), one `async-nats` (`0.50.0`) and one `uuid` (`1.26.0`).

What remains duplicated, and why:

- `rand 0.9.5` (via `proptest 1.11`, dev-only, and via `ulid` under `pricelevel 0.9`) alongside `rand 0.10.2` (via `optionstratlib`, `statrs`, `nalgebra`, `rand_distr`). `rand_core 0.9 / 0.10` and `getrandom 0.3 / 0.4` follow from it. Neither reaches this crate's public surface; unifying needs `pricelevel` and `proptest` to move to `rand 0.10`.
- Under `--all-features` only, the NATS/TLS stack (`async-nats`, `rustls`) brings its own `rand 0.8`, `rand_core 0.6`, `sha2 0.10 / 0.11`, `digest`, `block-buffer`, `crypto-common`, `cpufeatures`, `const-oid` and `webpki-roots` pairs. Pre-existing, and not touched by either bump.
- Pre-existing and unrelated: `hashbrown 0.14 / 0.17`, `itertools 0.13` (criterion) / `0.15` (optionstratlib), `syn 2 / 3`, `unicode-width 0.1 / 0.2`. The `memchr`, `regex` and `regex-automata` rows list the same version twice (host vs target builds), not two majors.

Net effect versus `main`'s lockfile, measured with `cargo tree -d --depth 0`: default features 37 rows to 20, all features 35 rows to 33. With default features the `optionstratlib 0.18` tail (`rand 0.8`, `rand_core 0.6`, `rand_chacha 0.3`, `rand_distr 0.4`, `getrandom 0.2`, second copies of `sha2`, `digest`, `block-buffer`, `crypto-common`, `cpufeatures`) leaves the graph.

## Public API impact

- **Breaking for downstream crates that co-pin `optionstratlib 0.18`.** `ExpirationDate`, `Positive`, `Greek`, `ExpirationDateError` and `DecimalError` are new types from their point of view (backed by `expiration_date 0.3`, `positive 0.6`, and `optionstratlib` itself), and all five appear in this crate's public signatures or `Error` variants. Same precedent as the `0.6.0` and `0.9.0` `orderbook-rs` bumps: the next release must be **`0.11.0`**, not a patch.
- **Breaking for downstream crates that co-pin `async-nats 0.49`** (see above). Same bump.
- **`OptionStyle` is not part of the break.** Both `optionstratlib 0.18` and `0.21` re-export it from `financial_types 0.2`, so `OptionOrderBook::new(symbol, OptionStyle)` keeps unifying across the bump. The signature is unchanged in this PR.
- **`cargo semver-checks` is green and will stay green** (`196 checks: 196 pass, 58 skip, no semver update required` against the published `0.10.0`). It compares this crate's own rustdoc, where the type paths are unchanged, so it cannot see a public-dependency identity change. The break is therefore stated in the changelog rather than detected by the semver job; do not read a green semver job as "patch is fine".
- Option for a follow-up, deliberately not done here: re-export `OptionStyle`, `ExpirationDate` and `Positive` from the crate root so downstream can name them without depending on `optionstratlib` directly. That is a separate public-surface decision.

## Testing

All run at the branch head on a lockfile generated from scratch, rustc 1.98.1 (the `stable` channel from `rust-toolchain.toml`, same as CI):

| Gate (as CI runs it) | Result |
|---|---|
| `cargo +stable fmt --check` (`make fmt-check`) | clean |
| `cargo clippy --all-targets --all-features --workspace -- -D warnings` (`make lint`) | 0 warnings |
| `LOGLEVEL=WARN cargo test --all-features` (`make test`) | 932 unit + 40 integration + 110 doctests passed, 0 failed, 3 ignored |
| `cargo test` (default features) | 804 unit + 24 integration + 108 doctests passed, 0 failed, 1 ignored |
| `cargo build` and `cargo build --release` | 0 warnings |
| `cargo clippy -- -W missing-docs` (`make doc`) | 0 warnings |
| `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` | 0 warnings |
| `cargo semver-checks --all-features --baseline-version 0.10.0` | 196 pass, 58 skip, no semver update required (see note above) |
| `cargo readme` vs `README.md` | identical |

- [x] Unit tests, integration tests under `tests/unit/`, doctests, and the frozen journal fixtures all pass unchanged
- [x] Replay determinism for the sequencer is covered by the existing `--all-features` suite (no sequencer code changed)
- [x] Greeks tests continue to assert sign and range against `optionstratlib` with a tolerance
- [x] Pre-submission checklist run locally and clean

## Checklist

- [x] Code follows `rules/global_rules.md` and `CLAUDE.md` (no source changes)
- [x] No `.unwrap()` / `.expect()` / unchecked indexing introduced
- [x] No `unsafe` introduced
- [x] Layering respected (no source changes)
- [x] Matching delegated to `orderbook-rs`; Greeks delegated to `optionstratlib`
- [x] No new dependencies added; version moves of existing public dependencies only
- [x] `README.md` verified in sync with `src/lib.rs`

## Owner's next steps

1. Merge this PR.
2. `chore(release): 0.11.0`: bump `version` in `Cargo.toml`, turn the `[Unreleased]` header into `[0.11.0] - <date>`, and optionally add a `MIGRATING-0.11.0.md` following the `0.9.0` precedent (the migration is "move your own `optionstratlib` pin to `0.21` and `async-nats` to `0.50`").
3. `cargo publish`.
4. IronCondor then drops its `optionstratlib 0.18` shim (joaquinbejar/IronCondor#128).
