### PR TITLE
fix(make): check-spanish failed on a clean tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,10 +116,11 @@ check-cargo-readme:
 
 .PHONY: check-spanish
 check-spanish:
-	@rg -n --pcre2 -e '^\s*(//|///|//!|#|/\*|\*).*?[áéíóúÁÉÍÓÚñÑ¿¡]' \
+	@if rg -n --pcre2 -e '^\s*(//|///|//!|#|/\*|\*).*?[áéíóúÁÉÍÓÚñÑ¿¡]' \
     	    --glob '!target/*' \
     	    --glob '!**/*.png' \
-    	    . || (echo "❌  Spanish comments found"; exit 1)
+    	    . ; then echo "❌  Spanish comments found"; exit 1; \
+    	else echo "✅  No Spanish comments"; fi
 
 .PHONY: zip
 zip:


### PR DESCRIPTION
`rg` exits 1 when it finds no match, so `make check-spanish`'s `|| (echo "❌ …"; exit 1)` branch fired exactly when there were **no** Spanish comments (the target failed on `main` today with zero hits), and a tree **with** a Spanish comment passed.

Inverted: a match prints the ❌ line and fails; no match prints ✅ and succeeds. Verified both branches locally: clean tree → exit 0; a probe file with `// comentario añadido` → exit 2.

Makefile only; no code change.